### PR TITLE
chore(docs): add SECURITY.md and expand security model in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,27 +40,6 @@ Orchestrator Agent
                Local · Kind · OpenShift · EKS · GKE
 ```
 
-### Components
-
-| Component | Module | Status |
-|-----------|--------|--------|
-| MCP server | `core/server.py` | ✅ Available |
-| Auth (bearer / JWT) | `core/auth.py` | ✅ Available |
-| Policy / personas | `core/policy.py` | ✅ Available |
-| Resilience (rate limit, circuit breaker) | `core/resilience.py` | ✅ Available |
-| Health endpoints | `core/health.py` | ✅ Available |
-| Input validation | `core/security.py` | ✅ Available |
-| HTTP edge | `core/http_edge.py` | ✅ Available |
-| Trainer tools (23) | `trainer/api/` | ✅ Available |
-| Optimizer | `optimizer/` | 🔲 Stub only |
-| Hub / Model Registry | `hub/` | 🔲 Stub only |
-| OpenTelemetry tracing | — | 🔄 In review ([#21](https://github.com/kubeflow/mcp-server/pull/21)) |
-| Docker image + CI | — | 🔄 In review ([#25](https://github.com/kubeflow/mcp-server/pull/25)) |
-| PyPI release workflow | — | 🔄 In review ([#28](https://github.com/kubeflow/mcp-server/pull/28)) |
-| CLI Agent Runtime | — | 🔲 Planned — Phase 3 ([#15](https://github.com/kubeflow/mcp-server/issues/15)) |
-| Gateway layer support | — | 🔲 Planned — Phase 4 |
-| Spark Connect | — | 🔲 Planned — Phase 6 ([#5](https://github.com/kubeflow/mcp-server/issues/5)) |
-
 ---
 
 ## Target Architecture
@@ -92,9 +71,9 @@ LiteLLM / Ollama Agent  →  Per-session LLM Router
 kubeflow-mcp serve
 ```
 
-#### Observability — Phase 2 (in review)
+#### Observability — Phase 2 (available)
 
-OTel tracing is being added in [#21](https://github.com/kubeflow/mcp-server/pull/21) using the
+OTel tracing is available via [#21](https://github.com/kubeflow/mcp-server/pull/21) using the
 [MCP semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/).
 
 ```
@@ -104,7 +83,7 @@ Kubernetes cluster ──►                  ├──► MLflow  (optional —
                                         └──► Langfuse (LLM traces + token cost)
 ```
 
-Enable with `--otel-endpoint <url>` or `KUBEFLOW_MCP_OTEL_ENDPOINT`.
+Enable with `--otel-endpoint <url>` or `OTEL_EXPORTER_OTLP_ENDPOINT`.
 
 #### Gateway Layer — Phase 4
 
@@ -175,15 +154,191 @@ Full eval run → GHA artifact + PR comment (score delta)
 
 ---
 
-## Security
+## Security Model
 
-- **stdio** — OS-level trust boundary; no network exposure, no auth.
-- **HTTP / SSE** — Bearer API key (`KUBEFLOW_MCP_AUTH_TOKEN`) or JWT (`KUBEFLOW_MCP_JWKS_URI`).
-- **Tool authorization** — Persona-based filtering; four built-in roles (`readonly`, `data-scientist`, `ml-engineer`, `platform-admin`).
-- **Confirm gate** — All mutating tools require `confirmed=True`; agents preview before executing.
-- **Input validation** — Kubernetes name/namespace checks, Python script safety, sensitive-data masking (`core/security.py`).
+For vulnerability reporting and disclosure, see [SECURITY.md](SECURITY.md).
 
-See [SECURITY.md](SECURITY.md) for the full threat model, RBAC guidance, and responsible disclosure policy.
+### Trust Boundaries
+
+```
+AI Agent (Claude, Cursor, etc.)
+    │
+    ▼
+MCP Server process  ← YOU ARE HERE (kubeflow-mcp)
+    │
+    ▼
+Kubeflow SDK (TrainerClient)
+    │
+    ▼
+Kubernetes API Server (RBAC enforced)
+```
+
+### What the MCP Server Controls
+
+- **Persona-based tool filtering** — restricts which tools are visible to the AI agent (default: `--persona readonly`, which hides all write tools)
+- **Policy file** — `~/.kf-mcp-policy.yaml` can further restrict tools and namespaces
+- **Two-phase confirmation** — write tools require `confirmed=True` (preview first, submit after)
+- **Input validation** — K8s name format, CPU/memory format, resource limits, training parameter bounds (batch_size, epochs, nodes, GPU count, LoRA rank, script size, package count)
+- **Namespace restrictions** — policy enforcement on both lifecycle and training tools (training tools use per-call `TrainerClient` with `KubernetesBackendConfig(namespace=...)`)
+- **Error sanitization** — stack traces are only included in error responses when the logger is at DEBUG level; production responses contain error messages only
+- **External API hardening** — HuggingFace Hub calls use a 10s timeout and model ID format validation (`org/model` regex) to prevent SSRF; malformed model IDs return suggestions via `huggingface_hub.list_models` (best-effort, degrades gracefully on network failure)
+- **Thread safety** — `RateLimiter` uses `threading.Lock`; policy cache uses `functools.lru_cache` (GIL-safe); policy reload uses a dedicated `threading.Lock`
+- **Audit logging** — every tool call is logged with masked parameters, duration, and correlation ID; log buffer redacts sensitive patterns (tokens, passwords, credentials) before storage
+- **Observability** — opt-in OpenTelemetry tracing via `--otel-endpoint` or `OTEL_EXPORTER_OTLP_ENDPOINT`. Each tool call emits a span with `tool.args_preview` (masked, truncated to 300 chars), persona, correlation ID, MCP session/request IDs, and error status. OTLP exporter uses a 2s timeout to avoid blocking tool calls. Tracing is no-op when OTel packages are not installed
+
+### What the MCP Server Does NOT Control
+
+- **Kubernetes RBAC** — the server operates under the caller's permissions; it cannot grant access beyond what the Kubeconfig allows
+- **Network security** — TLS, ingress, and API gateway configuration are infrastructure concerns
+- **Secret management** — the server does not store credentials; it reads Kubeconfig from the environment
+
+### Known Security Considerations
+
+#### 1. `run_custom_training` — Host Code Execution (High)
+
+The tool accepts a Python script string, wraps it inside `def train():`, and calls `exec()` on the host to define the function — the body runs later in the training pod. `compile()` + `exec()` execute at submission time, so malformed scripts could affect the host process.
+
+**Mitigated:** AST safety check (`is_safe_python_code`) blocks dangerous patterns (eval/exec/subprocess/ctypes/dunder access) on both preview and submit paths. Unsafe scripts are rejected by default; `KUBEFLOW_MCP_UNSAFE_SCRIPTS=true` overrides.
+
+**Not mitigated:** AST check is bypassable via indirection (`getattr`, `importlib`). No sandbox or seccomp inside the pod. Script runs with the pod's full ServiceAccount privileges.
+
+**Recommendation:** Restrict to trusted users via `--persona data-scientist` or higher.
+
+#### 2. HTTP Transport — Authentication
+
+**Severity: Medium** | **Status: Mitigated (API key + JWT implemented)**
+
+`kubeflow-mcp serve --transport http` exposes the MCP server over StreamableHTTP. Authentication is available via `--auth-token` (API key) or `KUBEFLOW_MCP_JWKS_URI` (JWT/OIDC). The server logs a warning if HTTP transport runs without any auth configured.
+
+**Recommendation:** Always configure `--auth-token` or JWT for HTTP transport. Use stdio transport for local development. For production, place behind an authenticating reverse proxy with TLS for defense-in-depth.
+
+#### 3. Identity — Per-User Mapping
+
+**Severity: Medium** | **Status: Open, tracked in [ROADMAP.md](ROADMAP.md) Step 3**
+
+`core/auth.py` implements HTTP-layer authentication (API key via `--auth-token`, JWT/OIDC via `KUBEFLOW_MCP_JWKS_URI`). However, authenticated identities are not yet mapped to distinct Kubernetes identities. All tool calls run under whatever Kubeconfig the process was started with.
+
+**Impact:** In multi-user deployments, all users share the same Kubernetes identity. There is no per-user RBAC enforcement at the MCP layer (the auth layer verifies *who* is calling, but cannot scope *what* they can do beyond persona-level filtering).
+
+**Recommendation:** For single-user local development (stdio), this is acceptable — the user's own Kubeconfig is used. For multi-user HTTP deployments, configure `--auth-token` or JWT and enforce identity at the ingress/gateway layer until per-user Kubernetes impersonation is wired (Step 3).
+
+### Recommended Deployment Practices
+
+```yaml
+# 1. Run in isolated namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow-mcp
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+
+---
+# 2. Use NetworkPolicy to restrict access
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mcp-server-ingress
+  namespace: kubeflow-mcp
+spec:
+  podSelector:
+    matchLabels:
+      app: kubeflow-mcp
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              trusted: "true"
+      ports:
+        - port: 8000
+```
+
+### RBAC Configuration
+
+#### Minimum ClusterRole for MCP Server
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-mcp-server
+rules:
+  # Planning: get_cluster_resources
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+
+  # Discovery + Monitoring: list/get jobs, logs, events
+  - apiGroups: ["trainer.kubeflow.org"]
+    resources: ["trainjobs"]
+    verbs: ["list", "get", "create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events"]
+    verbs: ["list", "get"]
+
+  # Discovery: list/get runtimes; Platform: patch/create/delete runtimes
+  - apiGroups: ["trainer.kubeflow.org"]
+    resources: ["clustertrainingruntimes"]
+    verbs: ["list", "get", "create", "delete", "patch"]
+```
+
+#### Read-Only ClusterRole
+
+For `--persona readonly` or monitoring-only deployments:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-mcp-readonly
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+  - apiGroups: ["trainer.kubeflow.org"]
+    resources: ["trainjobs", "clustertrainingruntimes"]
+    verbs: ["list", "get"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events"]
+    verbs: ["list", "get"]
+```
+
+#### Namespace-Scoped (recommended for multi-tenant)
+
+Replace `ClusterRole` / `ClusterRoleBinding` with `Role` / `RoleBinding` in specific namespaces, and configure `~/.kf-mcp-policy.yaml`:
+
+```yaml
+policy:
+  namespaces:
+    - team-a
+    - team-b
+```
+
+### Resilience
+
+All tool calls pass through a rate limiter and per-tool circuit breakers:
+
+- **Rate limiter** (token bucket): prevents runaway agent loops. Configurable via `KUBEFLOW_MCP_RATE_LIMIT` (default 10 req/s) and `KUBEFLOW_MCP_RATE_CAPACITY` (default 20 burst).
+- **Circuit breaker** (per-tool): trips on repeated K8s/SDK infrastructure errors (not validation errors). Auto-recovers after `KUBEFLOW_MCP_CB_RECOVERY_TIMEOUT` (default 30s). Prevents cascading failures when the K8s API is degraded.
+- **Retry with backoff**: exponential backoff with jitter for transient failures (sync and async variants available).
+
+### Hardening Checklist
+
+For production deployments:
+
+- [ ] Default persona is `readonly` — explicitly set `--persona ml-engineer` or `--persona data-scientist` only for users who need write access
+- [ ] Configure `~/.kf-mcp-policy.yaml` with `policy.namespaces` and `read_only: true` if appropriate
+- [ ] For HTTP transport: set `--auth-token` (dev) or `KUBEFLOW_MCP_JWKS_URI` (production JWT) — the server warns if HTTP runs without auth
+- [ ] Use stdio transport for local dev; place HTTP behind an authenticated reverse proxy for additional defense-in-depth
+- [ ] Bind the MCP server ServiceAccount to the minimum ClusterRole above
+- [ ] Do not grant `run_custom_training` access to untrusted users
+- [ ] Keep log level at INFO or above in production (DEBUG exposes stack traces in error responses)
+- [ ] Ensure every new tool has a `CLIENT_TOOL_ANNOTATIONS` entry — `read_only` mode is fail-closed: tools without an explicit `readOnlyHint: True` annotation are treated as write tools and excluded
+- [ ] Review audit logs (`tool_call` events with `"audit": true`) for unexpected tool usage
+- [ ] If enabling OTel tracing, ensure the OTLP endpoint is internal — `tool.args_preview` span attributes contain masked but non-empty parameter data
+- [ ] Pin `kubeflow-mcp` to a specific version in production
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -188,7 +188,7 @@ Kubernetes API Server (RBAC enforced)
 
 ### What the MCP Server Does NOT Control
 
-- **Kubernetes RBAC** — the server operates under the caller's permissions; it cannot grant access beyond what the Kubeconfig allows
+- **Kubernetes RBAC** — all tool calls use the server process Kubeconfig / ServiceAccount; HTTP auth does not map callers to distinct Kubernetes identities (see Identity below)
 - **Network security** — TLS, ingress, and API gateway configuration are infrastructure concerns
 - **Secret management** — the server does not store credentials; it reads Kubeconfig from the environment
 
@@ -265,10 +265,20 @@ kind: ClusterRole
 metadata:
   name: kubeflow-mcp-server
 rules:
-  # Planning: get_cluster_resources
+  # Health: health_check probes list_namespace
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list"]
+
+  # Planning: get_cluster_resources / platform detection
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["list"]
+
+  # Planning: check_compatibility reads the Trainer CRD
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get"]
 
   # Discovery + Monitoring: list/get jobs, logs, events
   - apiGroups: ["trainer.kubeflow.org"]
@@ -294,9 +304,21 @@ kind: ClusterRole
 metadata:
   name: kubeflow-mcp-readonly
 rules:
+  # Health: health_check probes list_namespace
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list"]
+
+  # Planning: get_cluster_resources / platform detection
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["list"]
+
+  # Planning: check_compatibility reads the Trainer CRD
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get"]
+
   - apiGroups: ["trainer.kubeflow.org"]
     resources: ["trainjobs", "clustertrainingruntimes"]
     verbs: ["list", "get"]
@@ -307,7 +329,11 @@ rules:
 
 #### Namespace-Scoped (recommended for multi-tenant)
 
-Replace `ClusterRole` / `ClusterRoleBinding` with `Role` / `RoleBinding` in specific namespaces, and configure `~/.kf-mcp-policy.yaml`:
+TrainJob / pod / event access can use a namespaced `Role` + `RoleBinding`. Cluster-scoped
+resources (`nodes`, `namespaces`, `clustertrainingruntimes`, CRDs) still need a
+`ClusterRole` + `ClusterRoleBinding` — a RoleBinding alone cannot grant them.
+
+Restrict which namespaces tools may target via `~/.kf-mcp-policy.yaml`:
 
 ```yaml
 policy:

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ make inspector TRANSPORT=sse      # Inspector + SSE (start server separately)
 
 - **[CONTRIBUTING](CONTRIBUTING.md)**: Development workflow and PR guidelines
 - **[ROADMAP](ROADMAP.md)**: Project roadmap
-- **[SECURITY](SECURITY.md)**: Threat model, RBAC, and hardening checklist
+- **[SECURITY](SECURITY.md)**: Vulnerability reporting; see [ARCHITECTURE.md#security-model](ARCHITECTURE.md#security-model) for threat model, RBAC, and hardening
 - **[KEP-936](https://github.com/kubeflow/community/tree/master/proposals/936-kubeflow-mcp-server)**: Design proposal
 
 ## License

--- a/README.md
+++ b/README.md
@@ -268,8 +268,9 @@ make inspector TRANSPORT=sse      # Inspector + SSE (start server separately)
 
 ## Documentation
 
-
 - **[CONTRIBUTING](CONTRIBUTING.md)**: Development workflow and PR guidelines
+- **[ROADMAP](ROADMAP.md)**: Project roadmap
+- **[SECURITY](SECURITY.md)**: Threat model, RBAC, and hardening checklist
 - **[KEP-936](https://github.com/kubeflow/community/tree/master/proposals/936-kubeflow-mcp-server)**: Design proposal
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,273 @@
+# Security Policy
+
+## Project Status
+
+This project is in **early development** and has not yet reached a stable release (1.0). The API and features may change between versions.
+
+## Supported Versions
+
+| Version | Supported | Notes |
+|---------|-----------|-------|
+| 0.x     | ✅ Yes    | Pre-release, actively developed |
+
+Once the project reaches 1.0, a formal support policy for stable releases will be established.
+
+## Reporting a Vulnerability
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via one of the following methods:
+
+### GitHub Security Advisories (Preferred)
+
+1. Go to the [Security tab](https://github.com/kubeflow/mcp-server/security)
+2. Click "Report a vulnerability"
+3. Fill out the form with details
+
+### Email
+
+- **Email:** [kubeflow-discuss@googlegroups.com](mailto:kubeflow-discuss@googlegroups.com)
+- **Subject:** `[SECURITY] kubeflow/mcp-server — <brief description>`
+
+### What to Include
+
+- Type of vulnerability (e.g., injection, authentication bypass)
+- Location of the affected code (file path, line number)
+- Steps to reproduce the issue
+- Potential impact
+- Suggested fix (if any)
+
+### Response Timeline
+
+- **Acknowledgment**: Within 48 hours
+- **Initial assessment**: Within 1 week
+- **Fix timeline**: Depends on severity (critical: ASAP, high: 2 weeks, medium: 1 month)
+
+## Security Model
+
+The MCP server is a **translation layer** between AI agents and the Kubeflow SDK. For HTTP transport, it supports bearer token and JWT/OIDC authentication (see `core/auth.py`). For Kubernetes API access, it inherits the identity of the process running it — per-user identity mapping is planned (ROADMAP Step 3).
+
+### Trust Boundaries
+
+```
+AI Agent (Claude, Cursor, etc.)
+    │
+    ▼
+MCP Server process  ← YOU ARE HERE (kubeflow-mcp)
+    │
+    ▼
+Kubeflow SDK (TrainerClient)
+    │
+    ▼
+Kubernetes API Server (RBAC enforced)
+```
+
+### What the MCP Server Controls
+
+- **Persona-based tool filtering** — restricts which tools are visible to the AI agent (default: `--persona readonly`, which hides all write tools)
+- **Policy file** — `~/.kf-mcp-policy.yaml` can further restrict tools and namespaces
+- **Two-phase confirmation** — write tools require `confirmed=True` (preview first, submit after)
+- **Input validation** — K8s name format, CPU/memory format, resource limits, training parameter bounds (batch_size, epochs, nodes, GPU count, LoRA rank, script size, package count)
+- **Namespace restrictions** — policy enforcement on both lifecycle and training tools (training tools use per-call `TrainerClient` with `KubernetesBackendConfig(namespace=...)`)
+- **Error sanitization** — stack traces are only included in error responses when the logger is at DEBUG level; production responses contain error messages only
+- **External API hardening** — HuggingFace Hub calls use a 10s timeout and model ID format validation to prevent SSRF
+- **Thread safety** — `RateLimiter` uses `threading.Lock`; policy cache uses `functools.lru_cache` (GIL-safe)
+- **Audit logging** — every tool call is logged with masked parameters, duration, and correlation ID
+
+### What the MCP Server Does NOT Control
+
+- **Kubernetes RBAC** — the server operates under the caller's permissions; it cannot grant access beyond what the Kubeconfig allows
+- **Network security** — TLS, ingress, and API gateway configuration are infrastructure concerns
+- **Secret management** — the server does not store credentials; it reads Kubeconfig from the environment
+
+## Known Security Considerations
+
+### 1. `run_custom_training` — Host Code Execution
+
+**Severity: High** | **Status: By design, documented**
+
+The `run_custom_training` tool accepts a Python script as a string. The script is embedded inside a `train_func()` closure that is serialized by `cloudpickle` and executed **inside the Kubernetes training pod**, not on the MCP host.
+
+The `exec(compile(script, ...))` call is **deferred** — it runs inside `train_func()` at pod runtime, not at submission time on the host. However, the closure is constructed on the host and serialized, so malformed scripts could theoretically cause issues during serialization.
+
+**Mitigations in place:**
+- `exec()` is called with `{"__builtins__": __builtins__}` — the **full** Python builtins are available (no language-level sandboxing); no additional globals are injected
+- An AST-based safety check (`is_safe_python_code`) walks the parsed AST and flags: dangerous calls (`eval`, `exec`, `compile`, `__import__`), dangerous module calls (`os.system`, `os.popen`, `subprocess.*`, `shutil.rmtree`), dangerous imports (`ctypes`, `socket`), and dunder attribute access (`__builtins__`, `__subclasses__`, `__globals__`, `__code__`)
+- The safety check runs on **both** preview and confirmed paths; `safety_warnings` are included in the preview response
+- On the confirmed (submit) path, unsafe scripts are **blocked by default** with a `VALIDATION_ERROR`. Set `KUBEFLOW_MCP_UNSAFE_SCRIPTS=true` to override (logged with a warning)
+
+**Mitigations NOT in place:**
+- The AST check is bypassable via indirection (e.g. `getattr`, string concatenation, `importlib`)
+- There is no sandbox, seccomp profile, or process isolation around the `exec()` call inside the pod
+- The script executes with full privileges of the training pod's ServiceAccount
+
+**Recommendation:** In production, restrict `run_custom_training` to trusted users via persona policy (`--persona data-scientist` or higher). Consider running the MCP server process with minimal filesystem and network permissions.
+
+### 2. HTTP Transport — Authentication
+
+**Severity: Medium** | **Status: Mitigated (API key + JWT implemented)**
+
+`kubeflow-mcp serve --transport http` exposes the MCP server over StreamableHTTP. Authentication is available via `--auth-token` (API key) or `KUBEFLOW_MCP_JWKS_URI` (JWT/OIDC). The server logs a warning if HTTP transport runs without any auth configured.
+
+**Recommendation:** Always configure `--auth-token` or JWT for HTTP transport. Use stdio transport for local development. For production, place behind an authenticating reverse proxy with TLS for defense-in-depth.
+
+### 3. Identity — Per-User Mapping
+
+**Severity: Medium** | **Status: Open, tracked in [ROADMAP.md](ROADMAP.md) Step 3**
+
+`core/auth.py` implements HTTP-layer authentication (API key via `--auth-token`, JWT/OIDC via `KUBEFLOW_MCP_JWKS_URI`). However, authenticated identities are not yet mapped to distinct Kubernetes identities. All tool calls run under whatever Kubeconfig the process was started with.
+
+**Impact:** In multi-user deployments, all users share the same Kubernetes identity. There is no per-user RBAC enforcement at the MCP layer (the auth layer verifies *who* is calling, but cannot scope *what* they can do beyond persona-level filtering).
+
+**Recommendation:** For single-user local development (stdio), this is acceptable — the user's own Kubeconfig is used. For multi-user HTTP deployments, configure `--auth-token` or JWT and enforce identity at the ingress/gateway layer until per-user Kubernetes impersonation is wired (Step 3).
+
+## Recommended Deployment Practices
+
+```yaml
+# 1. Run in isolated namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow-mcp
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+
+---
+# 2. Use NetworkPolicy to restrict access
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mcp-server-ingress
+  namespace: kubeflow-mcp
+spec:
+  podSelector:
+    matchLabels:
+      app: kubeflow-mcp
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              trusted: "true"
+      ports:
+        - port: 8000
+```
+
+## RBAC Configuration
+
+### Minimum ClusterRole for MCP Server
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-mcp-server
+rules:
+  # Planning: get_cluster_resources
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+
+  # Discovery + Monitoring: list/get jobs, logs, events
+  - apiGroups: ["trainer.kubeflow.org"]
+    resources: ["trainjobs"]
+    verbs: ["list", "get", "create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events"]
+    verbs: ["list", "get"]
+
+  # Discovery: list/get runtimes
+  - apiGroups: ["trainer.kubeflow.org"]
+    resources: ["clustertrainingruntimes"]
+    verbs: ["list", "get"]
+```
+
+### Read-Only ClusterRole
+
+For `--persona readonly` or monitoring-only deployments:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-mcp-readonly
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+  - apiGroups: ["trainer.kubeflow.org"]
+    resources: ["trainjobs", "clustertrainingruntimes"]
+    verbs: ["list", "get"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events"]
+    verbs: ["list", "get"]
+```
+
+### ServiceAccount with Minimal Permissions
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeflow-mcp
+  namespace: kubeflow-mcp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubeflow-mcp-binding
+  namespace: kubeflow-mcp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeflow-mcp-server
+subjects:
+  - kind: ServiceAccount
+    name: kubeflow-mcp
+    namespace: kubeflow-mcp
+```
+
+### Namespace-Scoped (recommended for multi-tenant)
+
+Replace `ClusterRole` / `ClusterRoleBinding` with `Role` / `RoleBinding` in specific namespaces, and configure `~/.kf-mcp-policy.yaml`:
+
+```yaml
+policy:
+  namespaces:
+    - team-a
+    - team-b
+```
+
+## Dependency Security
+
+- **Kubeflow SDK** (`kubeflow>=0.4.0`) — pinned range, tracks upstream releases
+- **FastMCP** (`fastmcp>=2.0.0`) — MCP protocol implementation
+- **Kubernetes client** (`kubernetes`) — transitive via SDK
+- **No credentials stored** — the server reads Kubeconfig from the environment; HuggingFace tokens are passed per-request via `hf_token` parameter
+
+## Hardening Checklist
+
+For production deployments:
+
+- [ ] Default persona is `readonly` — explicitly set `--persona ml-engineer` or `--persona data-scientist` only for users who need write access
+- [ ] Configure `~/.kf-mcp-policy.yaml` with `policy.namespaces` and `read_only: true` if appropriate
+- [ ] For HTTP transport: set `--auth-token` (dev) or `KUBEFLOW_MCP_JWKS_URI` (production JWT) — the server warns if HTTP runs without auth
+- [ ] Use stdio transport for local dev; place HTTP behind an authenticated reverse proxy for additional defense-in-depth
+- [ ] Bind the MCP server ServiceAccount to the minimum ClusterRole above
+- [ ] Do not grant `run_custom_training` access to untrusted users
+- [ ] Keep log level at INFO or above in production (DEBUG exposes stack traces in error responses)
+- [ ] Ensure every new tool has a `CLIENT_TOOL_ANNOTATIONS` entry — `read_only` mode is fail-closed: tools without an explicit `readOnlyHint: True` annotation are treated as write tools and excluded
+- [ ] Review audit logs (`tool_call` events with `"audit": true`) for unexpected tool usage
+- [ ] Pin `kubeflow-mcp` to a specific version in production
+
+## Resilience
+
+All tool calls pass through a rate limiter and per-tool circuit breakers:
+
+- **Rate limiter** (token bucket): prevents runaway agent loops. Configurable via `KUBEFLOW_MCP_RATE_LIMIT` (default 10 req/s) and `KUBEFLOW_MCP_RATE_CAPACITY` (default 20 burst).
+- **Circuit breaker** (per-tool): trips on repeated K8s/SDK infrastructure errors (not validation errors). Auto-recovers after `KUBEFLOW_MCP_CB_RECOVERY_TIMEOUT` (default 30s). Prevents cascading failures when the K8s API is degraded.
+
+## Security Roadmap
+
+See [ROADMAP.md](ROADMAP.md) for planned security enhancements.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,5 @@
 # Security Policy
 
-## Project Status
-
-This project is in **early development** and has not yet reached a stable release (1.0). The API and features may change between versions.
-
 ## Supported Versions
 
 | Version | Supported | Notes |
@@ -14,260 +10,48 @@ Once the project reaches 1.0, a formal support policy for stable releases will b
 
 ## Reporting a Vulnerability
 
+We're extremely grateful for security researchers and users that report vulnerabilities to the
+Kubeflow Open Source Community. All reports are thoroughly investigated by project owners.
+
 **Please do NOT report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them via one of the following methods:
+You can use the following ways to report security vulnerabilities privately:
 
-### GitHub Security Advisories (Preferred)
+- Using the [GitHub Security Advisory](https://github.com/kubeflow/mcp-server/security/advisories/new) (preferred).
+- Using the Kubeflow Steering Committee mailing list: [ksc@kubeflow.org](mailto:ksc@kubeflow.org).
 
-1. Go to the [Security tab](https://github.com/kubeflow/mcp-server/security)
-2. Click "Report a vulnerability"
-3. Fill out the form with details
+Please provide detailed information to help us understand and address the issue promptly,
+including: type of vulnerability, location of affected code, steps to reproduce, potential impact,
+and suggested fix (if any).
 
-### Email
+## Disclosure Process
 
-- **Email:** [kubeflow-discuss@googlegroups.com](mailto:kubeflow-discuss@googlegroups.com)
-- **Subject:** `[SECURITY] kubeflow/mcp-server — <brief description>`
+- **Acknowledgment**: We will acknowledge receipt of your report within 48 hours.
+- **Assessment**: Project owners will investigate to determine validity and severity.
+- **Resolution**: If confirmed, we will work on a fix and prepare a release.
+- **Notification**: Once a fix is available, we will notify the reporter and coordinate disclosure.
+- **Public Disclosure**: Details and the fix will be published in release notes.
 
-### What to Include
+Fix timelines depend on severity: critical — ASAP, high — 2 weeks, medium — 1 month.
 
-- Type of vulnerability (e.g., injection, authentication bypass)
-- Location of the affected code (file path, line number)
-- Steps to reproduce the issue
-- Potential impact
-- Suggested fix (if any)
+## Prevention Mechanisms
 
-### Response Timeline
-
-- **Acknowledgment**: Within 48 hours
-- **Initial assessment**: Within 1 week
-- **Fix timeline**: Depends on severity (critical: ASAP, high: 2 weeks, medium: 1 month)
+- **Code Reviews**: All changes are reviewed by maintainers via Prow `/lgtm` + `/approve`.
+- **Dependency Management**: Dependabot monitors dependencies; `pip-audit` runs in CI.
+- **Continuous Integration**: Automated tests, linting, and security checks on every PR.
+- **Image Scanning**: Container images are scanned for vulnerabilities via Trivy.
+- **Input Validation**: AST-based script safety checks, K8s name validation, training parameter bounds (`core/security.py`).
+- **Sensitive Data Masking**: Audit logs redact tokens, passwords, and credentials before storage.
 
 ## Security Model
 
-The MCP server is a **translation layer** between AI agents and the Kubeflow SDK. For HTTP transport, it supports bearer token and JWT/OIDC authentication (see `core/auth.py`). For Kubernetes API access, it inherits the identity of the process running it — per-user identity mapping is planned (ROADMAP Step 3).
+For the full security model — trust boundaries, threat model, RBAC configuration,
+known security considerations, hardening checklist, and deployment practices — see the
+[Security Model](ARCHITECTURE.md#security-model) section in `ARCHITECTURE.md`.
 
-### Trust Boundaries
+## Communication Channels
 
-```
-AI Agent (Claude, Cursor, etc.)
-    │
-    ▼
-MCP Server process  ← YOU ARE HERE (kubeflow-mcp)
-    │
-    ▼
-Kubeflow SDK (TrainerClient)
-    │
-    ▼
-Kubernetes API Server (RBAC enforced)
-```
+- Kubeflow [Slack channels](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels)
+- Kubeflow [mailing list](https://www.kubeflow.org/docs/about/community/#kubeflow-mailing-list)
 
-### What the MCP Server Controls
-
-- **Persona-based tool filtering** — restricts which tools are visible to the AI agent (default: `--persona readonly`, which hides all write tools)
-- **Policy file** — `~/.kf-mcp-policy.yaml` can further restrict tools and namespaces
-- **Two-phase confirmation** — write tools require `confirmed=True` (preview first, submit after)
-- **Input validation** — K8s name format, CPU/memory format, resource limits, training parameter bounds (batch_size, epochs, nodes, GPU count, LoRA rank, script size, package count)
-- **Namespace restrictions** — policy enforcement on both lifecycle and training tools (training tools use per-call `TrainerClient` with `KubernetesBackendConfig(namespace=...)`)
-- **Error sanitization** — stack traces are only included in error responses when the logger is at DEBUG level; production responses contain error messages only
-- **External API hardening** — HuggingFace Hub calls use a 10s timeout and model ID format validation to prevent SSRF
-- **Thread safety** — `RateLimiter` uses `threading.Lock`; policy cache uses `functools.lru_cache` (GIL-safe)
-- **Audit logging** — every tool call is logged with masked parameters, duration, and correlation ID
-
-### What the MCP Server Does NOT Control
-
-- **Kubernetes RBAC** — the server operates under the caller's permissions; it cannot grant access beyond what the Kubeconfig allows
-- **Network security** — TLS, ingress, and API gateway configuration are infrastructure concerns
-- **Secret management** — the server does not store credentials; it reads Kubeconfig from the environment
-
-## Known Security Considerations
-
-### 1. `run_custom_training` — Host Code Execution
-
-**Severity: High** | **Status: By design, documented**
-
-The `run_custom_training` tool accepts a Python script as a string. The script is embedded inside a `train_func()` closure that is serialized by `cloudpickle` and executed **inside the Kubernetes training pod**, not on the MCP host.
-
-The `exec(compile(script, ...))` call is **deferred** — it runs inside `train_func()` at pod runtime, not at submission time on the host. However, the closure is constructed on the host and serialized, so malformed scripts could theoretically cause issues during serialization.
-
-**Mitigations in place:**
-- `exec()` is called with `{"__builtins__": __builtins__}` — the **full** Python builtins are available (no language-level sandboxing); no additional globals are injected
-- An AST-based safety check (`is_safe_python_code`) walks the parsed AST and flags: dangerous calls (`eval`, `exec`, `compile`, `__import__`), dangerous module calls (`os.system`, `os.popen`, `subprocess.*`, `shutil.rmtree`), dangerous imports (`ctypes`, `socket`), and dunder attribute access (`__builtins__`, `__subclasses__`, `__globals__`, `__code__`)
-- The safety check runs on **both** preview and confirmed paths; `safety_warnings` are included in the preview response
-- On the confirmed (submit) path, unsafe scripts are **blocked by default** with a `VALIDATION_ERROR`. Set `KUBEFLOW_MCP_UNSAFE_SCRIPTS=true` to override (logged with a warning)
-
-**Mitigations NOT in place:**
-- The AST check is bypassable via indirection (e.g. `getattr`, string concatenation, `importlib`)
-- There is no sandbox, seccomp profile, or process isolation around the `exec()` call inside the pod
-- The script executes with full privileges of the training pod's ServiceAccount
-
-**Recommendation:** In production, restrict `run_custom_training` to trusted users via persona policy (`--persona data-scientist` or higher). Consider running the MCP server process with minimal filesystem and network permissions.
-
-### 2. HTTP Transport — Authentication
-
-**Severity: Medium** | **Status: Mitigated (API key + JWT implemented)**
-
-`kubeflow-mcp serve --transport http` exposes the MCP server over StreamableHTTP. Authentication is available via `--auth-token` (API key) or `KUBEFLOW_MCP_JWKS_URI` (JWT/OIDC). The server logs a warning if HTTP transport runs without any auth configured.
-
-**Recommendation:** Always configure `--auth-token` or JWT for HTTP transport. Use stdio transport for local development. For production, place behind an authenticating reverse proxy with TLS for defense-in-depth.
-
-### 3. Identity — Per-User Mapping
-
-**Severity: Medium** | **Status: Open, tracked in [ROADMAP.md](ROADMAP.md) Step 3**
-
-`core/auth.py` implements HTTP-layer authentication (API key via `--auth-token`, JWT/OIDC via `KUBEFLOW_MCP_JWKS_URI`). However, authenticated identities are not yet mapped to distinct Kubernetes identities. All tool calls run under whatever Kubeconfig the process was started with.
-
-**Impact:** In multi-user deployments, all users share the same Kubernetes identity. There is no per-user RBAC enforcement at the MCP layer (the auth layer verifies *who* is calling, but cannot scope *what* they can do beyond persona-level filtering).
-
-**Recommendation:** For single-user local development (stdio), this is acceptable — the user's own Kubeconfig is used. For multi-user HTTP deployments, configure `--auth-token` or JWT and enforce identity at the ingress/gateway layer until per-user Kubernetes impersonation is wired (Step 3).
-
-## Recommended Deployment Practices
-
-```yaml
-# 1. Run in isolated namespace
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kubeflow-mcp
-  labels:
-    pod-security.kubernetes.io/enforce: restricted
-
----
-# 2. Use NetworkPolicy to restrict access
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: mcp-server-ingress
-  namespace: kubeflow-mcp
-spec:
-  podSelector:
-    matchLabels:
-      app: kubeflow-mcp
-  policyTypes:
-    - Ingress
-  ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              trusted: "true"
-      ports:
-        - port: 8000
-```
-
-## RBAC Configuration
-
-### Minimum ClusterRole for MCP Server
-
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kubeflow-mcp-server
-rules:
-  # Planning: get_cluster_resources
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["list"]
-
-  # Discovery + Monitoring: list/get jobs, logs, events
-  - apiGroups: ["trainer.kubeflow.org"]
-    resources: ["trainjobs"]
-    verbs: ["list", "get", "create", "delete", "patch"]
-  - apiGroups: [""]
-    resources: ["pods", "pods/log", "events"]
-    verbs: ["list", "get"]
-
-  # Discovery: list/get runtimes
-  - apiGroups: ["trainer.kubeflow.org"]
-    resources: ["clustertrainingruntimes"]
-    verbs: ["list", "get"]
-```
-
-### Read-Only ClusterRole
-
-For `--persona readonly` or monitoring-only deployments:
-
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kubeflow-mcp-readonly
-rules:
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["list"]
-  - apiGroups: ["trainer.kubeflow.org"]
-    resources: ["trainjobs", "clustertrainingruntimes"]
-    verbs: ["list", "get"]
-  - apiGroups: [""]
-    resources: ["pods", "pods/log", "events"]
-    verbs: ["list", "get"]
-```
-
-### ServiceAccount with Minimal Permissions
-
-```yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kubeflow-mcp
-  namespace: kubeflow-mcp
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: kubeflow-mcp-binding
-  namespace: kubeflow-mcp
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kubeflow-mcp-server
-subjects:
-  - kind: ServiceAccount
-    name: kubeflow-mcp
-    namespace: kubeflow-mcp
-```
-
-### Namespace-Scoped (recommended for multi-tenant)
-
-Replace `ClusterRole` / `ClusterRoleBinding` with `Role` / `RoleBinding` in specific namespaces, and configure `~/.kf-mcp-policy.yaml`:
-
-```yaml
-policy:
-  namespaces:
-    - team-a
-    - team-b
-```
-
-## Dependency Security
-
-- **Kubeflow SDK** (`kubeflow>=0.4.0`) — pinned range, tracks upstream releases
-- **FastMCP** (`fastmcp>=2.0.0`) — MCP protocol implementation
-- **Kubernetes client** (`kubernetes`) — transitive via SDK
-- **No credentials stored** — the server reads Kubeconfig from the environment; HuggingFace tokens are passed per-request via `hf_token` parameter
-
-## Hardening Checklist
-
-For production deployments:
-
-- [ ] Default persona is `readonly` — explicitly set `--persona ml-engineer` or `--persona data-scientist` only for users who need write access
-- [ ] Configure `~/.kf-mcp-policy.yaml` with `policy.namespaces` and `read_only: true` if appropriate
-- [ ] For HTTP transport: set `--auth-token` (dev) or `KUBEFLOW_MCP_JWKS_URI` (production JWT) — the server warns if HTTP runs without auth
-- [ ] Use stdio transport for local dev; place HTTP behind an authenticated reverse proxy for additional defense-in-depth
-- [ ] Bind the MCP server ServiceAccount to the minimum ClusterRole above
-- [ ] Do not grant `run_custom_training` access to untrusted users
-- [ ] Keep log level at INFO or above in production (DEBUG exposes stack traces in error responses)
-- [ ] Ensure every new tool has a `CLIENT_TOOL_ANNOTATIONS` entry — `read_only` mode is fail-closed: tools without an explicit `readOnlyHint: True` annotation are treated as write tools and excluded
-- [ ] Review audit logs (`tool_call` events with `"audit": true`) for unexpected tool usage
-- [ ] Pin `kubeflow-mcp` to a specific version in production
-
-## Resilience
-
-All tool calls pass through a rate limiter and per-tool circuit breakers:
-
-- **Rate limiter** (token bucket): prevents runaway agent loops. Configurable via `KUBEFLOW_MCP_RATE_LIMIT` (default 10 req/s) and `KUBEFLOW_MCP_RATE_CAPACITY` (default 20 burst).
-- **Circuit breaker** (per-tool): trips on repeated K8s/SDK infrastructure errors (not validation errors). Auto-recovers after `KUBEFLOW_MCP_CB_RECOVERY_TIMEOUT` (default 30s). Prevents cascading failures when the K8s API is degraded.
-
-## Security Roadmap
-
-See [ROADMAP.md](ROADMAP.md) for planned security enhancements.
+Please **do not report** security vulnerabilities through public channels.


### PR DESCRIPTION
## Description

Adds vulnerability reporting policy and expands security documentation:
- Add SECURITY.md :  vulnerability reporting, disclosure process (aligned with kubeflow/trainer)
- Move threat model, RBAC, hardening checklist to ARCHITECTURE.md's Security Model section
- Fix RBAC manifests: add create/delete/patch verbs for clustertrainingruntimes

## Checklist

- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] Commit messages follow conventional format

## Related Issues

Fixes: #12