### PR TITLE
feat: add OpenTelemetry tracing for tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,14 +215,17 @@ OpenTelemetry tracing is optional and can be enabled without changing tool code.
 - Enable tracing with CLI flag or env var:
 
 ```bash
-kubeflow-mcp serve --otel-endpoint http://localhost:4318/v1/traces
+kubeflow-mcp serve --otel-endpoint http://localhost:4318
 # or
-export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 kubeflow-mcp serve
 ```
 
 Each tool invocation emits a span with attributes:
-`tool.name`, `tool.success`, `tool.duration_ms`, `kubeflow.persona`, and `correlation_id`.
+`tool.name`, `tool.args_preview`, `tool.success`, `tool.duration_ms`, `kubeflow.persona`, and `correlation_id`.
+
+> **Note:** `kubeflow-mcp agent --otel-endpoint ...` emits spans under a separate
+> `kubeflow-mcp-agent` service in Jaeger, distinct from the `kubeflow-mcp` server spans.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ OpenTelemetry tracing is optional and can be enabled without changing tool code.
 ```bash
 kubeflow-mcp serve --otel-endpoint http://localhost:4318/v1/traces
 # or
-export KUBEFLOW_MCP_OTEL_ENDPOINT=http://localhost:4318/v1/traces
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
 kubeflow-mcp serve
 ```
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ kubeflow-mcp serve \
   --instruction-tier full \       # full | compact | minimal
   --transport stdio \             # stdio | http | sse
   --auth-token SECRET \           # bearer token for HTTP auth (dev/staging)
+  --otel-endpoint URL \           # OTLP HTTP endpoint (optional tracing)
   --log-level INFO \              # DEBUG | INFO | WARNING | ERROR
   --log-format console \          # console | json (auto-detected if omitted)
   --no-banner                     # suppress startup banner
@@ -205,6 +206,23 @@ kubeflow-mcp agent \
 ```
 
 </details>
+
+## Observability
+
+OpenTelemetry tracing is optional and can be enabled without changing tool code.
+
+- Install optional dependencies: `pip install ".[otel]"`
+- Enable tracing with CLI flag or env var:
+
+```bash
+kubeflow-mcp serve --otel-endpoint http://localhost:4318/v1/traces
+# or
+export KUBEFLOW_MCP_OTEL_ENDPOINT=http://localhost:4318/v1/traces
+kubeflow-mcp serve
+```
+
+Each tool invocation emits a span with attributes:
+`tool.name`, `tool.success`, `tool.duration_ms`, `kubeflow.persona`, and `correlation_id`.
 
 ## Development
 

--- a/kubeflow_mcp/cli.py
+++ b/kubeflow_mcp/cli.py
@@ -98,7 +98,7 @@ def cli() -> None:
     "--otel-endpoint",
     default=None,
     help="OpenTelemetry OTLP HTTP endpoint for tracing. "
-    "Falls back to KUBEFLOW_MCP_OTEL_ENDPOINT env var, config file.",
+    "Falls back to OTEL_EXPORTER_OTLP_ENDPOINT env var, config file.",
 )
 def serve(
     clients: str | None,

--- a/kubeflow_mcp/cli.py
+++ b/kubeflow_mcp/cli.py
@@ -94,6 +94,12 @@ def cli() -> None:
     "Falls back to KUBEFLOW_MCP_AUTH_TOKEN env var, config file. "
     "Ignored for stdio transport.",
 )
+@click.option(
+    "--otel-endpoint",
+    default=None,
+    help="OpenTelemetry OTLP HTTP endpoint for tracing. "
+    "Falls back to KUBEFLOW_MCP_OTEL_ENDPOINT env var, config file.",
+)
 def serve(
     clients: str | None,
     persona: str | None,
@@ -104,6 +110,7 @@ def serve(
     instruction_tier: str | None,
     no_banner: bool,
     auth_token: str | None,
+    otel_endpoint: str | None,
 ) -> None:
     """Start the MCP server.
 
@@ -116,6 +123,7 @@ def serve(
     from kubeflow_mcp.core.logging import setup_logging
     from kubeflow_mcp.core.resilience import configure_circuit_breaker
     from kubeflow_mcp.core.server import configure_resilience, create_server
+    from kubeflow_mcp.core.telemetry import setup_tracing
 
     cfg = load_config()
 
@@ -128,8 +136,11 @@ def serve(
 
     if auth_token:
         cfg.auth.auth_token = auth_token
+    if otel_endpoint:
+        cfg.observability.otel_endpoint = otel_endpoint
 
     logger = setup_logging(level=log_level, format=log_format)
+    tracing_enabled = setup_tracing(endpoint=cfg.observability.otel_endpoint)
     logger.info(
         "Starting kubeflow-mcp",
         extra={
@@ -138,6 +149,7 @@ def serve(
             "transport": transport,
             "mode": mode,
             "instruction_tier": instruction_tier,
+            "tracing_enabled": tracing_enabled,
         },
     )
 

--- a/kubeflow_mcp/cli_test.py
+++ b/kubeflow_mcp/cli_test.py
@@ -97,6 +97,7 @@ def _make_serve_mocks(config=None):
     mock_load_config = MagicMock(return_value=config)
     mock_build_auth_provider = MagicMock(return_value=None)
     mock_configure_circuit_breaker = MagicMock()
+    mock_setup_tracing = MagicMock(return_value=False)
 
     fake_server_mod = MagicMock()
     fake_server_mod.create_server = mock_create_server
@@ -109,6 +110,8 @@ def _make_serve_mocks(config=None):
     fake_auth_mod.build_auth_provider = mock_build_auth_provider
     fake_resilience_mod = MagicMock()
     fake_resilience_mod.configure_circuit_breaker = mock_configure_circuit_breaker
+    fake_telemetry_mod = MagicMock()
+    fake_telemetry_mod.setup_tracing = mock_setup_tracing
 
     modules_patch = {
         "kubeflow_mcp.core.server": fake_server_mod,
@@ -116,6 +119,7 @@ def _make_serve_mocks(config=None):
         "kubeflow_mcp.core.config": fake_config_mod,
         "kubeflow_mcp.core.auth": fake_auth_mod,
         "kubeflow_mcp.core.resilience": fake_resilience_mod,
+        "kubeflow_mcp.core.telemetry": fake_telemetry_mod,
     }
     return mock_server, mock_create_server, modules_patch
 
@@ -401,3 +405,40 @@ def test_serve_default_shows_banner():
 
     _, kwargs = mock_server.run.call_args
     assert kwargs.get("show_banner") is True
+
+
+def test_serve_calls_setup_tracing_with_config_endpoint():
+    from kubeflow_mcp.core.config import ObservabilityConfig
+
+    config = _make_default_config()
+    config.observability = ObservabilityConfig(otel_endpoint="http://otel-collector:4318/v1/traces")
+    mock_server, _, modules_patch = _make_serve_mocks(config=config)
+    fake_telemetry_mod = modules_patch["kubeflow_mcp.core.telemetry"]
+
+    with patch.dict(sys.modules, modules_patch):
+        runner = CliRunner()
+        runner.invoke(cli, ["serve"])
+
+    fake_telemetry_mod.setup_tracing.assert_called_once_with(
+        endpoint="http://otel-collector:4318/v1/traces"
+    )
+
+
+def test_serve_otel_endpoint_cli_overrides_config():
+    from kubeflow_mcp.core.config import ObservabilityConfig
+
+    config = _make_default_config()
+    config.observability = ObservabilityConfig(otel_endpoint="http://old-endpoint:4318/v1/traces")
+    mock_server, _, modules_patch = _make_serve_mocks(config=config)
+    fake_telemetry_mod = modules_patch["kubeflow_mcp.core.telemetry"]
+
+    with patch.dict(sys.modules, modules_patch):
+        runner = CliRunner()
+        runner.invoke(
+            cli,
+            ["serve", "--otel-endpoint", "http://new-endpoint:4318/v1/traces"],
+        )
+
+    fake_telemetry_mod.setup_tracing.assert_called_once_with(
+        endpoint="http://new-endpoint:4318/v1/traces"
+    )

--- a/kubeflow_mcp/core/config.py
+++ b/kubeflow_mcp/core/config.py
@@ -51,7 +51,7 @@ Example config file (~/.kubeflow-mcp.yaml):
             format: json
 
         observability:
-            otel_endpoint: http://localhost:4318/v1/traces
+            otel_endpoint: http://localhost:4318
 
 Namespace restrictions are enforced via ``~/.kf-mcp-policy.yaml``
 (``policy.namespaces``), not through server config.

--- a/kubeflow_mcp/core/config.py
+++ b/kubeflow_mcp/core/config.py
@@ -242,7 +242,7 @@ def load_config(config_path: Path | None = None) -> Config:
     observability_file = file_config.get("observability", {})
     observability = ObservabilityConfig(
         otel_endpoint=os.getenv(
-            "KUBEFLOW_MCP_OTEL_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
             observability_file.get("otel_endpoint"),
         )
     )

--- a/kubeflow_mcp/core/config.py
+++ b/kubeflow_mcp/core/config.py
@@ -50,6 +50,9 @@ Example config file (~/.kubeflow-mcp.yaml):
             level: INFO
             format: json
 
+        observability:
+            otel_endpoint: http://localhost:4318/v1/traces
+
 Namespace restrictions are enforced via ``~/.kf-mcp-policy.yaml``
 (``policy.namespaces``), not through server config.
 """
@@ -135,6 +138,12 @@ class LoggingConfig(BaseModel):
     format: str | None = Field(default=None)
 
 
+class ObservabilityConfig(BaseModel):
+    """Observability configuration."""
+
+    otel_endpoint: str | None = Field(default=None)
+
+
 class Config(BaseModel):
     """Root configuration."""
 
@@ -144,6 +153,7 @@ class Config(BaseModel):
     trainer: TrainerConfig = Field(default_factory=TrainerConfig)
     optimizer: OptimizerConfig = Field(default_factory=OptimizerConfig)
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
+    observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
 
 
 def _find_config_file() -> Path | None:
@@ -229,6 +239,14 @@ def load_config(config_path: Path | None = None) -> Config:
         format=os.getenv("LOG_FORMAT", logging_file.get("format")),
     )
 
+    observability_file = file_config.get("observability", {})
+    observability = ObservabilityConfig(
+        otel_endpoint=os.getenv(
+            "KUBEFLOW_MCP_OTEL_ENDPOINT",
+            observability_file.get("otel_endpoint"),
+        )
+    )
+
     # Build client-specific configs
     trainer_file = file_config.get("trainer", {})
     trainer = TrainerConfig(
@@ -283,6 +301,7 @@ def load_config(config_path: Path | None = None) -> Config:
         trainer=trainer,
         optimizer=optimizer,
         logging=logging_config,
+        observability=observability,
     )
 
 

--- a/kubeflow_mcp/core/logging.py
+++ b/kubeflow_mcp/core/logging.py
@@ -49,7 +49,7 @@ class StructuredFormatter(logging.Formatter):
         if ctx is not None:
             log_dict["context"] = ctx
 
-        extra_keys = {"audit", "tool", "parameters", "success", "duration_ms"}
+        extra_keys = {"audit", "tool", "parameters", "success", "duration_ms", "tracing_enabled"}
         for key in extra_keys:
             if hasattr(record, key):
                 log_dict[key] = getattr(record, key)

--- a/kubeflow_mcp/core/middleware.py
+++ b/kubeflow_mcp/core/middleware.py
@@ -1,0 +1,125 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Middleware to bridge FastMCP async context into sync tool wrappers via ContextVars.
+
+FastMCP's ``CurrentContext()`` dependency injection may not reliably propagate
+into sync wrappers.  This module uses :mod:`contextvars` to capture session,
+request, and user identity from the async middleware layer so that the
+synchronous ``_audit_wrap`` in :mod:`kubeflow_mcp.core.server` can read them
+without depending on DI.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ContextVars populated by AuditIdentityMiddleware, read by _audit_wrap
+_session_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "mcp_session_id", default=None
+)
+_request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "mcp_request_id", default=None
+)
+_user_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "mcp_user_id", default=None
+)
+
+
+def get_mcp_session_id() -> str | None:
+    """Return the MCP session ID for the current request, or None."""
+    return _session_id_var.get()
+
+
+def get_mcp_request_id() -> str | None:
+    """Return the MCP request ID for the current request, or None."""
+    return _request_id_var.get()
+
+
+def get_user_id() -> str | None:
+    """Return the user identity for the current request, or None."""
+    return _user_id_var.get()
+
+
+class AuditIdentityMiddleware:
+    """FastMCP-compatible middleware that captures identity into ContextVars.
+
+    Extracts ``session_id``, ``request_id``, and optionally ``user_id``
+    from the FastMCP ``MiddlewareContext`` and stores them in module-level
+    :class:`contextvars.ContextVar` instances.  Downstream sync code
+    (e.g. ``_audit_wrap``) can retrieve these values via the public
+    ``get_mcp_*`` helpers without needing async or DI.
+
+    Usage::
+
+        from kubeflow_mcp.core.middleware import AuditIdentityMiddleware
+        mcp = FastMCP("kubeflow-mcp-server")
+        mcp.add_middleware(AuditIdentityMiddleware)
+    """
+
+    async def __call__(self, context: Any, call_next: Any) -> Any:
+        """Capture identity from context, then delegate to the next handler."""
+        # Use tokens so reset() restores the *previous* value rather than
+        # unconditionally writing None (correct ContextVar cleanup pattern).
+        session_token = _session_id_var.set(None)
+        request_token = _request_id_var.set(None)
+        user_token = _user_id_var.set(None)
+
+        # Extract session + request IDs from FastMCP context
+        fastmcp_ctx = None
+        try:
+            fastmcp_ctx = getattr(context, "fastmcp_context", None)
+        except Exception:
+            pass
+
+        if fastmcp_ctx is not None:
+            try:
+                session_id = getattr(fastmcp_ctx, "session_id", None)
+                if session_id is not None:
+                    _session_id_var.set(str(session_id))
+            except Exception:
+                pass
+            try:
+                request_id = getattr(fastmcp_ctx, "request_id", None)
+                if request_id is not None:
+                    _request_id_var.set(str(request_id))
+            except Exception:
+                pass
+
+        # Extract user identity (from auth or transport metadata)
+        try:
+            request_context = getattr(context, "request_context", None)
+            if request_context is not None:
+                meta = getattr(request_context, "meta", None)
+                if meta is not None:
+                    if isinstance(meta, dict):
+                        user_id = meta.get("user_id")
+                    else:
+                        user_id = getattr(meta, "user_id", None)
+                    if user_id is not None:
+                        _user_id_var.set(str(user_id))
+        except Exception:
+            pass
+
+        try:
+            return await call_next(context)
+        finally:
+            # Restore ContextVars to their previous values
+            _session_id_var.reset(session_token)
+            _request_id_var.reset(request_token)
+            _user_id_var.reset(user_token)

--- a/kubeflow_mcp/core/server.py
+++ b/kubeflow_mcp/core/server.py
@@ -21,6 +21,7 @@ Designed for extensibility:
 
 import functools
 import importlib
+import json
 import logging
 import re
 import time
@@ -118,6 +119,11 @@ def _audit_wrap(tool_func):
             span.set_attribute("tool.name", tool_name)
             span.set_attribute("kubeflow.persona", persona)
             span.set_attribute("correlation_id", cid)
+            masked = mask_sensitive_data(kwargs) if kwargs else {}
+            span.set_attribute(
+                "tool.args_preview",
+                json.dumps(masked, default=str)[:300],
+            )
 
             if _rate_limiter is not None and not _rate_limiter.acquire():
                 duration_ms = int((time.monotonic() - start) * 1000)
@@ -140,7 +146,6 @@ def _audit_wrap(tool_func):
                     "error_code": ErrorCode.CIRCUIT_OPEN,
                 }
 
-            masked = mask_sensitive_data(kwargs) if kwargs else {}
             try:
                 result = tool_func(**kwargs)
                 duration_ms = int((time.monotonic() - start) * 1000)

--- a/kubeflow_mcp/core/server.py
+++ b/kubeflow_mcp/core/server.py
@@ -27,8 +27,7 @@ import re
 import time
 from typing import Any
 
-from fastmcp import Context, FastMCP
-from fastmcp.dependencies import CurrentContext
+from fastmcp import FastMCP
 
 from kubeflow_mcp.common.constants import (
     TOOL_NEXT_HINTS,
@@ -43,6 +42,7 @@ from kubeflow_mcp.core.health import (
     HEALTH_TOOLS,
 )
 from kubeflow_mcp.core.logging import with_correlation_id
+from kubeflow_mcp.core.middleware import get_mcp_request_id, get_mcp_session_id, get_user_id
 from kubeflow_mcp.core.policy import (
     apply_policy_filters,
     get_allowed_tools,
@@ -68,8 +68,6 @@ try:
     from mcp.types import LATEST_PROTOCOL_VERSION as _MCP_PROTOCOL_VERSION
 except ImportError:  # pragma: no cover
     _MCP_PROTOCOL_VERSION = None
-
-_MCP_CTX_DEFAULT = CurrentContext()
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +110,7 @@ def _audit_wrap(tool_func):
     tracer = get_tracer("kubeflow_mcp.tools")
 
     @functools.wraps(tool_func)
-    def wrapper(ctx: Context | None = _MCP_CTX_DEFAULT, **kwargs):
+    def wrapper(**kwargs):
         tool_name = tool_func.__name__
         cid = with_correlation_id()
         persona = get_effective_persona()
@@ -131,18 +129,16 @@ def _audit_wrap(tool_func):
             if _MCP_PROTOCOL_VERSION:
                 span.set_attribute("mcp.protocol.version", _MCP_PROTOCOL_VERSION)
 
-            # MCP session/request context (populated by FastMCP at runtime)
-            if isinstance(ctx, Context):
-                try:
-                    if ctx.session_id:
-                        span.set_attribute("mcp.session.id", str(ctx.session_id))
-                except Exception:
-                    pass
-                try:
-                    if ctx.request_id is not None:
-                        span.set_attribute("mcp.request.id", str(ctx.request_id))
-                except Exception:
-                    pass
+            # MCP session/request context (populated via AuditIdentityMiddleware ContextVars)
+            session_id = get_mcp_session_id()
+            if session_id:
+                span.set_attribute("mcp.session.id", session_id)
+            request_id = get_mcp_request_id()
+            if request_id:
+                span.set_attribute("mcp.request.id", request_id)
+            user_id = get_user_id()
+            if user_id:
+                span.set_attribute("user.id", user_id)
 
             # Custom Kubeflow enrichment
             span.set_attribute("kubeflow.persona", persona)
@@ -361,7 +357,12 @@ def create_server(  # noqa: C901
     if auth_provider is not None:
         mcp_kwargs["auth"] = auth_provider
         logger.info("HTTP auth provider attached to server")
-    mcp: FastMCP = FastMCP("kubeflow-mcp", **mcp_kwargs)
+    mcp: FastMCP = FastMCP("kubeflow-mcp-server", **mcp_kwargs)
+
+    # Bridge FastMCP async context into sync _audit_wrap via ContextVars
+    from kubeflow_mcp.core.middleware import AuditIdentityMiddleware
+
+    mcp.add_middleware(AuditIdentityMiddleware)
 
     # Merge tool metadata from client modules
     all_descriptions: dict[str, str] = {}

--- a/kubeflow_mcp/core/server.py
+++ b/kubeflow_mcp/core/server.py
@@ -99,7 +99,7 @@ def _audit_wrap(tool_func):
         persona = get_effective_persona()
         start = time.monotonic()
 
-        with tracer.start_as_current_span("tool_call") as span:
+        with tracer.start_as_current_span(f"tool:{tool_name}") as span:
             span.set_attribute("tool.name", tool_name)
             span.set_attribute("kubeflow.persona", persona)
             span.set_attribute("correlation_id", cid)

--- a/kubeflow_mcp/core/server.py
+++ b/kubeflow_mcp/core/server.py
@@ -52,6 +52,15 @@ from kubeflow_mcp.core.resources import register_resources
 from kubeflow_mcp.core.security import mask_sensitive_data
 from kubeflow_mcp.core.telemetry import get_tracer
 
+try:
+    from opentelemetry.trace import SpanKind
+    from opentelemetry.trace import Status as _Status
+    from opentelemetry.trace import StatusCode as _StatusCode
+except ImportError:  # pragma: no cover
+    SpanKind = None  # type: ignore[assignment,misc]
+    _Status = None  # type: ignore[assignment,misc]
+    _StatusCode = None  # type: ignore[assignment,misc]
+
 logger = logging.getLogger(__name__)
 
 _rate_limiter: RateLimiter | None = None
@@ -90,16 +99,22 @@ def _inject_meta(result: Any, tool_name: str) -> Any:
 
 def _audit_wrap(tool_func):
     """Wrap a tool function with rate limiting, circuit breaking, audit logging, and response metadata."""
+    tracer = get_tracer("kubeflow_mcp.tools")
 
     @functools.wraps(tool_func)
     def wrapper(**kwargs):
         tool_name = tool_func.__name__
         cid = with_correlation_id()
-        tracer = get_tracer("kubeflow_mcp.tools")
         persona = get_effective_persona()
         start = time.monotonic()
 
-        with tracer.start_as_current_span(f"tool:{tool_name}") as span:
+        span_kwargs: dict[str, Any] = {}
+        if SpanKind is not None:
+            span_kwargs["kind"] = SpanKind.CLIENT
+
+        with tracer.start_as_current_span(
+            f"tool:{tool_name}", **span_kwargs
+        ) as span:
             span.set_attribute("tool.name", tool_name)
             span.set_attribute("kubeflow.persona", persona)
             span.set_attribute("correlation_id", cid)
@@ -158,7 +173,8 @@ def _audit_wrap(tool_func):
                 breaker.record_failure()
                 span.set_attribute("tool.success", False)
                 span.set_attribute("tool.duration_ms", duration_ms)
-                span.record_exception(exc)
+                if _StatusCode is not None:
+                    span.set_status(_Status(_StatusCode.ERROR, str(exc)))
                 logger.error(
                     "tool_call_failed",
                     extra={

--- a/kubeflow_mcp/core/server.py
+++ b/kubeflow_mcp/core/server.py
@@ -27,7 +27,8 @@ import re
 import time
 from typing import Any
 
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
+from fastmcp.dependencies import CurrentContext
 
 from kubeflow_mcp.common.constants import (
     TOOL_NEXT_HINTS,
@@ -61,6 +62,14 @@ except ImportError:  # pragma: no cover
     SpanKind = None  # type: ignore[assignment,misc]
     _Status = None  # type: ignore[assignment,misc]
     _StatusCode = None  # type: ignore[assignment,misc]
+
+# MCP protocol version from the SDK (used as span attribute)
+try:
+    from mcp.types import LATEST_PROTOCOL_VERSION as _MCP_PROTOCOL_VERSION
+except ImportError:  # pragma: no cover
+    _MCP_PROTOCOL_VERSION = None
+
+_MCP_CTX_DEFAULT = CurrentContext()
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +112,7 @@ def _audit_wrap(tool_func):
     tracer = get_tracer("kubeflow_mcp.tools")
 
     @functools.wraps(tool_func)
-    def wrapper(**kwargs):
+    def wrapper(ctx: Context | None = _MCP_CTX_DEFAULT, **kwargs):
         tool_name = tool_func.__name__
         cid = with_correlation_id()
         persona = get_effective_persona()
@@ -111,12 +120,31 @@ def _audit_wrap(tool_func):
 
         span_kwargs: dict[str, Any] = {}
         if SpanKind is not None:
-            span_kwargs["kind"] = SpanKind.CLIENT
+            span_kwargs["kind"] = SpanKind.SERVER
 
-        with tracer.start_as_current_span(
-            f"tool:{tool_name}", **span_kwargs
-        ) as span:
-            span.set_attribute("tool.name", tool_name)
+        with tracer.start_as_current_span(f"tools/call {tool_name}", **span_kwargs) as span:
+            # OTel MCP semantic conventions (Development status)
+            # https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/
+            span.set_attribute("mcp.method.name", "tools/call")
+            span.set_attribute("gen_ai.tool.name", tool_name)
+            span.set_attribute("gen_ai.operation.name", "execute_tool")
+            if _MCP_PROTOCOL_VERSION:
+                span.set_attribute("mcp.protocol.version", _MCP_PROTOCOL_VERSION)
+
+            # MCP session/request context (populated by FastMCP at runtime)
+            if isinstance(ctx, Context):
+                try:
+                    if ctx.session_id:
+                        span.set_attribute("mcp.session.id", str(ctx.session_id))
+                except Exception:
+                    pass
+                try:
+                    if ctx.request_id is not None:
+                        span.set_attribute("mcp.request.id", str(ctx.request_id))
+                except Exception:
+                    pass
+
+            # Custom Kubeflow enrichment
             span.set_attribute("kubeflow.persona", persona)
             span.set_attribute("correlation_id", cid)
             masked = mask_sensitive_data(kwargs) if kwargs else {}
@@ -178,6 +206,7 @@ def _audit_wrap(tool_func):
                 breaker.record_failure()
                 span.set_attribute("tool.success", False)
                 span.set_attribute("tool.duration_ms", duration_ms)
+                span.set_attribute("error.type", type(exc).__qualname__)
                 if _StatusCode is not None:
                     span.set_status(_Status(_StatusCode.ERROR, str(exc)))
                 logger.error(

--- a/kubeflow_mcp/core/server.py
+++ b/kubeflow_mcp/core/server.py
@@ -41,10 +41,16 @@ from kubeflow_mcp.core.health import (
     HEALTH_TOOLS,
 )
 from kubeflow_mcp.core.logging import with_correlation_id
-from kubeflow_mcp.core.policy import apply_policy_filters, get_allowed_tools, is_read_only
+from kubeflow_mcp.core.policy import (
+    apply_policy_filters,
+    get_allowed_tools,
+    get_effective_persona,
+    is_read_only,
+)
 from kubeflow_mcp.core.resilience import RateLimiter, get_breaker
 from kubeflow_mcp.core.resources import register_resources
 from kubeflow_mcp.core.security import mask_sensitive_data
+from kubeflow_mcp.core.telemetry import get_tracer
 
 logger = logging.getLogger(__name__)
 
@@ -88,66 +94,84 @@ def _audit_wrap(tool_func):
     @functools.wraps(tool_func)
     def wrapper(**kwargs):
         tool_name = tool_func.__name__
-
-        if _rate_limiter is not None and not _rate_limiter.acquire():
-            logger.warning("rate_limited", extra={"tool": tool_name})
-            return {
-                "error": "Rate limit exceeded. Retry after a brief pause.",
-                "error_code": ErrorCode.RATE_LIMITED,
-            }
-
-        breaker = get_breaker(tool_name)
-        if not breaker.can_execute():
-            logger.warning("circuit_open", extra={"tool": tool_name})
-            return {
-                "error": f"Circuit breaker open for '{tool_name}' — K8s API may be degraded. Retries automatically after recovery timeout.",
-                "error_code": ErrorCode.CIRCUIT_OPEN,
-            }
-
         cid = with_correlation_id()
-        masked = mask_sensitive_data(kwargs) if kwargs else {}
+        tracer = get_tracer("kubeflow_mcp.tools")
+        persona = get_effective_persona()
         start = time.monotonic()
-        try:
-            result = tool_func(**kwargs)
-            duration_ms = int((time.monotonic() - start) * 1000)
-            is_success = (
-                "error_code" not in result and "error" not in result
-                if isinstance(result, dict)
-                else True
-            )
-            if is_success:
-                breaker.record_success()
-            elif is_infrastructure_error(result):
-                breaker.record_failure()
 
-            logger.info(
-                "tool_call",
-                extra={
-                    "audit": True,
-                    "correlation_id": cid,
-                    "tool": tool_name,
-                    "parameters": masked,
-                    "success": is_success,
-                    "duration_ms": duration_ms,
-                },
-            )
-            return _inject_meta(result, tool_name)
-        except Exception:
-            duration_ms = int((time.monotonic() - start) * 1000)
-            breaker.record_failure()
-            logger.error(
-                "tool_call_failed",
-                extra={
-                    "audit": True,
-                    "correlation_id": cid,
-                    "tool": tool_name,
-                    "parameters": masked,
-                    "success": False,
-                    "duration_ms": duration_ms,
-                },
-                exc_info=True,
-            )
-            raise
+        with tracer.start_as_current_span("tool_call") as span:
+            span.set_attribute("tool.name", tool_name)
+            span.set_attribute("kubeflow.persona", persona)
+            span.set_attribute("correlation_id", cid)
+
+            if _rate_limiter is not None and not _rate_limiter.acquire():
+                duration_ms = int((time.monotonic() - start) * 1000)
+                span.set_attribute("tool.success", False)
+                span.set_attribute("tool.duration_ms", duration_ms)
+                logger.warning("rate_limited", extra={"tool": tool_name})
+                return {
+                    "error": "Rate limit exceeded. Retry after a brief pause.",
+                    "error_code": ErrorCode.RATE_LIMITED,
+                }
+
+            breaker = get_breaker(tool_name)
+            if not breaker.can_execute():
+                duration_ms = int((time.monotonic() - start) * 1000)
+                span.set_attribute("tool.success", False)
+                span.set_attribute("tool.duration_ms", duration_ms)
+                logger.warning("circuit_open", extra={"tool": tool_name})
+                return {
+                    "error": f"Circuit breaker open for '{tool_name}' — K8s API may be degraded. Retries automatically after recovery timeout.",
+                    "error_code": ErrorCode.CIRCUIT_OPEN,
+                }
+
+            masked = mask_sensitive_data(kwargs) if kwargs else {}
+            try:
+                result = tool_func(**kwargs)
+                duration_ms = int((time.monotonic() - start) * 1000)
+                is_success = (
+                    "error_code" not in result and "error" not in result
+                    if isinstance(result, dict)
+                    else True
+                )
+                span.set_attribute("tool.success", is_success)
+                span.set_attribute("tool.duration_ms", duration_ms)
+                if is_success:
+                    breaker.record_success()
+                elif is_infrastructure_error(result):
+                    breaker.record_failure()
+
+                logger.info(
+                    "tool_call",
+                    extra={
+                        "audit": True,
+                        "correlation_id": cid,
+                        "tool": tool_name,
+                        "parameters": masked,
+                        "success": is_success,
+                        "duration_ms": duration_ms,
+                    },
+                )
+                return _inject_meta(result, tool_name)
+            except Exception as exc:
+                duration_ms = int((time.monotonic() - start) * 1000)
+                breaker.record_failure()
+                span.set_attribute("tool.success", False)
+                span.set_attribute("tool.duration_ms", duration_ms)
+                span.record_exception(exc)
+                logger.error(
+                    "tool_call_failed",
+                    extra={
+                        "audit": True,
+                        "correlation_id": cid,
+                        "tool": tool_name,
+                        "parameters": masked,
+                        "success": False,
+                        "duration_ms": duration_ms,
+                    },
+                    exc_info=True,
+                )
+                raise
 
     return wrapper
 

--- a/kubeflow_mcp/core/telemetry.py
+++ b/kubeflow_mcp/core/telemetry.py
@@ -41,14 +41,18 @@ class _NoopSpan:
     def set_attribute(self, key: str, value: Any) -> None:
         return None
 
-    def record_exception(self, exception: BaseException) -> None:
+    def record_exception(self, exception: BaseException, **kwargs: Any) -> None:
+        return None
+
+    def set_status(self, status: Any, description: str | None = None) -> None:
         return None
 
 
 class _NoopTracer:
     @contextmanager
-    def start_as_current_span(self, name: str) -> Generator[_NoopSpan, None, None]:
-        del name
+    def start_as_current_span(
+        self, name: str, **kwargs: Any
+    ) -> Generator[_NoopSpan, None, None]:
         yield _NoopSpan()
 
 

--- a/kubeflow_mcp/core/telemetry.py
+++ b/kubeflow_mcp/core/telemetry.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import atexit
 import logging
+import os
 import threading
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -80,12 +81,16 @@ def _normalize_and_validate_endpoint(endpoint: str | None) -> str:
     return normalized_endpoint
 
 
-def setup_tracing(endpoint: str | None, service_name: str = "kubeflow-mcp") -> bool:
+def setup_tracing(endpoint: str | None = None, service_name: str = "kubeflow-mcp-server") -> bool:
     """Configure OpenTelemetry tracing.
 
     Returns True when tracing is configured, False when disabled/unavailable.
     """
     global _configured_endpoint, _tracing_initialized
+
+    # Fall back to standard OTel env var when no explicit endpoint is provided
+    if not endpoint or not endpoint.strip():
+        endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
 
     normalized_endpoint = _normalize_and_validate_endpoint(endpoint)
     if not normalized_endpoint:
@@ -108,8 +113,11 @@ def setup_tracing(endpoint: str | None, service_name: str = "kubeflow-mcp") -> b
                 )
             return True
 
-        exporter = OTLPSpanExporter(endpoint=normalized_endpoint)
-        processor = BatchSpanProcessor(exporter)
+        exporter = OTLPSpanExporter(
+            endpoint=normalized_endpoint,
+            timeout=2000,
+        )
+        processor = BatchSpanProcessor(exporter, export_timeout_millis=2000)
         current_provider = _otel_trace.get_tracer_provider()
 
         if hasattr(current_provider, "add_span_processor"):

--- a/kubeflow_mcp/core/telemetry.py
+++ b/kubeflow_mcp/core/telemetry.py
@@ -1,0 +1,125 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenTelemetry tracing helpers with safe no-op fallback."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+try:
+    from opentelemetry import trace as _otel_trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    _OTEL_AVAILABLE = True
+except ImportError:
+    _OTEL_AVAILABLE = False
+
+
+class _NoopSpan:
+    def set_attribute(self, key: str, value: Any) -> None:
+        return None
+
+    def record_exception(self, exception: BaseException) -> None:
+        return None
+
+
+class _NoopTracer:
+    @contextmanager
+    def start_as_current_span(self, name: str) -> Generator[_NoopSpan, None, None]:
+        del name
+        yield _NoopSpan()
+
+
+_NOOP_TRACER = _NoopTracer()
+_tracing_initialized = False
+_configured_endpoint: str | None = None
+_setup_lock = threading.Lock()
+
+
+def _normalize_and_validate_endpoint(endpoint: str | None) -> str:
+    """Normalize and validate OTLP endpoint."""
+    normalized_endpoint = endpoint.strip() if endpoint is not None else ""
+    if not normalized_endpoint:
+        return ""
+
+    parsed = urlparse(normalized_endpoint)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(
+            "Invalid OpenTelemetry endpoint. Use a full HTTP(S) URL, "
+            "for example: http://localhost:4318/v1/traces"
+        )
+    return normalized_endpoint
+
+
+def setup_tracing(endpoint: str | None, service_name: str = "kubeflow-mcp") -> bool:
+    """Configure OpenTelemetry tracing.
+
+    Returns True when tracing is configured, False when disabled/unavailable.
+    """
+    global _configured_endpoint, _tracing_initialized
+
+    normalized_endpoint = _normalize_and_validate_endpoint(endpoint)
+    if not normalized_endpoint:
+        return False
+
+    if not _OTEL_AVAILABLE:
+        logger.warning(
+            "OpenTelemetry endpoint configured but OTel packages are not installed. "
+            "Install with: pip install '.[otel]'"
+        )
+        return False
+
+    with _setup_lock:
+        if _tracing_initialized:
+            if _configured_endpoint and _configured_endpoint != normalized_endpoint:
+                logger.warning(
+                    "Tracing already initialized for endpoint '%s'; ignoring new endpoint '%s'.",
+                    _configured_endpoint,
+                    normalized_endpoint,
+                )
+            return True
+
+        exporter = OTLPSpanExporter(endpoint=normalized_endpoint)
+        processor = BatchSpanProcessor(exporter)
+        current_provider = _otel_trace.get_tracer_provider()
+
+        if hasattr(current_provider, "add_span_processor"):
+            current_provider.add_span_processor(processor)
+        else:
+            resource = Resource.create({"service.name": service_name})
+            provider = TracerProvider(resource=resource)
+            provider.add_span_processor(processor)
+            _otel_trace.set_tracer_provider(provider)
+
+        _tracing_initialized = True
+        _configured_endpoint = normalized_endpoint
+        return True
+
+
+def get_tracer(name: str = "kubeflow_mcp") -> Any:
+    """Return OpenTelemetry tracer or no-op tracer when OTel is unavailable."""
+    if not _OTEL_AVAILABLE:
+        return _NOOP_TRACER
+    return _otel_trace.get_tracer(name)

--- a/kubeflow_mcp/core/telemetry.py
+++ b/kubeflow_mcp/core/telemetry.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import atexit
 import logging
 import threading
 from collections.abc import Generator
@@ -72,8 +73,12 @@ def _normalize_and_validate_endpoint(endpoint: str | None) -> str:
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise ValueError(
             "Invalid OpenTelemetry endpoint. Use a full HTTP(S) URL, "
-            "for example: http://localhost:4318/v1/traces"
+            "for example: http://localhost:4318"
         )
+    # Append the standard OTLP trace path when only a base URL is provided,
+    # matching the OTel SDK convention for OTEL_EXPORTER_OTLP_ENDPOINT.
+    if not parsed.path or parsed.path == "/":
+        normalized_endpoint = normalized_endpoint.rstrip("/") + "/v1/traces"
     return normalized_endpoint
 
 
@@ -116,6 +121,7 @@ def setup_tracing(endpoint: str | None, service_name: str = "kubeflow-mcp") -> b
             provider = TracerProvider(resource=resource)
             provider.add_span_processor(processor)
             _otel_trace.set_tracer_provider(provider)
+            atexit.register(provider.shutdown)
 
         _tracing_initialized = True
         _configured_endpoint = normalized_endpoint

--- a/kubeflow_mcp/core/telemetry.py
+++ b/kubeflow_mcp/core/telemetry.py
@@ -51,9 +51,7 @@ class _NoopSpan:
 
 class _NoopTracer:
     @contextmanager
-    def start_as_current_span(
-        self, name: str, **kwargs: Any
-    ) -> Generator[_NoopSpan, None, None]:
+    def start_as_current_span(self, name: str, **kwargs: Any) -> Generator[_NoopSpan, None, None]:
         yield _NoopSpan()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,16 @@ dev = [
     "ruff>=0.9",
     "pip-audit>=2.7",
 ]
+docs = [
+    "sphinx>=7.0",
+    "furo>=2024.1.29",
+    "sphinx-copybutton>=0.5",
+    "sphinx-design>=0.5",
+]
+otel = [
+    "opentelemetry-exporter-otlp>=1.29.0",
+    "opentelemetry-sdk>=1.29.0",
+]
 
 [project.scripts]
 kubeflow-mcp = "kubeflow_mcp.cli:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,14 @@ addopts = "-v --tb=short"
 # Pin transitive deps to versions that resolve known CVEs detected by pip-audit.
 constraint-dependencies = [
     "idna>=3.15",       # CVE-2026-45409
-    "starlette>=1.0.1", # PYSEC-2026-161
+    "starlette>=1.3.1", # CVE-2026-54282, CVE-2026-54283
     "aiohttp>=3.14.0",  # CVE-2026-34993, CVE-2026-47265
     "pyjwt>=2.13.0",    # PYSEC-2026-175, PYSEC-2026-177, PYSEC-2026-178, PYSEC-2026-179
+    "cryptography>=48.0.1",
+    "msgpack>=1.2.1",
+    "pip>=26.1.2",
+    "pydantic-settings>=2.14.2",
+    "python-multipart>=0.0.31",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ docs = [
     "sphinx-design>=0.5",
 ]
 otel = [
-    "opentelemetry-exporter-otlp>=1.29.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.29.0",
     "opentelemetry-sdk>=1.29.0",
 ]
 

--- a/tests/unit/core/test_middleware.py
+++ b/tests/unit/core/test_middleware.py
@@ -1,0 +1,250 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for AuditIdentityMiddleware ContextVar bridge."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from kubeflow_mcp.core.middleware import (
+    AuditIdentityMiddleware,
+    _request_id_var,
+    _session_id_var,
+    _user_id_var,
+    get_mcp_request_id,
+    get_mcp_session_id,
+    get_user_id,
+)
+
+
+def _make_context(
+    *,
+    session_id: object = None,
+    request_id: object = None,
+    user_id: str | None = None,
+    has_fastmcp_ctx: bool = True,
+    meta_as_dict: bool = True,
+) -> SimpleNamespace:
+    """Build a minimal mock MiddlewareContext for testing."""
+    ctx = SimpleNamespace()
+
+    if has_fastmcp_ctx:
+        fastmcp_ctx = SimpleNamespace()
+        fastmcp_ctx.session_id = session_id
+        fastmcp_ctx.request_id = request_id
+        ctx.fastmcp_context = fastmcp_ctx
+    else:
+        ctx.fastmcp_context = None
+
+    if user_id is not None:
+        if meta_as_dict:
+            meta = {"user_id": user_id}
+        else:
+            meta = SimpleNamespace(user_id=user_id)
+        ctx.request_context = SimpleNamespace(meta=meta)
+    else:
+        ctx.request_context = None
+
+    return ctx
+
+
+class TestAuditIdentityMiddleware:
+    """Tests for the AuditIdentityMiddleware __call__ method."""
+
+    def _run(self, coro):
+        """Helper to run async code in tests."""
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    @pytest.fixture(autouse=True)
+    def _clean_contextvars(self):
+        """Ensure ContextVars are clean before and after each test."""
+        _session_id_var.set(None)
+        _request_id_var.set(None)
+        _user_id_var.set(None)
+        yield
+        _session_id_var.set(None)
+        _request_id_var.set(None)
+        _user_id_var.set(None)
+
+    async def test_extracts_session_and_request_ids(self) -> None:
+        """Middleware sets session and request ContextVars from fastmcp_context."""
+        context = _make_context(session_id="sess-123", request_id=42)
+        mw = AuditIdentityMiddleware()
+
+        captured: dict[str, str | None] = {}
+
+        async def call_next(_ctx):
+            captured["session"] = get_mcp_session_id()
+            captured["request"] = get_mcp_request_id()
+            return "ok"
+
+        result = await mw(context, call_next)
+
+        assert result == "ok"
+        assert captured["session"] == "sess-123"
+        assert captured["request"] == "42"
+
+    async def test_extracts_user_id_from_dict_meta(self) -> None:
+        """Middleware extracts user_id when meta is a dict."""
+        context = _make_context(user_id="alice@example.com", meta_as_dict=True)
+        mw = AuditIdentityMiddleware()
+
+        captured: dict[str, str | None] = {}
+
+        async def call_next(_ctx):
+            captured["user"] = get_user_id()
+            return "ok"
+
+        await mw(context, call_next)
+        assert captured["user"] == "alice@example.com"
+
+    async def test_extracts_user_id_from_object_meta(self) -> None:
+        """Middleware extracts user_id when meta is an object with attributes."""
+        context = _make_context(user_id="bob@example.com", meta_as_dict=False)
+        mw = AuditIdentityMiddleware()
+
+        captured: dict[str, str | None] = {}
+
+        async def call_next(_ctx):
+            captured["user"] = get_user_id()
+            return "ok"
+
+        await mw(context, call_next)
+        assert captured["user"] == "bob@example.com"
+
+    async def test_cleanup_after_request(self) -> None:
+        """ContextVars are reset after the middleware completes."""
+        context = _make_context(
+            session_id="sess-cleanup",
+            request_id=99,
+            user_id="cleanup-user",
+        )
+        mw = AuditIdentityMiddleware()
+
+        async def call_next(_ctx):
+            # Values should be set during the call
+            assert get_mcp_session_id() == "sess-cleanup"
+            return "ok"
+
+        await mw(context, call_next)
+
+        # After completion, values should be restored to None
+        assert get_mcp_session_id() is None
+        assert get_mcp_request_id() is None
+        assert get_user_id() is None
+
+    async def test_cleanup_on_exception(self) -> None:
+        """ContextVars are reset even when call_next raises."""
+        context = _make_context(session_id="sess-err", request_id=1)
+        mw = AuditIdentityMiddleware()
+
+        async def call_next(_ctx):
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await mw(context, call_next)
+
+        assert get_mcp_session_id() is None
+        assert get_mcp_request_id() is None
+        assert get_user_id() is None
+
+    async def test_missing_fastmcp_context(self) -> None:
+        """Middleware handles missing fastmcp_context gracefully."""
+        context = _make_context(has_fastmcp_ctx=False)
+        mw = AuditIdentityMiddleware()
+
+        async def call_next(_ctx):
+            return "ok"
+
+        result = await mw(context, call_next)
+
+        assert result == "ok"
+        assert get_mcp_session_id() is None
+        assert get_mcp_request_id() is None
+
+    async def test_none_session_and_request_ids(self) -> None:
+        """When session_id and request_id are None, ContextVars stay None."""
+        context = _make_context(session_id=None, request_id=None)
+        mw = AuditIdentityMiddleware()
+
+        async def call_next(_ctx):
+            assert get_mcp_session_id() is None
+            assert get_mcp_request_id() is None
+            return "ok"
+
+        await mw(context, call_next)
+
+    async def test_no_request_context_for_user_id(self) -> None:
+        """When request_context is None, user_id stays None."""
+        context = _make_context(session_id="s1")
+        # request_context is None by default when user_id is not passed
+        mw = AuditIdentityMiddleware()
+
+        async def call_next(_ctx):
+            assert get_user_id() is None
+            return "ok"
+
+        await mw(context, call_next)
+
+    async def test_token_based_reset_restores_previous_value(self) -> None:
+        """Token reset restores previous ContextVar value, not just None."""
+        # Simulate an outer layer that set a value
+        _session_id_var.set("outer-session")
+
+        context = _make_context(session_id="inner-session")
+        mw = AuditIdentityMiddleware()
+
+        async def call_next(_ctx):
+            # During the call, the inner value should be active
+            assert get_mcp_session_id() == "inner-session"
+            return "ok"
+
+        await mw(context, call_next)
+
+        # After middleware completes, the *outer* value should be restored
+        assert get_mcp_session_id() == "outer-session"
+
+
+class TestGetterFunctions:
+    """Tests for the public getter functions."""
+
+    def test_defaults_are_none(self) -> None:
+        """All getters return None when no ContextVar is set."""
+        # Reset to defaults
+        _session_id_var.set(None)
+        _request_id_var.set(None)
+        _user_id_var.set(None)
+
+        assert get_mcp_session_id() is None
+        assert get_mcp_request_id() is None
+        assert get_user_id() is None
+
+    def test_getters_return_set_values(self) -> None:
+        """Getters return values when ContextVars are populated."""
+        _session_id_var.set("test-session")
+        _request_id_var.set("test-request")
+        _user_id_var.set("test-user")
+
+        try:
+            assert get_mcp_session_id() == "test-session"
+            assert get_mcp_request_id() == "test-request"
+            assert get_user_id() == "test-user"
+        finally:
+            _session_id_var.set(None)
+            _request_id_var.set(None)
+            _user_id_var.set(None)

--- a/tests/unit/core/test_telemetry.py
+++ b/tests/unit/core/test_telemetry.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import builtins
 from contextlib import contextmanager
 from types import SimpleNamespace
 
@@ -24,14 +23,6 @@ import pytest
 
 from kubeflow_mcp.core import telemetry
 from kubeflow_mcp.core.server import _audit_wrap
-
-
-class _MockMCPContext:
-    """Minimal mock that passes isinstance(ctx, Context) check."""
-
-    def __init__(self, session_id: str | None = None, request_id: object = None) -> None:
-        self.session_id = session_id
-        self.request_id = request_id
 
 
 class _FakeSpan:
@@ -116,11 +107,11 @@ def test_setup_tracing_configures_provider_when_available(monkeypatch: pytest.Mo
             return data
 
     class _FakeBatchProcessor:
-        def __init__(self, exporter: object) -> None:
+        def __init__(self, exporter: object, **kwargs) -> None:
             self.exporter = exporter
 
     class _FakeExporter:
-        def __init__(self, endpoint: str) -> None:
+        def __init__(self, endpoint: str, **kwargs) -> None:
             self.endpoint = endpoint
             calls["endpoint"] = endpoint
 
@@ -163,6 +154,52 @@ def test_setup_tracing_treats_whitespace_endpoint_as_disabled(
     assert telemetry.setup_tracing("   ") is False
 
 
+def test_setup_tracing_falls_back_to_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """setup_tracing() reads OTEL_EXPORTER_OTLP_ENDPOINT when endpoint is None."""
+    calls: dict[str, object] = {}
+
+    class _FakeBatchProcessor:
+        def __init__(self, exporter: object, **kwargs) -> None:
+            self.exporter = exporter
+
+    class _FakeExporter:
+        def __init__(self, endpoint: str, **kwargs) -> None:
+            calls["endpoint"] = endpoint
+
+    class _FakeProvider:
+        def __init__(self, resource: object) -> None:
+            pass
+
+        def add_span_processor(self, processor: object) -> None:
+            pass
+
+        def shutdown(self) -> None:
+            pass
+
+    class _FakeResource:
+        @staticmethod
+        def create(data: dict[str, str]) -> dict[str, str]:
+            return data
+
+    fake_trace = SimpleNamespace()
+    fake_trace.set_tracer_provider = lambda _p: None
+    fake_trace.get_tracer = lambda _name: "tracer"
+    fake_trace.get_tracer_provider = lambda: object()
+
+    monkeypatch.setattr(telemetry, "_OTEL_AVAILABLE", True)
+    monkeypatch.setattr(telemetry, "_tracing_initialized", False)
+    monkeypatch.setattr(telemetry, "_configured_endpoint", None, raising=False)
+    monkeypatch.setattr(telemetry, "Resource", _FakeResource, raising=False)
+    monkeypatch.setattr(telemetry, "TracerProvider", _FakeProvider, raising=False)
+    monkeypatch.setattr(telemetry, "BatchSpanProcessor", _FakeBatchProcessor, raising=False)
+    monkeypatch.setattr(telemetry, "OTLPSpanExporter", _FakeExporter, raising=False)
+    monkeypatch.setattr(telemetry, "_otel_trace", fake_trace, raising=False)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-collector:4318")
+
+    assert telemetry.setup_tracing(endpoint=None) is True
+    assert calls["endpoint"] == "http://env-collector:4318/v1/traces"
+
+
 def test_setup_tracing_rejects_invalid_endpoint() -> None:
     with pytest.raises(ValueError, match="Invalid OpenTelemetry endpoint"):
         telemetry.setup_tracing("localhost:4318/v1/traces")
@@ -180,11 +217,11 @@ def test_setup_tracing_reuses_existing_provider(monkeypatch: pytest.MonkeyPatch)
             calls["processor"] = processor
 
     class _FakeBatchProcessor:
-        def __init__(self, exporter: object) -> None:
+        def __init__(self, exporter: object, **kwargs) -> None:
             self.exporter = exporter
 
     class _FakeExporter:
-        def __init__(self, endpoint: str) -> None:
+        def __init__(self, endpoint: str, **kwargs) -> None:
             calls["endpoint"] = endpoint
 
     provider = _ExistingProvider()
@@ -249,9 +286,8 @@ def test_audit_wrap_sets_span_attributes_on_success(monkeypatch: pytest.MonkeyPa
 
 
 def test_audit_wrap_sets_mcp_context_attributes(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When a FastMCP Context is passed, mcp.session.id and mcp.request.id are set."""
-    from fastmcp import Context
-
+    """ContextVars populated by middleware are reflected as span attributes."""
+    import kubeflow_mcp.core.middleware as mw_mod
     import kubeflow_mcp.core.server as server_mod
 
     span = _FakeSpan()
@@ -263,25 +299,26 @@ def test_audit_wrap_sets_mcp_context_attributes(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(server_mod, "get_tracer", lambda _name: tracer)
     monkeypatch.setattr(server_mod, "get_breaker", lambda _tool: breaker)
 
-    # Patch isinstance to accept our mock as Context
-    mock_ctx = _MockMCPContext(session_id="sess-abc", request_id=42)
-    original_isinstance = builtins.isinstance
-
-    def _patched_isinstance(obj, cls):
-        if cls is Context and type(obj) is _MockMCPContext:
-            return True
-        return original_isinstance(obj, cls)
-
-    monkeypatch.setattr(builtins, "isinstance", _patched_isinstance)
+    # Simulate what AuditIdentityMiddleware does: set ContextVars
+    mw_mod._session_id_var.set("sess-abc")
+    mw_mod._request_id_var.set("42")
+    mw_mod._user_id_var.set("alice@example.com")
 
     def sample_tool(**_kwargs):
         return {"ok": True}
 
-    wrapped = _audit_wrap(sample_tool)
-    wrapped(ctx=mock_ctx)
+    try:
+        wrapped = _audit_wrap(sample_tool)
+        wrapped()
 
-    assert span.attributes["mcp.session.id"] == "sess-abc"
-    assert span.attributes["mcp.request.id"] == "42"
+        assert span.attributes["mcp.session.id"] == "sess-abc"
+        assert span.attributes["mcp.request.id"] == "42"
+        assert span.attributes["user.id"] == "alice@example.com"
+    finally:
+        # Clean up ContextVars
+        mw_mod._session_id_var.set(None)
+        mw_mod._request_id_var.set(None)
+        mw_mod._user_id_var.set(None)
 
 
 def test_audit_wrap_records_exception_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/core/test_telemetry.py
+++ b/tests/unit/core/test_telemetry.py
@@ -40,9 +40,11 @@ class _FakeSpan:
 class _FakeTracer:
     def __init__(self, span: _FakeSpan) -> None:
         self._span = span
+        self.last_span_name: str | None = None
 
     @contextmanager
-    def start_as_current_span(self, _name: str):
+    def start_as_current_span(self, name: str):
+        self.last_span_name = name
         yield self._span
 
 
@@ -188,11 +190,12 @@ def test_audit_wrap_sets_span_attributes_on_success(monkeypatch: pytest.MonkeyPa
     import kubeflow_mcp.core.server as server_mod
 
     span = _FakeSpan()
+    tracer = _FakeTracer(span)
     breaker = _FakeBreaker()
     monkeypatch.setattr(server_mod, "_rate_limiter", None)
     monkeypatch.setattr(server_mod, "with_correlation_id", lambda: "cid-123")
     monkeypatch.setattr(server_mod, "get_effective_persona", lambda: "ml-engineer")
-    monkeypatch.setattr(server_mod, "get_tracer", lambda _name: _FakeTracer(span))
+    monkeypatch.setattr(server_mod, "get_tracer", lambda _name: tracer)
     monkeypatch.setattr(server_mod, "get_breaker", lambda _tool: breaker)
 
     def sample_tool(**_kwargs):
@@ -202,6 +205,7 @@ def test_audit_wrap_sets_span_attributes_on_success(monkeypatch: pytest.MonkeyPa
     wrapped()
 
     assert span.attributes["tool.name"] == "sample_tool"
+    assert tracer.last_span_name == "tool:sample_tool"
     assert span.attributes["correlation_id"] == "cid-123"
     assert span.attributes["kubeflow.persona"] == "ml-engineer"
     assert span.attributes["tool.success"] is True

--- a/tests/unit/core/test_telemetry.py
+++ b/tests/unit/core/test_telemetry.py
@@ -98,6 +98,9 @@ def test_setup_tracing_configures_provider_when_available(monkeypatch: pytest.Mo
             self._processors.append(processor)
             calls["processor"] = processor
 
+        def shutdown(self) -> None:
+            pass
+
     class _FakeResource:
         @staticmethod
         def create(data: dict[str, str]) -> dict[str, str]:
@@ -218,6 +221,7 @@ def test_audit_wrap_sets_span_attributes_on_success(monkeypatch: pytest.MonkeyPa
     assert span.attributes["kubeflow.persona"] == "ml-engineer"
     assert span.attributes["tool.success"] is True
     assert "tool.duration_ms" in span.attributes
+    assert span.attributes["tool.args_preview"] == "{}"
     assert breaker.successes == 1
     # Verify SpanKind.CLIENT is passed when OTel is available
     from kubeflow_mcp.core.server import SpanKind as _SpanKind
@@ -256,3 +260,28 @@ def test_audit_wrap_records_exception_on_failure(monkeypatch: pytest.MonkeyPatch
         status = span.status_code
         assert status.status_code == _StatusCode.ERROR
         assert status.description == "boom"
+
+
+def test_audit_wrap_circuit_breaker_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Circuit-open path sets tool.success=False on the span before the early return."""
+    import kubeflow_mcp.core.server as server_mod
+
+    span = _FakeSpan()
+    tracer = _FakeTracer(span)
+    breaker = _FakeBreaker(can_execute=False)
+    monkeypatch.setattr(server_mod, "_rate_limiter", None)
+    monkeypatch.setattr(server_mod, "with_correlation_id", lambda: "cid-456")
+    monkeypatch.setattr(server_mod, "get_effective_persona", lambda: "readonly")
+    monkeypatch.setattr(server_mod, "get_tracer", lambda _name: tracer)
+    monkeypatch.setattr(server_mod, "get_breaker", lambda _tool: breaker)
+
+    def sample_tool(**_kwargs):
+        return {"ok": True}
+
+    wrapped = _audit_wrap(sample_tool)
+    result = wrapped()
+
+    assert span.attributes["tool.success"] is False
+    assert "tool.duration_ms" in span.attributes
+    assert "error" in result
+    assert result["error_code"] == "CIRCUIT_OPEN"

--- a/tests/unit/core/test_telemetry.py
+++ b/tests/unit/core/test_telemetry.py
@@ -29,6 +29,8 @@ class _FakeSpan:
     def __init__(self) -> None:
         self.attributes: dict[str, object] = {}
         self.exceptions: list[BaseException] = []
+        self.status_code: object | None = None
+        self.status_description: str | None = None
 
     def set_attribute(self, key: str, value: object) -> None:
         self.attributes[key] = value
@@ -36,15 +38,21 @@ class _FakeSpan:
     def record_exception(self, exception: BaseException) -> None:
         self.exceptions.append(exception)
 
+    def set_status(self, code: object, description: str | None = None) -> None:
+        self.status_code = code
+        self.status_description = description
+
 
 class _FakeTracer:
     def __init__(self, span: _FakeSpan) -> None:
         self._span = span
         self.last_span_name: str | None = None
+        self.last_span_kwargs: dict[str, object] = {}
 
     @contextmanager
-    def start_as_current_span(self, name: str):
+    def start_as_current_span(self, name: str, **kwargs):
         self.last_span_name = name
+        self.last_span_kwargs = kwargs
         yield self._span
 
 
@@ -211,6 +219,11 @@ def test_audit_wrap_sets_span_attributes_on_success(monkeypatch: pytest.MonkeyPa
     assert span.attributes["tool.success"] is True
     assert "tool.duration_ms" in span.attributes
     assert breaker.successes == 1
+    # Verify SpanKind.CLIENT is passed when OTel is available
+    from kubeflow_mcp.core.server import SpanKind as _SpanKind
+
+    if _SpanKind is not None:
+        assert tracer.last_span_kwargs.get("kind") == _SpanKind.CLIENT
 
 
 def test_audit_wrap_records_exception_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -233,6 +246,13 @@ def test_audit_wrap_records_exception_on_failure(monkeypatch: pytest.MonkeyPatch
 
     assert span.attributes["tool.success"] is False
     assert "tool.duration_ms" in span.attributes
-    assert len(span.exceptions) == 1
-    assert isinstance(span.exceptions[0], RuntimeError)
     assert breaker.failures == 1
+    # record_exception is no longer called manually; start_as_current_span
+    # auto-records it.  Instead, set_status(ERROR) must be called.
+    assert len(span.exceptions) == 0
+    from kubeflow_mcp.core.server import _StatusCode
+
+    if _StatusCode is not None:
+        status = span.status_code
+        assert status.status_code == _StatusCode.ERROR
+        assert status.description == "boom"

--- a/tests/unit/core/test_telemetry.py
+++ b/tests/unit/core/test_telemetry.py
@@ -1,0 +1,234 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenTelemetry tracing tests."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from kubeflow_mcp.core import telemetry
+from kubeflow_mcp.core.server import _audit_wrap
+
+
+class _FakeSpan:
+    def __init__(self) -> None:
+        self.attributes: dict[str, object] = {}
+        self.exceptions: list[BaseException] = []
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+    def record_exception(self, exception: BaseException) -> None:
+        self.exceptions.append(exception)
+
+
+class _FakeTracer:
+    def __init__(self, span: _FakeSpan) -> None:
+        self._span = span
+
+    @contextmanager
+    def start_as_current_span(self, _name: str):
+        yield self._span
+
+
+class _FakeBreaker:
+    def __init__(self, can_execute: bool = True) -> None:
+        self._can_execute = can_execute
+        self.successes = 0
+        self.failures = 0
+
+    def can_execute(self) -> bool:
+        return self._can_execute
+
+    def record_success(self) -> None:
+        self.successes += 1
+
+    def record_failure(self) -> None:
+        self.failures += 1
+
+
+def test_get_tracer_returns_noop_when_otel_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(telemetry, "_OTEL_AVAILABLE", False)
+    tracer = telemetry.get_tracer("test")
+    with tracer.start_as_current_span("span") as span:
+        span.set_attribute("k", "v")
+        span.record_exception(ValueError("boom"))
+
+
+def test_setup_tracing_noop_when_otel_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(telemetry, "_OTEL_AVAILABLE", False)
+    monkeypatch.setattr(telemetry, "_tracing_initialized", False)
+    assert telemetry.setup_tracing("http://collector:4318/v1/traces") is False
+
+
+def test_setup_tracing_configures_provider_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict[str, object] = {}
+
+    class _FakeProvider:
+        def __init__(self, resource: object) -> None:
+            calls["resource"] = resource
+            self._processors: list[object] = []
+
+        def add_span_processor(self, processor: object) -> None:
+            self._processors.append(processor)
+            calls["processor"] = processor
+
+    class _FakeResource:
+        @staticmethod
+        def create(data: dict[str, str]) -> dict[str, str]:
+            return data
+
+    class _FakeBatchProcessor:
+        def __init__(self, exporter: object) -> None:
+            self.exporter = exporter
+
+    class _FakeExporter:
+        def __init__(self, endpoint: str) -> None:
+            self.endpoint = endpoint
+            calls["endpoint"] = endpoint
+
+    fake_trace = SimpleNamespace()
+
+    def _set_tracer_provider(provider: object) -> None:
+        calls["provider"] = provider
+
+    def _get_tracer(name: str) -> str:
+        return f"tracer:{name}"
+
+    def _get_tracer_provider() -> object:
+        return object()
+
+    fake_trace.set_tracer_provider = _set_tracer_provider
+    fake_trace.get_tracer = _get_tracer
+    fake_trace.get_tracer_provider = _get_tracer_provider
+
+    monkeypatch.setattr(telemetry, "_OTEL_AVAILABLE", True)
+    monkeypatch.setattr(telemetry, "_tracing_initialized", False)
+    monkeypatch.setattr(telemetry, "_configured_endpoint", None, raising=False)
+    monkeypatch.setattr(telemetry, "Resource", _FakeResource, raising=False)
+    monkeypatch.setattr(telemetry, "TracerProvider", _FakeProvider, raising=False)
+    monkeypatch.setattr(telemetry, "BatchSpanProcessor", _FakeBatchProcessor, raising=False)
+    monkeypatch.setattr(telemetry, "OTLPSpanExporter", _FakeExporter, raising=False)
+    monkeypatch.setattr(telemetry, "_otel_trace", fake_trace, raising=False)
+
+    assert telemetry.setup_tracing("http://collector:4318/v1/traces", "kubeflow-mcp") is True
+    assert calls["endpoint"] == "http://collector:4318/v1/traces"
+    assert calls["resource"] == {"service.name": "kubeflow-mcp"}
+    assert telemetry.get_tracer("unit") == "tracer:unit"
+
+
+def test_setup_tracing_treats_whitespace_endpoint_as_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(telemetry, "_OTEL_AVAILABLE", True)
+    monkeypatch.setattr(telemetry, "_tracing_initialized", False)
+    monkeypatch.setattr(telemetry, "_configured_endpoint", None, raising=False)
+    assert telemetry.setup_tracing("   ") is False
+
+
+def test_setup_tracing_rejects_invalid_endpoint() -> None:
+    with pytest.raises(ValueError, match="Invalid OpenTelemetry endpoint"):
+        telemetry.setup_tracing("localhost:4318/v1/traces")
+
+
+def test_setup_tracing_reuses_existing_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict[str, object] = {}
+
+    class _ExistingProvider:
+        def __init__(self) -> None:
+            self.processors: list[object] = []
+
+        def add_span_processor(self, processor: object) -> None:
+            self.processors.append(processor)
+            calls["processor"] = processor
+
+    class _FakeBatchProcessor:
+        def __init__(self, exporter: object) -> None:
+            self.exporter = exporter
+
+    class _FakeExporter:
+        def __init__(self, endpoint: str) -> None:
+            calls["endpoint"] = endpoint
+
+    provider = _ExistingProvider()
+    fake_trace = SimpleNamespace()
+    fake_trace.get_tracer_provider = lambda: provider
+    fake_trace.get_tracer = lambda _name: "tracer"
+    fake_trace.set_tracer_provider = lambda _provider: calls.update({"set_called": True})
+
+    monkeypatch.setattr(telemetry, "_OTEL_AVAILABLE", True)
+    monkeypatch.setattr(telemetry, "_tracing_initialized", False)
+    monkeypatch.setattr(telemetry, "_configured_endpoint", None, raising=False)
+    monkeypatch.setattr(telemetry, "BatchSpanProcessor", _FakeBatchProcessor, raising=False)
+    monkeypatch.setattr(telemetry, "OTLPSpanExporter", _FakeExporter, raising=False)
+    monkeypatch.setattr(telemetry, "_otel_trace", fake_trace, raising=False)
+
+    assert telemetry.setup_tracing("http://collector:4318/v1/traces", "kubeflow-mcp") is True
+    assert calls["endpoint"] == "http://collector:4318/v1/traces"
+    assert "processor" in calls
+    assert "set_called" not in calls
+
+
+def test_audit_wrap_sets_span_attributes_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    import kubeflow_mcp.core.server as server_mod
+
+    span = _FakeSpan()
+    breaker = _FakeBreaker()
+    monkeypatch.setattr(server_mod, "_rate_limiter", None)
+    monkeypatch.setattr(server_mod, "with_correlation_id", lambda: "cid-123")
+    monkeypatch.setattr(server_mod, "get_effective_persona", lambda: "ml-engineer")
+    monkeypatch.setattr(server_mod, "get_tracer", lambda _name: _FakeTracer(span))
+    monkeypatch.setattr(server_mod, "get_breaker", lambda _tool: breaker)
+
+    def sample_tool(**_kwargs):
+        return {"ok": True}
+
+    wrapped = _audit_wrap(sample_tool)
+    wrapped()
+
+    assert span.attributes["tool.name"] == "sample_tool"
+    assert span.attributes["correlation_id"] == "cid-123"
+    assert span.attributes["kubeflow.persona"] == "ml-engineer"
+    assert span.attributes["tool.success"] is True
+    assert "tool.duration_ms" in span.attributes
+    assert breaker.successes == 1
+
+
+def test_audit_wrap_records_exception_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    import kubeflow_mcp.core.server as server_mod
+
+    span = _FakeSpan()
+    breaker = _FakeBreaker()
+    monkeypatch.setattr(server_mod, "_rate_limiter", None)
+    monkeypatch.setattr(server_mod, "with_correlation_id", lambda: "cid-123")
+    monkeypatch.setattr(server_mod, "get_effective_persona", lambda: "readonly")
+    monkeypatch.setattr(server_mod, "get_tracer", lambda _name: _FakeTracer(span))
+    monkeypatch.setattr(server_mod, "get_breaker", lambda _tool: breaker)
+
+    def failing_tool(**_kwargs):
+        raise RuntimeError("boom")
+
+    wrapped = _audit_wrap(failing_tool)
+    with pytest.raises(RuntimeError, match="boom"):
+        wrapped()
+
+    assert span.attributes["tool.success"] is False
+    assert "tool.duration_ms" in span.attributes
+    assert len(span.exceptions) == 1
+    assert isinstance(span.exceptions[0], RuntimeError)
+    assert breaker.failures == 1

--- a/tests/unit/core/test_telemetry.py
+++ b/tests/unit/core/test_telemetry.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import builtins
 from contextlib import contextmanager
 from types import SimpleNamespace
 
@@ -23,6 +24,14 @@ import pytest
 
 from kubeflow_mcp.core import telemetry
 from kubeflow_mcp.core.server import _audit_wrap
+
+
+class _MockMCPContext:
+    """Minimal mock that passes isinstance(ctx, Context) check."""
+
+    def __init__(self, session_id: str | None = None, request_id: object = None) -> None:
+        self.session_id = session_id
+        self.request_id = request_id
 
 
 class _FakeSpan:
@@ -215,19 +224,64 @@ def test_audit_wrap_sets_span_attributes_on_success(monkeypatch: pytest.MonkeyPa
     wrapped = _audit_wrap(sample_tool)
     wrapped()
 
-    assert span.attributes["tool.name"] == "sample_tool"
-    assert tracer.last_span_name == "tool:sample_tool"
+    # OTel MCP semantic conventions
+    assert span.attributes["gen_ai.tool.name"] == "sample_tool"
+    assert span.attributes["mcp.method.name"] == "tools/call"
+    assert span.attributes["gen_ai.operation.name"] == "execute_tool"
+    assert tracer.last_span_name == "tools/call sample_tool"
+    # mcp.protocol.version from SDK
+    from kubeflow_mcp.core.server import _MCP_PROTOCOL_VERSION
+
+    if _MCP_PROTOCOL_VERSION:
+        assert span.attributes["mcp.protocol.version"] == _MCP_PROTOCOL_VERSION
+    # Custom Kubeflow enrichment
     assert span.attributes["correlation_id"] == "cid-123"
     assert span.attributes["kubeflow.persona"] == "ml-engineer"
     assert span.attributes["tool.success"] is True
     assert "tool.duration_ms" in span.attributes
     assert span.attributes["tool.args_preview"] == "{}"
     assert breaker.successes == 1
-    # Verify SpanKind.CLIENT is passed when OTel is available
+    # Verify SpanKind.SERVER is passed when OTel is available
     from kubeflow_mcp.core.server import SpanKind as _SpanKind
 
     if _SpanKind is not None:
-        assert tracer.last_span_kwargs.get("kind") == _SpanKind.CLIENT
+        assert tracer.last_span_kwargs.get("kind") == _SpanKind.SERVER
+
+
+def test_audit_wrap_sets_mcp_context_attributes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When a FastMCP Context is passed, mcp.session.id and mcp.request.id are set."""
+    from fastmcp import Context
+
+    import kubeflow_mcp.core.server as server_mod
+
+    span = _FakeSpan()
+    tracer = _FakeTracer(span)
+    breaker = _FakeBreaker()
+    monkeypatch.setattr(server_mod, "_rate_limiter", None)
+    monkeypatch.setattr(server_mod, "with_correlation_id", lambda: "cid-ctx")
+    monkeypatch.setattr(server_mod, "get_effective_persona", lambda: "readonly")
+    monkeypatch.setattr(server_mod, "get_tracer", lambda _name: tracer)
+    monkeypatch.setattr(server_mod, "get_breaker", lambda _tool: breaker)
+
+    # Patch isinstance to accept our mock as Context
+    mock_ctx = _MockMCPContext(session_id="sess-abc", request_id=42)
+    original_isinstance = builtins.isinstance
+
+    def _patched_isinstance(obj, cls):
+        if cls is Context and type(obj) is _MockMCPContext:
+            return True
+        return original_isinstance(obj, cls)
+
+    monkeypatch.setattr(builtins, "isinstance", _patched_isinstance)
+
+    def sample_tool(**_kwargs):
+        return {"ok": True}
+
+    wrapped = _audit_wrap(sample_tool)
+    wrapped(ctx=mock_ctx)
+
+    assert span.attributes["mcp.session.id"] == "sess-abc"
+    assert span.attributes["mcp.request.id"] == "42"
 
 
 def test_audit_wrap_records_exception_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -250,6 +304,7 @@ def test_audit_wrap_records_exception_on_failure(monkeypatch: pytest.MonkeyPatch
 
     assert span.attributes["tool.success"] is False
     assert "tool.duration_ms" in span.attributes
+    assert span.attributes["error.type"] == "RuntimeError"
     assert breaker.failures == 1
     # record_exception is no longer called manually; start_as_current_span
     # auto-records it.  Instead, set_status(ERROR) must be called.

--- a/uv.lock
+++ b/uv.lock
@@ -4,10 +4,12 @@ requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version < '3.11' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform != 'win32'",
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
@@ -21,6 +23,18 @@ constraints = [
 ]
 
 [[package]]
+name = "accessible-pygments"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz", hash = "sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872", size = 1377899, upload-time = "2024-05-10T11:23:10.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl", hash = "sha256:88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7", size = 1395903, upload-time = "2024-05-10T11:23:08.421Z" },
+]
+
+[[package]]
 name = "aiofile"
 version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -29,7 +43,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "caio" },
+    { name = "caio", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -43,13 +57,15 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "caio" },
+    { name = "caio", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
@@ -228,6 +244,15 @@ wheels = [
 ]
 
 [[package]]
+name = "alabaster"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -282,6 +307,15 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -306,6 +340,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
 ]
 
 [[package]]
@@ -821,6 +868,38 @@ wheels = [
 ]
 
 [[package]]
+name = "docutils"
+version = "0.21.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1057,6 +1136,24 @@ wheels = [
 ]
 
 [[package]]
+name = "furo"
+version = "2025.12.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accessible-pygments" },
+    { name = "beautifulsoup4" },
+    { name = "pygments" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-basic-ng" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1260,11 +1357,20 @@ wheels = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
+]
+
+[[package]]
 name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1323,6 +1429,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -1475,6 +1593,19 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+docs = [
+    { name = "furo" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-copybutton" },
+    { name = "sphinx-design", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx-design", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+otel = [
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-sdk" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1498,6 +1629,16 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-cov", specifier = ">=4.0" },
     { name = "ruff", specifier = ">=0.9" },
+]
+docs = [
+    { name = "furo", specifier = ">=2024.1.29" },
+    { name = "sphinx", specifier = ">=7.0" },
+    { name = "sphinx-copybutton", specifier = ">=0.5" },
+    { name = "sphinx-design", specifier = ">=0.5" },
+]
+otel = [
+    { name = "opentelemetry-exporter-otlp", specifier = ">=1.29.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.29.0" },
 ]
 
 [[package]]
@@ -1566,6 +1707,91 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -2004,8 +2230,10 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
 wheels = [
@@ -2088,6 +2316,106 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/47/b77366bcbe719373a8cac2b4e8ad01f8ff3c9f2c223374d77ece280aae6f/opentelemetry_exporter_otlp-1.43.0.tar.gz", hash = "sha256:65aded6c50ee7dd2b9948c9d0e59ddb4ed4eea6e8532fba95cbe6a4a64a566ba", size = 6086, upload-time = "2026-06-24T15:19:58.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/26/d28cc854d2eb779f91351216c51ed0d54886f89f2dd56db9d493ba9fd429/opentelemetry_exporter_otlp-1.43.0-py3-none-any.whl", hash = "sha256:70f3fe740a64596d4157588a2ee7e4fd37d2acc0c0f522a2882b8c29316cd0f0", size = 6726, upload-time = "2026-06-24T15:19:38.437Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/1d/6336453716ca0a240d4417d19e6d5b77a5e7163e5670ec4f7ec4d3ede7bf/opentelemetry_exporter_otlp_proto_grpc-1.43.0.tar.gz", hash = "sha256:1b3e0627daa9bc21884d4a13946807c255eb558bfe5bdd543dffb6f4c9faee0d", size = 27213, upload-time = "2026-06-24T15:20:00.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/74/2700b5d5c946bf2dba87073fce3dfc198c46bc92ea3d5693f54bc51c90b1/opentelemetry_exporter_otlp_proto_grpc-1.43.0-py3-none-any.whl", hash = "sha256:6a10d1feacffffda19acacbf277b736094b1e2f4dbb98c90ccb2c6e1962e2ec6", size = 19626, upload-time = "2026-06-24T15:19:42.233Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/92/0b9f56412483a8891d4843890294796c9df8ab42417bd9bad8035d840cb3/opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f", size = 25406, upload-time = "2026-06-24T15:20:01.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/20/b685ed7af2e17c29ffc8af56f1fa8bc2033258fc30fb0d2b722f49d13ba0/opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610", size = 21795, upload-time = "2026-06-24T15:19:43.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+]
+
+[[package]]
 name = "packageurl-python"
 version = "0.17.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2114,10 +2442,10 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -2177,16 +2505,18 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -3051,6 +3381,15 @@ wheels = [
 ]
 
 [[package]]
+name = "roman-numerals"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3183,9 +3522,11 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
@@ -3337,8 +3678,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -3355,12 +3696,251 @@ wheels = [
 ]
 
 [[package]]
+name = "snowballstemmer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/f8/0a71edf031f03c40db17503cb8ca78a69a171254e568e7db241b0ab57ea1/snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260", size = 123314, upload-time = "2026-06-03T00:56:40.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752", size = 104164, upload-time = "2026-06-03T00:56:38.614Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "8.1.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/60/1ddff83a56d33aaf6f10ec8ce84b4c007d9368b21008876fceda7e7381ef/sphinx-8.1.3-py3-none-any.whl", hash = "sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2", size = 3487125, upload-time = "2024-10-13T20:27:10.448Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.0.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
+    { name = "babel", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
+    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
+    { name = "packaging", marker = "python_full_version == '3.11.*'" },
+    { name = "pygments", marker = "python_full_version == '3.11.*'" },
+    { name = "requests", marker = "python_full_version == '3.11.*'" },
+    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
+    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/3f/4bbd76424c393caead2e1eb89777f575dee5c8653e2d4b6afd7a564f5974/sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb", size = 3917713, upload-time = "2025-12-04T07:45:24.944Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version >= '3.12'" },
+    { name = "babel", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "imagesize", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
+]
+
+[[package]]
+name = "sphinx-basic-ng"
+version = "1.0.0b2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
+]
+
+[[package]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
+]
+
+[[package]]
+name = "sphinx-design"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/43/65c0acbd8cc6f50195a3a1fc195c404988b15c67090e73c7a41a9f57d6bd/sphinx_design-0.6.1-py3-none-any.whl", hash = "sha256:b11f37db1a802a183d61b159d9a202314d4d2fe29c163437001324fe2f19549c", size = 2215338, upload-time = "2024-08-02T13:48:42.106Z" },
+]
+
+[[package]]
+name = "sphinx-design"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/cf/45dd359f6ca0c3762ce0490f681da242f0530c49c81050c035c016bfdd3a/sphinx_design-0.7.0-py3-none-any.whl", hash = "sha256:f82bf179951d58f55dca78ab3706aeafa496b741a91b1911d371441127d64282", size = 2220350, upload-time = "2026-01-19T13:12:51.077Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1603,7 +1603,7 @@ docs = [
     { name = "sphinx-design", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 otel = [
-    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
 ]
 
@@ -1637,7 +1637,7 @@ docs = [
     { name = "sphinx-design", specifier = ">=0.5" },
 ]
 otel = [
-    { name = "opentelemetry-exporter-otlp", specifier = ">=1.29.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.29.0" },
 ]
 
@@ -2316,19 +2316,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-exporter-otlp"
-version = "1.43.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/47/b77366bcbe719373a8cac2b4e8ad01f8ff3c9f2c223374d77ece280aae6f/opentelemetry_exporter_otlp-1.43.0.tar.gz", hash = "sha256:65aded6c50ee7dd2b9948c9d0e59ddb4ed4eea6e8532fba95cbe6a4a64a566ba", size = 6086, upload-time = "2026-06-24T15:19:58.003Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/26/d28cc854d2eb779f91351216c51ed0d54886f89f2dd56db9d493ba9fd429/opentelemetry_exporter_otlp-1.43.0-py3-none-any.whl", hash = "sha256:70f3fe740a64596d4157588a2ee7e4fd37d2acc0c0f522a2882b8c29316cd0f0", size = 6726, upload-time = "2026-06-24T15:19:38.437Z" },
-]
-
-[[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2338,24 +2325,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.43.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "grpcio" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/1d/6336453716ca0a240d4417d19e6d5b77a5e7163e5670ec4f7ec4d3ede7bf/opentelemetry_exporter_otlp_proto_grpc-1.43.0.tar.gz", hash = "sha256:1b3e0627daa9bc21884d4a13946807c255eb558bfe5bdd543dffb6f4c9faee0d", size = 27213, upload-time = "2026-06-24T15:20:00.907Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/74/2700b5d5c946bf2dba87073fce3dfc198c46bc92ea3d5693f54bc51c90b1/opentelemetry_exporter_otlp_proto_grpc-1.43.0-py3-none-any.whl", hash = "sha256:6a10d1feacffffda19acacbf277b736094b1e2f4dbb98c90ccb2c6e1962e2ec6", size = 19626, upload-time = "2026-06-24T15:19:42.233Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -17,9 +17,14 @@ resolution-markers = [
 [manifest]
 constraints = [
     { name = "aiohttp", specifier = ">=3.14.0" },
+    { name = "cryptography", specifier = ">=48.0.1" },
     { name = "idna", specifier = ">=3.15" },
+    { name = "msgpack", specifier = ">=1.2.1" },
+    { name = "pip", specifier = ">=26.1.2" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },
-    { name = "starlette", specifier = ">=1.0.1" },
+    { name = "python-multipart", specifier = ">=0.0.31" },
+    { name = "starlette", specifier = ">=1.3.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
 
 Adds optional OpenTelemetry tracing for tool calls in Kubeflow MCP Server.
 
 - Adds `core/telemetry.py` with `setup_tracing()` and `get_tracer()` plus safe no-op fallback when OTel deps are unavailable.
 - Instruments `core.server._audit_wrap` to create one span per tool invocation, set tool/persona/duration/success attributes, attach `correlation_id`, and record
 exceptions.
 - Wires tracing config through CLI/env/config:
   - `--otel-endpoint`
   - `KUBEFLOW_MCP_OTEL_ENDPOINT`
   - `observability.otel_endpoint`
 - Adds unit tests for no-op path, provider setup/reuse, endpoint validation, and span behavior.
 - Updates README with an Observability section.
 
 Important compatibility note: `correlation_id` semantics are preserved and exposed as a span attribute; it is not remapped to OTel trace ID.
 
 ## Type of Change
 
 - [x] feat: New feature
 
 ## Checklist
 
 - [x] Tests pass locally (`make test-python`)
 - [x] Linting passes (`make verify`)
 - [x] Documentation updated (if applicable)
 - [x] Commit messages follow conventional format
 
 ## Related Issues
 
 Fixes #18