### PR TITLE
fix: do not wrap training script if it already defines def train()

### DIFF
--- a/kubeflow_mcp/trainer/api/training.py
+++ b/kubeflow_mcp/trainer/api/training.py
@@ -14,6 +14,7 @@
 
 """Training submission tools: fine_tune, run_custom_training, run_container_training."""
 
+import ast
 import logging
 import os
 import tempfile
@@ -104,15 +105,44 @@ def _make_train_func(script: str, func_args: dict[str, Any] | None = None) -> Ca
     keyword parameters so the trainer can pass them at runtime.
     """
     func_name = "train"
-    lines = script.strip().splitlines()
+    
+    try:
+        tree = ast.parse(script)
+    except SyntaxError:
+        tree = None
 
-    if func_args:
-        params = ", ".join(f"{k}=None" for k in func_args)
-        wrapped = f"def {func_name}({params}):\n"
+    has_train_func = False
+    if tree is not None:
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef) and node.name == func_name:
+                has_train_func = True
+                if func_args:
+                    arg_names = {arg.arg for arg in node.args.args}
+                    arg_names.update({arg.arg for arg in node.args.kwonlyargs})
+                    has_kwargs = node.args.kwarg is not None
+                    
+                    if not has_kwargs:
+                        missing = set(func_args.keys()) - arg_names
+                        if missing:
+                            raise ValueError(
+                                f"Script defines a top-level '{func_name}' function but it is missing "
+                                f"parameters required by func_args: {', '.join(missing)}."
+                            )
+                break
+
+    if has_train_func:
+        wrapped = script
+        if not wrapped.endswith("\n"):
+            wrapped += "\n"
     else:
-        wrapped = f"def {func_name}():\n"
-    for line in lines:
-        wrapped += f"    {line}\n"
+        lines = script.strip().splitlines()
+        if func_args:
+            params = ", ".join(f"{k}=None" for k in func_args)
+            wrapped = f"def {func_name}({params}):\n"
+        else:
+            wrapped = f"def {func_name}():\n"
+        for line in lines:
+            wrapped += f"    {line}\n"
 
     script_dir = _get_script_dir()
     script_path = os.path.join(script_dir, f"_mcp_train_{uuid.uuid4().hex[:8]}.py")

--- a/tests/unit/trainer/test_training_script_wrapper.py
+++ b/tests/unit/trainer/test_training_script_wrapper.py
@@ -1,0 +1,31 @@
+import pytest
+from unittest.mock import patch, mock_open
+from kubeflow_mcp.trainer.api.training import _make_train_func
+
+def test_make_train_func_simple():
+    script = "print('hello')"
+    with patch("kubeflow_mcp.trainer.api.training.uuid") as mock_uuid, \
+         patch("builtins.open", mock_open()) as mock_file:
+        func = _make_train_func(script)
+        assert callable(func)
+        assert func.__name__ == "train"
+
+def test_make_train_func_with_existing_train():
+    script = "def train():\n    return 42\n"
+    func = _make_train_func(script)
+    assert func() == 42
+
+def test_make_train_func_missing_args():
+    script = "def train():\n    return 42\n"
+    with pytest.raises(ValueError, match="is missing parameters required by func_args: param1"):
+        _make_train_func(script, func_args={"param1": 1})
+
+def test_make_train_func_matching_args():
+    script = "def train(param1, param2=None):\n    return param1\n"
+    func = _make_train_func(script, func_args={"param1": 1})
+    assert func(42) == 42
+
+def test_make_train_func_with_kwargs():
+    script = "def train(**kwargs):\n    return kwargs.get('param1')\n"
+    func = _make_train_func(script, func_args={"param1": 1})
+    assert func(param1=42) == 42


### PR DESCRIPTION
Fixes #19.

When a user passes a custom training script that already defines `def train():` or `def train(parameters...):`, the `_make_train_func` helper previously wrapped the entire script in another `def train():` wrapper and just indented the user's code. This meant the inner function was defined but never called, leading to jobs completing with `exit code 0` but skipping training entirely.

This PR uses `ast.parse` to detect if a top-level `train` function is already defined in the script. If it is, we return the script verbatim. If `func_args` are provided, we also check the AST to ensure the user's `train` function accepts the parameters (or has `**kwargs`), and raise an early clear `ValueError` if it does not.

Added unit tests in `tests/unit/trainer/test_training_script_wrapper.py`.