### PR TITLE
Fix custom training scripts that define train()

### DIFF
--- a/kubeflow_mcp/trainer/api/sdk_contracts_test.py
+++ b/kubeflow_mcp/trainer/api/sdk_contracts_test.py
@@ -10,6 +10,7 @@ Tests validate:
 - Ensure dataclass fields match our usage
 """
 
+import builtins
 import inspect
 from dataclasses import fields
 from typing import get_type_hints
@@ -563,6 +564,89 @@ def train_func():
         )
 
         assert callable(trainer.func)
+
+    def _run_wrapped_train(
+        self,
+        script: str,
+        func_args: dict | None = None,
+        **kwargs,
+    ):
+        from kubeflow_mcp.trainer.api.training import _make_train_func
+
+        builtins._kubeflow_mcp_train_marker = []
+        try:
+            train_func = _make_train_func(script, func_args=func_args)
+            train_func(**kwargs)
+            return builtins._kubeflow_mcp_train_marker
+        finally:
+            del builtins._kubeflow_mcp_train_marker
+
+    def test_make_train_func_calls_user_defined_train(self):
+        """A script-defined train() should run when the generated wrapper runs."""
+        marker = self._run_wrapped_train(
+            """
+import builtins
+
+def train():
+    builtins._kubeflow_mcp_train_marker.append("ran")
+"""
+        )
+
+        assert marker == ["ran"]
+
+    def test_make_train_func_does_not_double_call_user_defined_train(self):
+        """A script that already calls train() should not run twice."""
+        marker = self._run_wrapped_train(
+            """
+import builtins
+
+def train():
+    builtins._kubeflow_mcp_train_marker.append("ran")
+
+train()
+"""
+        )
+
+        assert marker == ["ran"]
+
+    @pytest.mark.parametrize(
+        "train_call",
+        [
+            "result = train()",
+            "if True:\n    train()",
+            "print(train())",
+        ],
+    )
+    def test_make_train_func_detects_existing_train_calls(self, train_call):
+        """Existing train() calls in module-level code should not be duplicated."""
+        marker = self._run_wrapped_train(
+            f"""
+import builtins
+
+def train():
+    builtins._kubeflow_mcp_train_marker.append("ran")
+
+{train_call}
+"""
+        )
+
+        assert marker == ["ran"]
+
+    def test_make_train_func_forwards_func_args_to_user_defined_train(self):
+        """Generated train() should forward matching func_args to a user-defined train()."""
+        marker = self._run_wrapped_train(
+            """
+import builtins
+
+def train(lr=None, epochs=None):
+    builtins._kubeflow_mcp_train_marker.append((lr, epochs))
+""",
+            func_args={"lr": 0.01, "epochs": 3},
+            lr=0.01,
+            epochs=3,
+        )
+
+        assert marker == [(0.01, 3)]
 
     def test_resources_dict_format(self):
         """Test resources_per_node dict format is valid for SDK."""

--- a/kubeflow_mcp/trainer/api/training.py
+++ b/kubeflow_mcp/trainer/api/training.py
@@ -14,6 +14,7 @@
 
 """Training submission tools: fine_tune, run_custom_training, run_container_training."""
 
+import ast
 import logging
 import os
 import tempfile
@@ -104,7 +105,8 @@ def _make_train_func(script: str, func_args: dict[str, Any] | None = None) -> Ca
     keyword parameters so the trainer can pass them at runtime.
     """
     func_name = "train"
-    lines = script.strip().splitlines()
+    stripped_script = script.strip()
+    lines = stripped_script.splitlines()
 
     if func_args:
         params = ", ".join(f"{k}=None" for k in func_args)
@@ -113,6 +115,9 @@ def _make_train_func(script: str, func_args: dict[str, Any] | None = None) -> Ca
         wrapped = f"def {func_name}():\n"
     for line in lines:
         wrapped += f"    {line}\n"
+    train_call = _uncalled_train_call(stripped_script, func_args)
+    if train_call:
+        wrapped += f"    {train_call}\n"
 
     script_dir = _get_script_dir()
     script_path = os.path.join(script_dir, f"_mcp_train_{uuid.uuid4().hex[:8]}.py")
@@ -123,6 +128,59 @@ def _make_train_func(script: str, func_args: dict[str, Any] | None = None) -> Ca
     ns: dict[str, Any] = {}
     exec(code, ns)  # noqa: S102
     return ns[func_name]
+
+
+def _uncalled_train_call(script: str, func_args: dict[str, Any] | None = None) -> str | None:
+    """Return the train call to append when a script defines but does not call train."""
+    try:
+        tree = ast.parse(script)
+    except SyntaxError:
+        return None
+
+    train_defs = (
+        node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "train"
+    )
+    train_def = next(train_defs, None)
+    if train_def is None or _has_train_call(tree.body):
+        return None
+
+    forwarded_args = _forwarded_train_args(train_def, func_args)
+    return f"train({forwarded_args})" if forwarded_args else "train()"
+
+
+def _has_train_call(nodes: list[ast.stmt]) -> bool:
+    """Return True when module-level code calls ``train`` directly or indirectly."""
+    for node in nodes:
+        # Only module-level execution can run before the generated wrapper returns.
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            continue
+        for child in ast.walk(node):
+            if (
+                isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Name)
+                and child.func.id == "train"
+            ):
+                return True
+    return False
+
+
+def _forwarded_train_args(
+    train_def: ast.FunctionDef,
+    func_args: dict[str, Any] | None,
+) -> str:
+    """Build keyword forwarding for user-defined train parameters."""
+    if not func_args:
+        return ""
+
+    if train_def.args.kwarg is not None:
+        forwarded = func_args
+    else:
+        accepted_names = {
+            arg.arg for arg in [*train_def.args.args, *train_def.args.kwonlyargs]
+        }
+        forwarded = {key: value for key, value in func_args.items() if key in accepted_names}
+
+    return ", ".join(f"{key}={key}" for key in forwarded)
 
 
 def _get_client(namespace: str | None = None) -> Any:


### PR DESCRIPTION
# PR Draft: kubeflow/mcp-server#19

## Title

Fix custom training scripts that define an uncalled `train()`

## Summary

This fixes `run_custom_training` script wrapping when a user provides a script that already defines a top-level `train()` function but does not call it.

Previously `_make_train_func()` always wrapped the submitted script inside another generated `def train():`. For scripts like:

```python
def train():
    print("Training started")
```

the user-defined `train()` became a nested function and was never invoked when the generated wrapper ran.

The patch detects a top-level `def train()` with no module-level `train()` call and appends a call inside the generated wrapper. Scripts that already call `train()` are left alone to avoid double execution. Matching `func_args` are forwarded to a user-defined `train(...)` signature.

## Tests

```bash
uv sync --extra dev
.venv/bin/ruff check kubeflow_mcp/trainer/api/training.py kubeflow_mcp/trainer/api/sdk_contracts_test.py
.venv/bin/python -m pytest kubeflow_mcp/trainer/api/sdk_contracts_test.py -q
.venv/bin/python -m pytest kubeflow_mcp/trainer/api/sdk_contracts_test.py tests/unit/trainer/test_architecture.py -q
.venv/bin/python -m pytest -q
```

Results:

- Ruff: passed.
- SDK contract test: 74 passed.
- Full local suite: 139 passed, 3 upstream dependency deprecation warnings.

Current diff size:

- Implementation: `59` insertions, `1` deletion.
- Tests: `84` insertions.
- Total: `143` insertions, `1` deletion.

## Changed Files

- `kubeflow_mcp/trainer/api/training.py`
- `kubeflow_mcp/trainer/api/sdk_contracts_test.py`
