### PR TITLE
feat(ci): replace pip-audit with OSV-Scanner for CVE detection

### DIFF
--- a/.github/scripts/compare_versions.py
+++ b/.github/scripts/compare_versions.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+Compare PEP 440 versions.
+
+Usage:
+    python compare_versions.py <current_version> <target_version>
+
+Exit codes:
+    0 - current_version < target_version (upgrade needed)
+    1 - current_version >= target_version (no upgrade needed)
+    2 - error parsing versions
+"""
+
+import sys
+
+from packaging.version import InvalidVersion, Version
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: compare_versions.py <current_version> <target_version>", file=sys.stderr)
+        sys.exit(2)
+
+    current_str = sys.argv[1]
+    target_str = sys.argv[2]
+
+    try:
+        current = Version(current_str)
+        target = Version(target_str)
+
+        # Exit 0 if current < target (upgrade needed)
+        # Exit 1 if current >= target (no upgrade needed)
+        sys.exit(0 if current < target else 1)
+    except InvalidVersion as e:
+        print(f"Error: Invalid version format - {e}", file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/extract_version.py
+++ b/.github/scripts/extract_version.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+Extract package version from uv tree output.
+
+This script parses uv tree output to extract the full version
+(including pre-release, post-release, dev versions) of a package.
+
+Usage:
+    uv tree --package <package> | python extract_version.py <package>
+
+Exit codes:
+    0 - version found and printed to stdout
+    1 - version not found or error
+"""
+
+import re
+import sys
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: uv tree --package <pkg> | extract_version.py <pkg>", file=sys.stderr)
+        sys.exit(1)
+
+    package_name = sys.argv[1]
+
+    # Read from stdin (piped from uv tree)
+    tree_output = sys.stdin.read()
+
+    # Look for pattern: "package_name vX.Y.Z"
+    # Using non-greedy match to get version until whitespace
+    pattern = rf"{re.escape(package_name)}\s+v([^\s]+)"
+    match = re.search(pattern, tree_output)
+
+    if match:
+        version = match.group(1)
+        print(version)
+        sys.exit(0)
+    else:
+        print(f"Error: Could not find version for {package_name}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""
+Unit tests for GitHub Actions scripts.
+
+Run with: uv run pytest .github/scripts/test_scripts.py -v
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent
+
+
+def _assert_valid_toml(content: str) -> None:
+    """Assert `content` parses as TOML. No-op on Python 3.10 (no stdlib tomllib)."""
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        return
+    tomllib.loads(content)
+
+
+class TestCompareVersions:
+    """Tests for compare_versions.py"""
+
+    def run_compare(self, current: str, target: str) -> int:
+        """Helper to run compare_versions.py and return exit code"""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "compare_versions.py"), current, target],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        return result.returncode
+
+    def test_upgrade_needed(self):
+        """Current version is less than target - should return 0 (upgrade needed)"""
+        assert self.run_compare("2.0.0", "2.1.0") == 0
+        assert self.run_compare("1.0.0", "2.0.0") == 0
+        assert self.run_compare("2.0.0", "2.0.1") == 0
+
+    def test_no_upgrade_needed(self):
+        """Current version equals or exceeds target - should return 1 (no upgrade)"""
+        assert self.run_compare("2.1.0", "2.0.0") == 1
+        assert self.run_compare("2.0.0", "2.0.0") == 1
+        assert self.run_compare("3.0.0", "2.9.9") == 1
+
+    def test_pre_release_versions(self):
+        """Test PEP 440 pre-release versions"""
+        assert self.run_compare("2.0.0rc1", "2.0.0") == 0
+        assert self.run_compare("2.0.0a1", "2.0.0") == 0
+        assert self.run_compare("2.0.0b1", "2.0.0") == 0
+        assert self.run_compare("2.0.0", "2.0.0rc1") == 1
+
+    def test_post_release_versions(self):
+        """Test PEP 440 post-release versions"""
+        assert self.run_compare("2.0.0", "2.0.0.post1") == 0
+        assert self.run_compare("2.0.0.post1", "2.0.0") == 1
+
+    def test_dev_versions(self):
+        """Test PEP 440 dev versions"""
+        assert self.run_compare("2.0.0.dev1", "2.0.0") == 0
+        assert self.run_compare("2.0.0", "2.0.0.dev1") == 1
+
+    def test_complex_version_comparison(self):
+        """Test complex multi-part version numbers"""
+        assert self.run_compare("2.0.0.1", "2.0.0.2") == 0
+        assert self.run_compare("2.10.0", "2.9.0") == 1  # 10 > 9, not string comparison
+        assert self.run_compare("1.0.0rc1", "1.0.0rc2") == 0
+
+    def test_invalid_version_error(self):
+        """Invalid version should return error code 2"""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "compare_versions.py"), "invalid", "2.0.0"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        assert result.returncode == 2
+        assert "Error" in result.stderr
+
+    def test_missing_arguments(self):
+        """Missing arguments should return error code 2"""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "compare_versions.py"), "2.0.0"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        assert result.returncode == 2
+
+
+class TestExtractVersion:
+    """Tests for extract_version.py"""
+
+    def run_extract(self, tree_output: str, package: str) -> tuple[int, str, str]:
+        """Helper to run extract_version.py and return (exit_code, stdout, stderr)"""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "extract_version.py"), package],
+            input=tree_output,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+    def test_simple_version_extraction(self):
+        """Extract version from simple uv tree output"""
+        exit_code, version, _ = self.run_extract("requests v2.31.0", "requests")
+        assert exit_code == 0
+        assert version == "2.31.0"
+
+    def test_version_with_metadata(self):
+        """Extract version from tree output with metadata"""
+        exit_code, version, _ = self.run_extract("├── requests v2.31.0 (transitive)", "requests")
+        assert exit_code == 0
+        assert version == "2.31.0"
+
+    def test_pre_release_version(self):
+        """Extract pre-release version"""
+        exit_code, version, _ = self.run_extract("package v1.0.0rc1", "package")
+        assert exit_code == 0
+        assert version == "1.0.0rc1"
+
+    def test_post_release_version(self):
+        """Extract post-release version"""
+        exit_code, version, _ = self.run_extract("package v1.0.0.post1", "package")
+        assert exit_code == 0
+        assert version == "1.0.0.post1"
+
+    def test_dev_version(self):
+        """Extract dev version"""
+        exit_code, version, _ = self.run_extract("package v1.0.0.dev1", "package")
+        assert exit_code == 0
+        assert version == "1.0.0.dev1"
+
+    def test_package_not_found(self):
+        """Package not in tree output should return error"""
+        exit_code, _, stderr = self.run_extract("other-package v1.0.0", "requests")
+        assert exit_code == 1
+        assert "Could not find version" in stderr
+
+    def test_multiline_tree_output(self):
+        """Extract from realistic multi-line uv tree output"""
+        tree_output = """
+        project v1.0.0
+        ├── requests v2.31.0
+        │   ├── certifi v2023.7.22
+        │   └── urllib3 v2.0.4
+        └── pytest v7.4.0
+        """
+        exit_code, version, _ = self.run_extract(tree_output, "requests")
+        assert exit_code == 0
+        assert version == "2.31.0"
+
+
+class TestUpdateOverrides:
+    """Tests for update_overrides.py"""
+
+    def run_update(
+        self, pyproject_content: str, package: str, target: str, date: str, advisory: str
+    ) -> tuple[int, str]:
+        """Run update_overrides.py against a throwaway pyproject.toml in an isolated dir."""
+        original_dir = os.getcwd()
+        with TemporaryDirectory() as tmp:
+            try:
+                os.chdir(tmp)
+                Path("pyproject.toml").write_text(pyproject_content)
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(SCRIPTS_DIR / "update_overrides.py"),
+                        package,
+                        target,
+                        date,
+                        advisory,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                )
+                return result.returncode, Path("pyproject.toml").read_text()
+            finally:
+                os.chdir(original_dir)
+
+    def test_create_tool_uv_section(self):
+        """Create [tool.uv] section if it doesn't exist"""
+        pyproject = "[project]\nname = 'test'\n"
+        exit_code, updated = self.run_update(
+            pyproject, "requests", "requests==2.31.0", "2025-01-15", "https://advisory.com"
+        )
+
+        assert exit_code == 0
+        assert "[tool.uv]" in updated
+        assert "override-dependencies = [" in updated
+        assert '"requests==2.31.0",' in updated
+        assert "# requests==2.31.0 - Added 2025-01-15" in updated
+
+    def test_add_to_existing_tool_uv(self):
+        """Add override-dependencies to existing [tool.uv]"""
+        pyproject = "[project]\nname = 'test'\n\n[tool.uv]\n"
+        exit_code, updated = self.run_update(
+            pyproject, "requests", "requests==2.31.0", "2025-01-15", "https://advisory.com"
+        )
+
+        assert exit_code == 0
+        assert "override-dependencies = [" in updated
+        assert '"requests==2.31.0",' in updated
+
+    def test_update_existing_override(self):
+        """Update existing package override to new version"""
+        pyproject = """[project]
+name = 'test'
+
+[tool.uv]
+# Security overrides - Review periodically and remove if parent constraints allow natural upgrade
+override-dependencies = [
+    # requests==2.30.0 - Added 2025-01-01 for security fix - https://old.com
+    "requests==2.30.0",
+]
+"""
+        exit_code, updated = self.run_update(
+            pyproject, "requests", "requests==2.31.0", "2025-01-15", "https://new.com"
+        )
+
+        assert exit_code == 0
+        assert '"requests==2.31.0",' in updated
+        assert "2.30.0" not in updated  # Old version removed
+        assert "2025-01-15" in updated  # New date
+        assert "https://new.com" in updated  # New advisory
+
+    def test_add_second_override(self):
+        """Add second package to existing overrides"""
+        pyproject = """[project]
+name = 'test'
+
+[tool.uv]
+override-dependencies = [
+    # requests==2.31.0 - Added 2025-01-15 for security fix - https://advisory.com
+    "requests==2.31.0",
+]
+"""
+        exit_code, updated = self.run_update(
+            pyproject, "urllib3", "urllib3==2.0.5", "2025-01-16", "https://urllib-advisory.com"
+        )
+
+        assert exit_code == 0
+        assert '"requests==2.31.0",' in updated
+        assert '"urllib3==2.0.5",' in updated
+        # Should be alphabetically sorted
+        lines = updated.split("\n")
+        requests_line = next(i for i, line in enumerate(lines) if "requests==" in line)
+        urllib_line = next(i for i, line in enumerate(lines) if "urllib3==" in line)
+        assert requests_line < urllib_line  # requests comes before urllib3
+
+    def test_multiline_array_preserved(self):
+        """Ensure output is always multi-line array format"""
+        pyproject = "[project]\nname = 'test'\n"
+        exit_code, updated = self.run_update(
+            pyproject, "pkg", "pkg==1.0.0", "2025-01-15", "https://advisory.com"
+        )
+
+        assert exit_code == 0
+        assert "override-dependencies = [\n" in updated
+        assert '    "pkg==1.0.0",\n' in updated
+        assert "]\n" in updated
+
+    def test_single_line_array_converted(self):
+        """Single-line array should be parsed and converted to multi-line"""
+        pyproject = """[project]
+name = 'test'
+
+[tool.uv]
+override-dependencies = ["pkg1==1.0.0", "pkg2==2.0.0"]
+"""
+        exit_code, updated = self.run_update(
+            pyproject, "pkg3", "pkg3==3.0.0", "2025-01-15", "https://advisory.com"
+        )
+
+        assert exit_code == 0
+        assert '"pkg1==1.0.0",' in updated
+        assert '"pkg2==2.0.0",' in updated
+        assert '"pkg3==3.0.0",' in updated
+        assert "override-dependencies = [\n" in updated
+        # Should not have duplicate override-dependencies
+        assert updated.count("override-dependencies") == 1
+
+    def test_create_section_no_duplicate_key(self):
+        """Creating [tool.uv] from scratch emits exactly one override key"""
+        pyproject = "[project]\nname = 'test'\n"
+        exit_code, updated = self.run_update(
+            pyproject, "requests", "requests==2.31.0", "2025-01-15", "https://advisory.com"
+        )
+
+        assert exit_code == 0
+        assert updated.count("override-dependencies") == 1
+        _assert_valid_toml(updated)
+
+    def test_indented_override_dependencies(self):
+        """Indented override key is replaced, not duplicated"""
+        pyproject = (
+            "[project]\nname = 'test'\n\n[tool.uv]\n"
+            "  override-dependencies = [\n"
+            '      "flask==3.0.0",\n'
+            '      "requests==2.20.0",\n'
+            "  ]\n"
+        )
+        exit_code, updated = self.run_update(
+            pyproject, "requests", "requests==2.31.0", "2025-01-15", "https://advisory.com"
+        )
+
+        assert exit_code == 0
+        assert updated.count("override-dependencies") == 1
+        assert '"requests==2.31.0",' in updated
+        assert "2.20.0" not in updated  # old indented entry replaced
+        assert '"flask==3.0.0",' in updated  # sibling preserved
+        _assert_valid_toml(updated)
+
+
+if __name__ == "__main__":
+    # Allow running with: python test_scripts.py
+    pytest.main([__file__, "-v"])

--- a/.github/scripts/update_overrides.py
+++ b/.github/scripts/update_overrides.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Update override-dependencies in pyproject.toml.
+
+This script manages the [tool.uv] override-dependencies section by:
+1. Reading existing overrides
+2. Adding or updating a package override
+3. Rewriting the entire section in consistent multi-line format
+
+Usage:
+    python update_overrides.py <package> <target> <date> <advisory_url>
+
+Example:
+    python update_overrides.py requests "requests==2.31.0" "2025-01-15" "https://..."
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def parse_existing_overrides(content):
+    """Parse existing [tool.uv] override-dependencies into {pkg_name: (spec, comment)}.
+
+    Handles both single-line (`override-dependencies = ["pkg==1.0"]`) and
+    multi-line array formats. Returns an empty dict when no overrides exist.
+    """
+    overrides = {}
+    if "override-dependencies" not in content:
+        return overrides
+
+    in_override = False
+    last_comment = None
+    for line in content.split("\n"):
+        if "override-dependencies" in line and "=" in line:
+            in_override = True
+            # Check if it's a single-line array: override-dependencies = ["pkg1", "pkg2"]
+            single_line_match = re.search(r"override-dependencies\s*=\s*\[(.*?)\]", line)
+            if single_line_match:
+                # Parse all packages from single line
+                for pkg_match in re.finditer(r'"([^"]+)"', single_line_match.group(1)):
+                    spec = pkg_match.group(1)
+                    pkg_name = spec.split("==")[0] if "==" in spec else spec.split("[")[0]
+                    overrides[pkg_name] = (spec, None)
+                break  # Single-line format, done parsing
+            continue
+        if in_override:
+            if line.strip() == "]":
+                break
+            # Check for comment lines
+            if line.strip().startswith("#"):
+                last_comment = line.strip()
+                continue
+            # Extract package spec
+            match = re.search(r'"([^"]+)"', line)
+            if match:
+                spec = match.group(1)
+                pkg_name = spec.split("==")[0] if "==" in spec else spec.split("[")[0]
+                overrides[pkg_name] = (spec, last_comment)
+                last_comment = None
+    return overrides
+
+
+def main():
+    if len(sys.argv) != 5:
+        print(
+            "Usage: update_overrides.py <package> <target> <date> <advisory_url>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    package = sys.argv[1]
+    target = sys.argv[2]
+    current_date = sys.argv[3]
+    advisory_url = sys.argv[4]
+
+    pyproject_path = Path("pyproject.toml")
+    if not pyproject_path.exists():
+        print(f"Error: {pyproject_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    # Read current pyproject.toml
+    content = pyproject_path.read_text()
+
+    comment = f"# {target} - Added {current_date} for security fix - {advisory_url}"
+
+    # Extract existing override-dependencies
+    has_tool_uv = "[tool.uv]" in content
+    has_overrides = "override-dependencies" in content
+    overrides = parse_existing_overrides(content)
+
+    # Add or update the current package
+    overrides[package] = (target, comment)
+
+    # Rebuild pyproject.toml
+    if not has_tool_uv:
+        # Add a bare [tool.uv] section at the end; the header comment and
+        # override-dependencies array are inserted by the logic below. (Adding
+        # the header here too would duplicate the whole block -> invalid TOML.)
+        content += "\n[tool.uv]\n"
+        has_tool_uv = True
+
+    if has_overrides:
+        # Remove old override-dependencies section (handles both single-line and multi-line)
+        # Single-line: override-dependencies = ["pkg==1.0"]
+        # Multi-line: override-dependencies = [\n    "pkg",\n]
+        content = re.sub(
+            r"^override-dependencies\s*=\s*\[.*?\]",
+            "",
+            content,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        # Also remove any orphaned comments before override-dependencies
+        content = re.sub(
+            r"^# Security overrides.*?\n(?:[ \t]*\n)?",
+            "",
+            content,
+            flags=re.MULTILINE,
+        )
+
+        # Re-add the header after [tool.uv] so insertion logic stays consistent
+        content = re.sub(
+            r"(\[tool\.uv\]\r?\n)",
+            r"\1# Security overrides - Review periodically and remove "
+            r"if parent constraints allow natural upgrade\n",
+            content,
+            count=1,
+        )
+
+    # Find [tool.uv] and insert override-dependencies
+    if not has_overrides and has_tool_uv:
+        # Insert after [tool.uv]
+        content = re.sub(
+            r"(\[tool\.uv\]\r?\n)",
+            r"\1# Security overrides - Review periodically and remove if parent constraints allow natural upgrade\n",
+            content,
+        )
+
+    # Build override-dependencies array
+    override_lines = ["override-dependencies = ["]
+    for _pkg_name, (spec, pkg_comment) in sorted(overrides.items()):
+        if pkg_comment:
+            override_lines.append(f"    {pkg_comment}")
+        override_lines.append(f'    "{spec}",')
+    override_lines.append("]")
+    override_block = "\n".join(override_lines)
+
+    # Insert after [tool.uv] or the header comment
+    if "# Security overrides" in content:
+        content = re.sub(r"(# Security overrides.*?\r?\n)", r"\1" + override_block + "\n", content)
+    else:
+        content = re.sub(r"(\[tool\.uv\]\r?\n)", r"\1" + override_block + "\n", content, count=1)
+
+    # Write back
+    pyproject_path.write_text(content)
+    print(f"Updated override-dependencies with {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/update_overrides.py
+++ b/.github/scripts/update_overrides.py
@@ -104,15 +104,17 @@ def main():
         # Remove old override-dependencies section (handles both single-line and multi-line)
         # Single-line: override-dependencies = ["pkg==1.0"]
         # Multi-line: override-dependencies = [\n    "pkg",\n]
+        # Leading [ \t]* so an indented key (valid TOML) is still matched and
+        # removed; otherwise the old block survives and we emit a duplicate key.
         content = re.sub(
-            r"^override-dependencies\s*=\s*\[.*?\]",
+            r"^[ \t]*override-dependencies\s*=\s*\[.*?\]",
             "",
             content,
             flags=re.MULTILINE | re.DOTALL,
         )
         # Also remove any orphaned comments before override-dependencies
         content = re.sub(
-            r"^# Security overrides.*?\n(?:[ \t]*\n)?",
+            r"^[ \t]*# Security overrides.*?\n(?:[ \t]*\n)?",
             "",
             content,
             flags=re.MULTILINE,

--- a/.github/scripts/update_overrides.py
+++ b/.github/scripts/update_overrides.py
@@ -20,11 +20,7 @@ from pathlib import Path
 
 
 def parse_existing_overrides(content):
-    """Parse existing [tool.uv] override-dependencies into {pkg_name: (spec, comment)}.
-
-    Handles both single-line (`override-dependencies = ["pkg==1.0"]`) and
-    multi-line array formats. Returns an empty dict when no overrides exist.
-    """
+    """Parse existing [tool.uv] override-dependencies into {pkg_name: (spec, comment)}."""
     overrides = {}
     if "override-dependencies" not in content:
         return overrides
@@ -94,9 +90,7 @@ def main():
 
     # Rebuild pyproject.toml
     if not has_tool_uv:
-        # Add a bare [tool.uv] section at the end; the header comment and
-        # override-dependencies array are inserted by the logic below. (Adding
-        # the header here too would duplicate the whole block -> invalid TOML.)
+        # Add the [tool.uv] section; the header and array are inserted below.
         content += "\n[tool.uv]\n"
         has_tool_uv = True
 
@@ -104,8 +98,6 @@ def main():
         # Remove old override-dependencies section (handles both single-line and multi-line)
         # Single-line: override-dependencies = ["pkg==1.0"]
         # Multi-line: override-dependencies = [\n    "pkg",\n]
-        # Leading [ \t]* so an indented key (valid TOML) is still matched and
-        # removed; otherwise the old block survives and we emit a duplicate key.
         content = re.sub(
             r"^[ \t]*override-dependencies\s*=\s*\[.*?\]",
             "",

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -1,0 +1,235 @@
+name: OSV-Scanner Vulnerability Scan
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  osv-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install OSV-Scanner
+        # Bump cadence: check https://github.com/google/osv-scanner/releases monthly
+        # Dependabot cannot bump curl-installed binaries — update version + checksum manually
+        run: |
+          OSV_VERSION="2.3.8"
+          EXPECTED_SHA="bc98e15319ed0d515e3f9235287ba53cdc5535d576d24fd573978ecfe9ab92dc"
+          curl -fsSL "https://github.com/google/osv-scanner/releases/download/v${OSV_VERSION}/osv-scanner_linux_amd64" -o osv-scanner
+          ACTUAL_SHA=$(sha256sum osv-scanner | awk '{print $1}')
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::OSV-Scanner checksum mismatch! Expected ${EXPECTED_SHA}, got ${ACTUAL_SHA}"
+            exit 1
+          fi
+          chmod +x osv-scanner
+          sudo mv osv-scanner /usr/local/bin/
+
+      - name: Run OSV-Scanner (SARIF for Security Tab)
+        # continue-on-error so a SARIF failure doesn't block the JSON scan + auto-fix below
+        continue-on-error: true
+        run: |
+          rc=0
+          osv-scanner scan \
+            --format sarif \
+            --output osv-results.sarif \
+            -L uv.lock || rc=$?
+          # Exit code 1 = vulns found (expected), 0 = clean. Any other code is a real failure.
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+            echo "::error::OSV-Scanner failed with unexpected exit code $rc"
+            exit 1
+          fi
+
+      - name: Upload SARIF to GitHub Security tab
+        if: always() && hashFiles('osv-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: osv-results.sarif
+          category: kubeflow-mcp-osv-scanner
+
+      - name: Run OSV-Scanner (JSON for auto-fix)
+        run: |
+          rc=0
+          osv-scanner scan \
+            --format json \
+            --output osv-results.json \
+            -L uv.lock || rc=$?
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+            echo "::error::OSV-Scanner failed with unexpected exit code $rc"
+            exit 1
+          fi
+          # Validate JSON output is parseable before downstream steps consume it
+          if [ -f osv-results.json ] && [ -s osv-results.json ]; then
+            jq empty osv-results.json
+          fi
+
+      - name: Process vulnerabilities and apply fixes
+        id: fixer
+        run: |
+          if [ ! -f osv-results.json ] || [ ! -s osv-results.json ]; then
+            echo "No scan results found."
+            echo "updates_found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          CURRENT_DATE=$(date +%Y-%m-%d)
+
+          # Extract fixable vulnerabilities: package name, current version, fix version, advisory ID, URL
+          # The OSV JSON embeds full advisory objects; fixed versions are in affected[].ranges[].events
+          # Use group_by + last to deduplicate: keep the highest fix version per package+advisory pair
+          FIX_DATA=$(jq -r '
+            [
+              .results[]?.packages[]? |
+              .package as $pkg |
+              .vulnerabilities[]? |
+              . as $vuln |
+              .affected[]? |
+              select(.package.name == $pkg.name) |
+              .ranges[]? |
+              .events[] |
+              select(.fixed != null) |
+              {
+                pkg: $pkg.name,
+                ver: $pkg.version,
+                fix: .fixed,
+                id: $vuln.id,
+                url: ($vuln.references[0].url // "https://osv.dev/vulnerability/\($vuln.id)")
+              }
+            ] |
+            group_by([.pkg, .id]) |
+            map(sort_by(.fix | split(".") | map(tonumber? // 0)) | last) |
+            .[] |
+            "\(.pkg)|\(.ver)|\(.fix)|\(.id)|\(.url)"
+          ' osv-results.json 2>/dev/null | sort -u)
+
+          if [ -z "$FIX_DATA" ]; then
+            echo "No fixable vulnerabilities found."
+            echo "updates_found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Fixable vulnerabilities found:"
+          echo "$FIX_DATA"
+          echo ""
+
+          rm -f applied_fixes.txt
+
+          while IFS='|' read -r pkg current_ver fix_ver advisory_id advisory_url; do
+            [ -z "$pkg" ] && continue
+
+            echo ""
+            echo "=== Processing: $pkg $current_ver -> $fix_ver ($advisory_id) ==="
+
+            # Try natural upgrade first
+            echo "Attempting: uv lock --upgrade-package $pkg"
+            LOCK_RC=0
+            uv lock --upgrade-package "$pkg" 2>&1 || LOCK_RC=$?
+            if [ "$LOCK_RC" -ne 0 ]; then
+              echo "Warning: uv lock failed for $pkg (exit code $LOCK_RC), skipping"
+              continue
+            fi
+
+            # Check resulting version
+            TREE_RC=0
+            TREE_OUTPUT=$(uv tree --package "$pkg" 2>&1) || TREE_RC=$?
+            if [ "$TREE_RC" -ne 0 ]; then
+              echo "Warning: uv tree failed for $pkg (exit code $TREE_RC), skipping"
+              continue
+            fi
+            EXTRACT_RC=0
+            NATURAL_VER=$(echo "$TREE_OUTPUT" | uv run python3 .github/scripts/extract_version.py "$pkg") || EXTRACT_RC=$?
+            if [ "$EXTRACT_RC" -ne 0 ]; then
+              echo "Warning: Could not parse version for $pkg from uv tree output, skipping"
+              continue
+            fi
+
+            if [ -z "$NATURAL_VER" ]; then
+              echo "Warning: Could not determine version for $pkg after upgrade"
+              continue
+            fi
+
+            echo "Natural upgrade resulted in version: $NATURAL_VER"
+
+            # Compare: does natural version meet the fix?
+            # compare_versions.py exits: 0 = upgrade needed, 1 = sufficient, 2 = parse error
+            CMP_EXIT=0
+            uv run python3 .github/scripts/compare_versions.py "$NATURAL_VER" "$fix_ver" || CMP_EXIT=$?
+
+            if [ "$CMP_EXIT" -eq 2 ]; then
+              echo "Warning: Could not parse versions for $pkg ($NATURAL_VER vs $fix_ver), skipping"
+              continue
+            elif [ "$CMP_EXIT" -eq 0 ]; then
+              # NATURAL_VER < fix_ver — natural upgrade insufficient, add override
+              echo "Natural upgrade insufficient ($NATURAL_VER < $fix_ver). Adding override..."
+              uv run python3 .github/scripts/update_overrides.py "$pkg" "${pkg}==${fix_ver}" "$CURRENT_DATE" "$advisory_url"
+              LOCK_RC=0
+              uv lock --upgrade-package "$pkg" 2>&1 || LOCK_RC=$?
+              if [ "$LOCK_RC" -ne 0 ]; then
+                echo "Warning: uv lock failed after adding override for $pkg (exit code $LOCK_RC), skipping"
+                continue
+              fi
+              printf '%s\n' "- ${pkg}==${fix_ver} (override) | [$advisory_id]($advisory_url)" >> applied_fixes.txt
+            else
+              # NATURAL_VER >= fix_ver — natural upgrade worked
+              echo "Natural upgrade sufficient ($NATURAL_VER >= $fix_ver)"
+              printf '%s\n' "- ${pkg}==${NATURAL_VER} (upgraded) | [$advisory_id]($advisory_url)" >> applied_fixes.txt
+            fi
+          done <<< "$FIX_DATA"
+
+          if [ ! -s applied_fixes.txt ]; then
+            echo "No fixes were applied."
+            echo "updates_found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "updates_found=true" >> $GITHUB_OUTPUT
+          {
+            echo "fix_details<<EOF"
+            cat applied_fixes.txt
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.fixer.outputs.updates_found == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "fix: nightly automated dependency update for security vulnerabilities"
+          title: "fix: nightly security dependency updates"
+          add-paths: |
+            pyproject.toml
+            uv.lock
+          body: |
+            ## Security Update
+
+            This is an automated PR triggered by the nightly OSV-Scanner security scan.
+
+            The following dependencies were updated to resolve known vulnerabilities:
+
+            | Package & Version | Advisory Link |
+            | :--- | :--- |
+            ${{ steps.fixer.outputs.fix_details }}
+
+            **Verification:** Updated via `uv lock --upgrade-package` or `override-dependencies`.
+
+            > **Note:** This PR was created with `GITHUB_TOKEN`, which does not trigger `pull_request` workflows.
+            > CI checks will not run automatically. Push an empty commit (`git commit --allow-empty -m "trigger CI"`)
+            > to kick off CI before merging.
+            >
+            > **TODO:** Migrate to a GitHub App token via `actions/create-github-app-token` to trigger CI automatically.
+          branch: security-nightly-updates
+          delete-branch: true
+          labels: |
+            area/security

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -38,8 +38,6 @@ jobs:
           sudo mv osv-scanner /usr/local/bin/
 
       - name: Run OSV-Scanner (SARIF for Security Tab)
-        # continue-on-error so a SARIF failure doesn't block the JSON scan + auto-fix below
-        continue-on-error: true
         run: |
           rc=0
           osv-scanner scan \
@@ -60,6 +58,8 @@ jobs:
           category: kubeflow-mcp-osv-scanner
 
       - name: Run OSV-Scanner (JSON for auto-fix)
+        # always() so a crash in the SARIF step above still doesn't skip the independent JSON scan
+        if: always()
         run: |
           rc=0
           osv-scanner scan \
@@ -165,7 +165,7 @@ jobs:
             # Compare: does natural version meet the fix?
             # compare_versions.py exits: 0 = upgrade needed, 1 = sufficient, 2 = parse error
             CMP_EXIT=0
-            uv run python3 .github/scripts/compare_versions.py "$NATURAL_VER" "$fix_ver" || CMP_EXIT=$?
+            uv run --with packaging python3 .github/scripts/compare_versions.py "$NATURAL_VER" "$fix_ver" || CMP_EXIT=$?
 
             if [ "$CMP_EXIT" -eq 2 ]; then
               echo "Warning: Could not parse versions for $pkg ($NATURAL_VER vs $fix_ver), skipping"

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -26,8 +26,8 @@ jobs:
         # Bump cadence: check https://github.com/google/osv-scanner/releases monthly
         # Dependabot cannot bump curl-installed binaries — update version + checksum manually
         run: |
-          OSV_VERSION="2.3.8"
-          EXPECTED_SHA="bc98e15319ed0d515e3f9235287ba53cdc5535d576d24fd573978ecfe9ab92dc"
+          OSV_VERSION="2.4.0"
+          EXPECTED_SHA="15314940c10d26af9c6649f150b8a47c1262e8fc7e17b1d1029b0e479e8ed8a0"
           curl -fsSL "https://github.com/google/osv-scanner/releases/download/v${OSV_VERSION}/osv-scanner_linux_amd64" -o osv-scanner
           ACTUAL_SHA=$(sha256sum osv-scanner | awk '{print $1}')
           if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
@@ -149,7 +149,7 @@ jobs:
               continue
             fi
             EXTRACT_RC=0
-            NATURAL_VER=$(echo "$TREE_OUTPUT" | uv run python3 .github/scripts/extract_version.py "$pkg") || EXTRACT_RC=$?
+            NATURAL_VER=$(printf '%s\n' "$TREE_OUTPUT" | uv run python3 .github/scripts/extract_version.py "$pkg") || EXTRACT_RC=$?
             if [ "$EXTRACT_RC" -ne 0 ]; then
               echo "Warning: Could not parse version for $pkg from uv tree output, skipping"
               continue

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -180,11 +180,11 @@ jobs:
                 echo "Warning: uv lock failed after adding override for $pkg (exit code $LOCK_RC), skipping"
                 continue
               fi
-              printf '%s\n' "- ${pkg}==${fix_ver} (override) | [$advisory_id]($advisory_url)" >> applied_fixes.txt
+              printf '%s\n' "| ${pkg}==${fix_ver} (override) | [$advisory_id]($advisory_url) |" >> applied_fixes.txt
             else
               # NATURAL_VER >= fix_ver — natural upgrade worked
               echo "Natural upgrade sufficient ($NATURAL_VER >= $fix_ver)"
-              printf '%s\n' "- ${pkg}==${NATURAL_VER} (upgraded) | [$advisory_id]($advisory_url)" >> applied_fixes.txt
+              printf '%s\n' "| ${pkg}==${NATURAL_VER} (upgraded) | [$advisory_id]($advisory_url) |" >> applied_fixes.txt
             fi
           done <<< "$FIX_DATA"
 

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -26,22 +26,6 @@ jobs:
         with:
           extra_args: --all-files
 
-  security-audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          python-version: "3.12"
-          enable-cache: true
-
-      - name: Run pip-audit
-        run: |
-          uv sync --all-extras --group dev
-          uv run pip-audit
-
   test:
     runs-on: ubuntu-latest
     needs: pre-commit

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -48,6 +48,9 @@ jobs:
       - name: Verify
         run: make verify
 
+      - name: Test GitHub Actions Scripts
+        run: make test-scripts
+
       - name: Run Tests
         run: |
           make test-python report=xml

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-.PHONY: help uv install-dev verify format test-python test test-cov clean inspector
+.PHONY: help uv install-dev verify format test-python test-scripts test test-cov clean inspector
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -50,6 +50,10 @@ format: ## Auto-format and fix lint issues
 test-python: ## Run unit tests
 	@uv sync --all-extras --group dev
 	@uv run pytest --cov=kubeflow_mcp --cov-report=$(or $(report),term)
+
+test-scripts: ## Run GitHub Actions script tests
+	@uv sync --all-extras --group dev
+	@uv run pytest .github/scripts/test_scripts.py -v
 
 test: ## Run all tests (unit + integration)
 	@uv sync --all-extras --group dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dev = [
     "pytest-asyncio>=0.23",
     "pytest-cov>=4.0",
     "ruff>=0.9",
-    "pip-audit>=2.7",
 ]
 docs = [
     "sphinx>=7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ testpaths = ["kubeflow_mcp", "tests"]
 addopts = "-v --tb=short"
 
 [tool.uv]
-# Pin transitive deps to versions that resolve known CVEs detected by pip-audit.
+# Pin transitive deps to versions that resolve known CVEs detected by the OSV-Scanner workflow.
 constraint-dependencies = [
     "idna>=3.15",       # CVE-2026-45409
     "starlette>=1.3.1", # CVE-2026-54282, CVE-2026-54283

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "caio" },
+    { name = "caio", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -70,7 +70,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "caio" },
+    { name = "caio", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
@@ -358,33 +358,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
-]
-
-[[package]]
-name = "boolean-py"
-version = "5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
-]
-
-[[package]]
-name = "cachecontrol"
-version = "0.14.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "msgpack" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
-]
-
-[package.optional-dependencies]
-filecache = [
-    { name = "filelock" },
 ]
 
 [[package]]
@@ -822,22 +795,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cyclonedx-python-lib"
-version = "11.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "license-expression" },
-    { name = "packageurl-python" },
-    { name = "py-serializable" },
-    { name = "sortedcontainers" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/75/c9/5d0ccdd19bc7d8ab803b90695c1706aa2ea8529685d18e682dc2524d2630/cyclonedx_python_lib-11.11.0.tar.gz", hash = "sha256:4b3194db72b613717f2912447e67ab618c75ff7dcac6c4af3c0e9e1ac617c102", size = 1442983, upload-time = "2026-06-17T11:57:49.055Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/f3/56ccb2884aaa3db5622368e5191a3384b15f35392aa93df8b2f508c660d2/cyclonedx_python_lib-11.11.0-py3-none-any.whl", hash = "sha256:3049fc83e06a059b5c5907a527625a8ed5073caab10607ed4c9e5503b590fd44", size = 528689, upload-time = "2026-06-17T11:57:47.358Z" },
-]
-
-[[package]]
 name = "cyclopts"
 version = "4.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -852,15 +809,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/89/f4c775c651d91f9cd8149f70baec94c902a34e5f17a7a67881881bcfb244/cyclopts-4.20.0.tar.gz", hash = "sha256:1d819de2b12dc6b1c9f17ce0f4937d82922c0b83ac846eb4b3289c9c9f321c9f", size = 190236, upload-time = "2026-06-29T15:04:42.253Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/d4/7243bc65d33c5ff5150569c42c8c1154aadae20b25638afe35f7f568489c/cyclopts-4.20.0-py3-none-any.whl", hash = "sha256:0b4337e9c11303d86b33d3f37c629dc01638f84591681e0e5611286bdd507646", size = 229383, upload-time = "2026-06-29T15:04:40.621Z" },
-]
-
-[[package]]
-name = "defusedxml"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -1402,7 +1350,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1619,7 +1567,6 @@ spark = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1657,7 +1604,6 @@ provides-extras = ["hub", "spark", "all"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pip-audit", specifier = ">=2.7" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
@@ -1717,18 +1663,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602, upload-time = "2026-01-16T01:05:25.991Z" },
-]
-
-[[package]]
-name = "license-expression"
-version = "30.4.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "boolean-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
 ]
 
 [[package]]
@@ -1886,79 +1820,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
-]
-
-[[package]]
-name = "msgpack"
-version = "1.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/16/f70100614b69feb3ade7285f08c9c52d6cda0a5c03f3f5e2facd63acb211/msgpack-1.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8c7b398c56ff125feae96c2737abfec5595f1fa0aa186df60c56040b8accb95c", size = 82926, upload-time = "2026-06-18T16:12:31.531Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/3c/08ecd5cdfe4e2de43aec79062028ad0f7b2d9b1fea5430068c198ba570da/msgpack-1.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1548006a91aa93c5da81f3bdcebc1a0d10cea2d25969754fbe848da622b2b895", size = 82730, upload-time = "2026-06-18T16:12:32.894Z" },
-    { url = "https://files.pythonhosted.org/packages/19/9f/a70c9cb1a04ecc134005149367dcfe35d167284e8f65035a1e4156ad17b5/msgpack-1.2.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dabedcd0f23559f3596428c6589c1cd8c6eaed3a0d720795b07b0225d769203", size = 400729, upload-time = "2026-06-18T16:12:34.052Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/7f/5ce020168cf0439041526e95aa068c722c016aee21624e331aeabeee2e8e/msgpack-1.2.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83efa1c898e0fc5380fc0cabbf75164c52e3b5cbb45973710d75821928380c73", size = 407625, upload-time = "2026-06-18T16:12:35.239Z" },
-    { url = "https://files.pythonhosted.org/packages/79/70/fb7668ce0386819303047057aef6fc1da73b584291d9cff82b821744e2ef/msgpack-1.2.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:01e2dd6c9b19d333a00282330cc8a73d38d8dabc306dc5b42cd668c3ac82e833", size = 377891, upload-time = "2026-06-18T16:12:36.684Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/dc/9ebe654a73c3aed2e40aa6b52e3c2a02b5f53ef0085fa235a45d5b367f87/msgpack-1.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:350cb813d0af6e65d2f7ef0d729f7ff5be5a8bce03665892f43e5883d4ecc1b8", size = 391987, upload-time = "2026-06-18T16:12:37.839Z" },
-    { url = "https://files.pythonhosted.org/packages/42/eb/b67cf64218a2fa25e1c671fe1d3dbb06cbeb973e71bc4b822da079862d0b/msgpack-1.2.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ee1d9ed27d0497b848923746cf762ed2e7db24f4be7eec8e5cbe8c766aa707b7", size = 374603, upload-time = "2026-06-18T16:12:39.221Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/2e/9ee200cde32fd1a0101b4006202fde554c1860adfb9bf7bff31ea4c08df8/msgpack-1.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:633727297ed063441fd1cda2288865487f33ad14eeb8831afb5f0c396a62cfce", size = 405121, upload-time = "2026-06-18T16:12:40.524Z" },
-    { url = "https://files.pythonhosted.org/packages/43/b6/f10117be7ca7a51e8feed699a907b8e663a8cd66e115ae6b4fb30cc7945c/msgpack-1.2.1-cp310-cp310-win32.whl", hash = "sha256:298872ecf9e61950f1c6af4ca969b859ee91783bb920ef6e6172697d0c8aad74", size = 64088, upload-time = "2026-06-18T16:12:41.762Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/93/89976c696fb0224662239d952c47b4d1661b34d79a332ef5584facaa8579/msgpack-1.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:2ff164c1b0bcb740b073b99e945234d0212852fa378e44a208c425379140dbeb", size = 70113, upload-time = "2026-06-18T16:12:42.78Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/6b/e9b1cdc042c4458801d2545ed782a95f3d6ba8e270cce8745b8603c7f748/msgpack-1.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:29a3f6e9667868429d8240dfd063ea5ffdc1321c13d783aa23827a38de0dcb22", size = 82812, upload-time = "2026-06-18T16:12:45.022Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/3a/dd518a1bf78ed1e9ad8afe57307c079a00eafe4b3068932a27ca1ea56b4f/msgpack-1.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aded5bdf32609dc7987a49bbbd15a8ef096193f96dd8bbeb791de729e650acf5", size = 82739, upload-time = "2026-06-18T16:12:46.025Z" },
-    { url = "https://files.pythonhosted.org/packages/70/e0/7ba9e1542bf0771a27b8b37c1316e3f95ae9d748fd765284655c476ad4ef/msgpack-1.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:146ee4e9ce80b365c6d4c47073da9da7bcec473e58194ceee5dd7620ace77e06", size = 414233, upload-time = "2026-06-18T16:12:47.029Z" },
-    { url = "https://files.pythonhosted.org/packages/03/8d/671d81534ea0e2b0e8a121be100020da09eb78861fe3aa8f3ef7dcd3bed1/msgpack-1.2.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a28d076ca7c82b9c8728ad90b7147489449557038bed50e4241eb832395169b4", size = 423843, upload-time = "2026-06-18T16:12:48.19Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/b6/e5c737515ed1f166664b87601b532f58cbb73d8aa6a90b99f7c2c5037e8e/msgpack-1.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7d31c0ac0c640f877804c67cb2bc9f4e23dc2db97e96c2e67fa27d38283b41f8", size = 390772, upload-time = "2026-06-18T16:12:49.624Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/46/62ed8c2e87d7021eab19921594d961ef3aa3794eec76c716dc30f3bfd433/msgpack-1.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8ff92d7feeaf5bc26c51495b69e2f99ed97ab79346fb6555f44be7dd2ac6503b", size = 409559, upload-time = "2026-06-18T16:12:50.936Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ff/59aa3887b860bbf43532835e192b1c388a17590d6068ae4f8b2bc74c906e/msgpack-1.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:779197a6513bab3c3632265e3d0f7cb3227e62510841a6f34f1eaa37efbb345e", size = 387838, upload-time = "2026-06-18T16:12:52.161Z" },
-    { url = "https://files.pythonhosted.org/packages/09/11/f8563e471093420cf6478cb3271a0175d8402b82d879783d4035d2d03360/msgpack-1.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:67f6dd22fa72a93752643f07889796d62739a13415ee630169a8ce764f86cf9f", size = 421732, upload-time = "2026-06-18T16:12:53.556Z" },
-    { url = "https://files.pythonhosted.org/packages/57/cf/e673683c4c6c90c1022b24c65af4b03eda72b182a1176ef6449069d66acc/msgpack-1.2.1-cp311-cp311-win32.whl", hash = "sha256:91054a783328e0ea7954b8771095705c8d2243b814743fbaadf14552c9c52c5d", size = 64091, upload-time = "2026-06-18T16:12:54.821Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/07/ca212739d179f9083bff2c7c08c24101c3555a334fadc2b876b18768a3ae/msgpack-1.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2eda0b7ebb1283a98d3e4492ac933c8af6aff59fd3df1c3ed024f536af4b1dc8", size = 70462, upload-time = "2026-06-18T16:12:55.898Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/be/6798347b425e26f35db82e69dd83c09716c856a3714e7bffc4c0860fd830/msgpack-1.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:6ee967f7c7e1df2890c671ff2ee51a28ded0efc95da3e507176dee881ce36c66", size = 65059, upload-time = "2026-06-18T16:12:57.053Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
-    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
-    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
-    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
-    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
-    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
-    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
-    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
-    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
-    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
-    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
-    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
-    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
-    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
-    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
-    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
-    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
-    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
-    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
-    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
 ]
 
 [[package]]
@@ -2428,15 +2289,6 @@ wheels = [
 ]
 
 [[package]]
-name = "packageurl-python"
-version = "0.17.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2454,10 +2306,10 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -2525,10 +2377,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -2588,61 +2440,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
-]
-
-[[package]]
-name = "pip"
-version = "26.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
-]
-
-[[package]]
-name = "pip-api"
-version = "0.0.34"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pip" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369, upload-time = "2024-07-09T20:32:29.099Z" },
-]
-
-[[package]]
-name = "pip-audit"
-version = "2.10.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cachecontrol", extra = ["filecache"] },
-    { name = "cyclonedx-python-lib" },
-    { name = "packaging" },
-    { name = "pip-api" },
-    { name = "pip-requirements-parser" },
-    { name = "platformdirs" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "tomli" },
-    { name = "tomli-w" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/a4/f21d5f0a0edabcbce31560b73c7c5a6f72ae87af4236fd1069c8f59a353d/pip_audit-2.10.1.tar.gz", hash = "sha256:1eb4565d19ebe5d48996f4b770b4d2b32887e12cb12cfa637f1a064011b55ffc", size = 54275, upload-time = "2026-06-10T22:17:01.744Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/a7/b0c504148114047bd1bc9d97447453c6850ca176bb2f3c0038835994e8b7/pip_audit-2.10.1-py3-none-any.whl", hash = "sha256:99ef3f600a317c1945f1e89e227ef26e1c2d618429b8bd3fa6f4f7c440c4611a", size = 62023, upload-time = "2026-06-10T22:17:00.309Z" },
-]
-
-[[package]]
-name = "pip-requirements-parser"
-version = "32.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pyparsing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
 ]
 
 [[package]]
@@ -2846,18 +2643,6 @@ keyring = [
 ]
 memory = [
     { name = "cachetools" },
-]
-
-[[package]]
-name = "py-serializable"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "defusedxml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
 ]
 
 [[package]]
@@ -3109,15 +2894,6 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
-]
-
-[[package]]
-name = "pyparsing"
-version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -3719,8 +3495,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -3746,15 +3522,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sortedcontainers"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
-]
-
-[[package]]
 name = "soupsieve"
 version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3772,23 +3539,23 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-    { name = "tomli" },
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -3804,23 +3571,23 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
+    { name = "babel", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
+    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
+    { name = "packaging", marker = "python_full_version == '3.11.*'" },
+    { name = "pygments", marker = "python_full_version == '3.11.*'" },
+    { name = "requests", marker = "python_full_version == '3.11.*'" },
+    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
+    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -3840,23 +3607,23 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version >= '3.12'" },
+    { name = "babel", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "imagesize", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -3900,7 +3667,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
 wheels = [
@@ -3922,7 +3689,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
@@ -4062,15 +3829,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
-]
-
-[[package]]
-name = "tomli-w"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

We were using pip-audit for the security scan, but it's fairly limited ie it only checks PyPI's advisory database, never opens fix PRs, and nothing shows up in GitHub's Security tab. This swaps it out for OSV-Scanner, ported over from kubeflow/sdk.

What changes:
- A nightly scan of `uv.lock` (also runnable on demand from the Actions tab)
- Findings upload as SARIF, so they land in the Security tab
- If a vuln is fixable, it opens a PR bumping the package, a normal upgrade where that works, or a `[tool.uv]` override when a plain upgrade isn't enough

The auto-fix part pulls in three small helper scripts (`extract_version`, `compare_versions`, `update_overrides`). pip-audit is dropped from the dev dependencies and the lockfile is regenerated.

Heads-up, since the repo wasn't quite in the state the issue's task list assumed:
- No `security-audit` job existed in `test-python.yaml` to remove, pip-audit was only a dev dependency, never run in CI.
- pip-audit lived under `[project.optional-dependencies].dev`, not `[dependency-groups].dev`; removed from there.
- No `[tool.uv] constraint-dependencies` section exists yet, so nothing to keep. The scanner only writes `override-dependencies` when it needs to.

For a maintainer with admin access: the auto-fix PR step needs an `area/security` label to exist and "Allow GitHub Actions to create and approve pull requests" enabled (Settings -> Actions -> General). Scanning and the Security-tab upload work without either.

Workflow link = https://github.com/Kartikeya-trivedi/mcp-server/actions/runs/27156215089

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] revert: Revert a change
- [ ] chore: Maintenance / tooling

## Checklist

- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow conventional format

## Related Issues

Fixes #29
