### PR TITLE
feat: Add Dockerfile, CI publish workflow, and Docker docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# Version control
+.git
+.github
+
+# Python runtime artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+
+# Build / dist
+build/
+dist/
+
+# Virtual environments
+.venv/
+venv/
+
+# Test + coverage
+tests/
+.coverage
+coverage.xml
+coverage.json
+htmlcov/
+.pytest_cache/
+
+# Documentation
+docs/
+
+# Dev tooling
+Makefile
+.pre-commit-config.yaml
+.ruff_cache/
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+*.swp
+*~
+
+# Secrets / local config
+.env
+.env.*
+*.yaml
+*.yml

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,66 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image for critical CVEs (Trivy)
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          format: table
+          exit-code: 1
+          severity: CRITICAL
+          ignore-unfixed: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.12-slim AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /build
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+COPY kubeflow_mcp ./kubeflow_mcp
+RUN uv sync --frozen --no-dev
+
+FROM python:3.12-slim AS runtime
+
+RUN groupadd --gid 65532 kubeflow-mcp \
+ && useradd  --uid 65532 --gid 65532 --no-create-home --shell /sbin/nologin kubeflow-mcp
+
+WORKDIR /app
+
+COPY --from=builder /build/.venv /app/.venv
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    # Sensible defaults for in-cluster operation; override at deploy time
+    MCP_TRANSPORT=http \
+    KUBEFLOW_MCP_LOG_FORMAT=json
+
+EXPOSE 8000
+
+USER 65532:65532
+
+ENTRYPOINT ["kubeflow-mcp", "serve", "--transport", "http"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,47 @@ kubeflow-mcp serve
 
 > Once published to PyPI, install with `pip install kubeflow-mcp`.
 
+### Run with Docker
+
+Pre-built multi-arch images are published to GHCR on every release:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e KUBEFLOW_MCP_AUTH_TOKEN=my-secret-token \
+  ghcr.io/kubeflow/mcp-server:latest
+```
+
+The server listens on `http://localhost:8000/mcp`.
+
+**Environment variables**
+
+| Variable | Default | Description |
+|---|---|---|
+| `MCP_TRANSPORT` | `http` | Transport protocol (`http`, `sse`, `stdio`) |
+| `KUBEFLOW_MCP_AUTH_TOKEN` | _(none)_ | Bearer token for HTTP auth |
+| `KUBEFLOW_MCP_JWKS_URI` | _(none)_ | JWKS endpoint for JWT verification (production) |
+| `KUBEFLOW_MCP_JWT_ISSUER` | _(none)_ | Expected JWT issuer |
+| `KUBEFLOW_MCP_JWT_AUDIENCE` | _(none)_ | Expected JWT audience |
+| `KUBEFLOW_MCP_CLIENTS` | `trainer` | Comma-separated client modules to load |
+| `KUBEFLOW_MCP_PERSONA` | `readonly` | Tool persona (`readonly`, `data-scientist`, `ml-engineer`, `platform-admin`) |
+| `KUBEFLOW_MCP_LOG_FORMAT` | `json` | Log format (`json`, `console`) |
+| `LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+
+**MCP client config (HTTP transport)**
+
+```json
+{
+  "mcpServers": {
+    "kubeflow": {
+      "url": "http://localhost:8000/mcp",
+      "headers": { "Authorization": "Bearer my-secret-token" }
+    }
+  }
+}
+```
+
+For in-cluster deployments, replace `localhost:8000` with the Kubernetes Service address and mount `KUBEFLOW_MCP_AUTH_TOKEN` from a Secret.
+
 ### Example: Fine-tune a model via AI agent
 
 Once connected, your AI agent can run a complete training workflow through natural language:


### PR DESCRIPTION
  fixes #17
  ## Description
  Implements a production-ready container image and CI publish pipeline for in-cluster deployment of the Kubeflow MCP Server.
  ## Dockerfile
  - Multi-stage build: `builder` (uv install) → `runtime` (`python:3.12-slim`)
  - Non-root user `kubeflow-mcp` (uid 65532) for hardened security
  - Only the pre-built `.venv` copied to the final image - no compiler, no uv, no source
  - Exposes port 8000 with `kubeflow-mcp serve --transport http` as the default entrypoint
  - `KUBEFLOW_MCP_AUTH_TOKEN` and `KUBEFLOW_MCP_LOG_FORMAT=json` configurable via env
  ## CI Workflow (`.github/workflows/docker-publish.yaml`)
  - Triggers on `v*.*.*` release tags and `workflow_dispatch`
  - Builds multi-arch image (`linux/amd64`, `linux/arm64`) via Docker Buildx + QEMU
  - Pushes to `ghcr.io/kubeflow/mcp-server` with semver tags (`1.2.3`, `1.2`, `1`, `latest`)
  - No manual secrets - authenticates to GHCR using `GITHUB_TOKEN`
  - GHA layer cache for fast subsequent builds
  - Trivy scan for `CRITICAL` CVEs after push - fails the release if any are found
  ## Documentation
  - New "Run with Docker" section in `README.md` with `docker run` one-liner, full env var reference table, and MCP client config snippet for HTTP transport
  ## Checklist
  - [x] `docker build -t kubeflow-mcp:local .` succeeds
  - [x] Container starts and serves on port 8000
  - [x] Linting passes (`make verify`)
  - [x] Commit messages follow conventional format
