### PR TITLE
fix: detect user-defined train() to prevent silent training skips

### DIFF
--- a/kubeflow_mcp/trainer/api/training.py
+++ b/kubeflow_mcp/trainer/api/training.py
@@ -102,8 +102,57 @@ def _make_train_func(script: str, func_args: dict[str, Any] | None = None) -> Ca
 
     When *func_args* is provided, the generated function signature includes matching
     keyword parameters so the trainer can pass them at runtime.
+
+    If the script already defines a top-level ``def train()``, that function is
+    used directly — avoiding silent training skips from double-wrapping.
     """
+    import ast
+
     func_name = "train"
+
+    # Check if the script already defines a top-level train() function.
+    try:
+        tree = ast.parse(script)
+    except SyntaxError:
+        tree = None
+
+    user_train = None
+    if tree is not None:
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == func_name:
+                user_train = node
+                break
+
+    if user_train is not None:
+        # The user already defined train() — use it directly instead of wrapping.
+        if func_args:
+            user_params = {arg.arg for arg in user_train.args.args}
+            required = set(func_args.keys())
+            missing = required - user_params
+            if missing:
+                raise ValueError(
+                    f"func_args requires parameters {sorted(missing)} but "
+                    f"the script's train() function does not include them. "
+                    f"Add these parameters to your train() signature: "
+                    f"{sorted(missing)}"
+                )
+
+        script_dir = _get_script_dir()
+        script_path = os.path.join(script_dir, f"_mcp_train_{uuid.uuid4().hex[:8]}.py")
+        with open(script_path, "w") as f:
+            f.write(script)
+
+        code = compile(script, script_path, "exec")
+        ns: dict[str, Any] = {}
+        exec(code, ns)  # noqa: S102
+        if func_name not in ns:
+            raise ValueError(
+                f"The script defines 'def {func_name}()' but it was not found "
+                f"after execution. Ensure the function is defined at module level."
+            )
+        return ns[func_name]
+
+    # No user-defined train() — wrap the script body.
     lines = script.strip().splitlines()
 
     if func_args:

--- a/tests/unit/trainer/test_make_train_func.py
+++ b/tests/unit/trainer/test_make_train_func.py
@@ -1,0 +1,143 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for _make_train_func: user-defined train() detection and wrapping."""
+
+import pytest
+
+from kubeflow_mcp.trainer.api.training import _make_train_func
+
+
+class TestMakeTrainFuncWithUserDefinedTrain:
+    """When the user already defines ``def train()`` at module level,
+    _make_train_func must use that function directly instead of wrapping
+    it inside another ``def train(): ...`` (which would silently skip
+    execution).
+    """
+
+    def test_user_train_is_called(self):
+        """A user-defined train() at module level is returned and callable."""
+        script = """
+def train():
+    return "user code ran"
+"""
+        func = _make_train_func(script)
+        assert func() == "user code ran"
+
+    def test_user_train_with_print_output(self):
+        """The function executes and produces expected side effects."""
+        script = """
+results = []
+def train():
+    for i in range(3):
+        results.append(i)
+    return results
+"""
+        func = _make_train_func(script)
+        assert func() == [0, 1, 2]
+
+    def test_user_train_imports_at_module_level(self):
+        """Module-level imports work inside a user-defined train script."""
+        script = """
+import math as maths
+def train():
+    return maths.pi
+"""
+        func = _make_train_func(script)
+        assert func() == pytest.approx(3.14159, rel=1e-4)
+
+    def test_user_train_with_non_train_code(self):
+        """Module-level code outside train() also executes on import."""
+        script = """
+flag = "set"
+def train():
+    return flag
+"""
+        func = _make_train_func(script)
+        assert func() == "set"
+
+    def test_nested_train_not_detected(self):
+        """A ``def train(self):`` inside a class is not a top-level function
+        and must still be wrapped."""
+        script = """
+class MyClass:
+    def train(self):
+        return 42
+"""
+        func = _make_train_func(script)
+        # The user's train() is a method, not top-level.  Wrapping should
+        # produce a callable train() that instantiates the class.
+        func()
+        # If we got here without error, the wrapper worked fine.
+        # The wrapped function just defines the class but doesn't call the method,
+        # so we don't assert a specific return value.
+
+    def test_user_train_with_func_args_match(self):
+        """When func_args matches the user's train() signature, the function
+        is returned directly and can be called with those kwargs."""
+        script = """
+def train(model_dir, batch_size=32):
+    return f"model={model_dir} batch={batch_size}"
+"""
+        func = _make_train_func(script, func_args={"model_dir": None, "batch_size": None})
+        result = func(model_dir="/models", batch_size=64)
+        assert result == "model=/models batch=64"
+
+    def test_user_train_with_func_args_default_values(self):
+        """func_args defaults (None) are passed through; the SDK calls
+        func(**func_args) with the actual values."""
+        script = """
+def train(data_dir):
+    return f"data={data_dir}"
+"""
+        func = _make_train_func(script, func_args={"data_dir": None})
+        # The SDK will replace None with the actual value at call time.
+        assert func(data_dir="/datasets/imagenet") == "data=/datasets/imagenet"
+
+    def test_user_train_missing_func_args_raises(self):
+        """If func_args specifies parameters not in the user's train()
+        signature, raise ValueError with a clear message."""
+        script = """
+def train(model_dir):
+    return "done"
+"""
+        with pytest.raises(ValueError, match="func_args requires parameters"):
+            _make_train_func(script, func_args={"unknown_param": None})
+
+        with pytest.raises(ValueError, match="unknown_param"):
+            _make_train_func(script, func_args={"unknown_param": None})
+
+    def test_user_train_syntax_error_raises(self):
+        """If the script has a syntax error, _make_train_func raises
+        SyntaxError (both direct and wrapping paths will fail to compile)."""
+        script = "def train(:  # broken syntax"
+        with pytest.raises(SyntaxError):
+            _make_train_func(script)
+
+    def test_original_behavior_preserved_for_script_without_def_train(self):
+        """Scripts without ``def train()`` still get wrapped as before."""
+        script = "x = 1 + 1"
+        func = _make_train_func(script)
+        func()  # Should not raise
+        # x=2 is set in the wrapper's namespace but not returned.
+        # Just verifying no exception.
+
+    def test_original_behavior_with_func_args(self):
+        """Scripts without def train + func_args still get the wrapper
+        with the requested parameter signature."""
+        script = "print(f'training with {data_dir}')"
+        func = _make_train_func(script, func_args={"data_dir": None})
+        # Should accept the keyword argument.
+        func(data_dir="/data")
+        # No exception = success


### PR DESCRIPTION
## Summary

Fixes #19 — `run_custom_training` silently skips training when the script defines a top-level `def train()` without calling it.

## Root Cause

`_make_train_func` unconditionally wraps the entire script inside `def train():`. When the user's script already defines `def train()` at the top level, the user's function gets nested inside the wrapper:

```python
def train():        # outer wrapper (called by SDK)
    def train():    # user's function (defined, never called)
        print("Training started")
train()             # appended by SDK
```

## Solution

Use `ast.parse` to detect whether the script already has a top-level `def train()`:
- If yes: write the script as-is (no wrapping), compile, and return the user's function directly
- If func_args provided: validate that the user's `train()` signature includes all required parameters, raising a clear `ValueError` on mismatch
- If no: use the existing wrapping behavior (backward compatible)

Edge cases handled:
- Nested `def train(self)` inside a class is not detected as top-level
- SyntaxError in script propagates correctly from `compile()`
- Module-level imports and non-train code in user scripts execute normally

## Testing

Added 11 unit tests covering:
- User-defined `train()` is detected and called directly
- Side effects and return values work correctly
- Module-level imports and helper code execute normally
- Nested `train()` methods not falsely detected
- `func_args` matching, defaults, and mismatched detection
- Syntax error propagation
- Existing wrapping behavior preserved for scripts without `def train()`

All 51 tests pass (40 existing + 11 new), zero regressions.