### PR TITLE
fix(trainer): execute top-level train calls and strictly validate func_args

### DIFF
--- a/kubeflow_mcp/trainer/api/sdk_contracts_test.py
+++ b/kubeflow_mcp/trainer/api/sdk_contracts_test.py
@@ -641,17 +641,42 @@ class TestMCPToSDKConversions:
 
         assert marker == [(0.01, 3)]
 
-    def test_make_train_func_skips_call_for_required_params(self):
-        """train(required_param) with no func_args must NOT auto-append a call."""
-        marker = self._run_wrapped_train(
-            """
-                import builtins
-                def train(required_param):
-                    builtins._kubeflow_mcp_train_marker.append("ran")
-            """
-        )
-        # train() was NOT called because required_param cannot be supplied
-        assert marker == []
+    def test_make_train_func_raises_value_error_for_required_params(self):
+        """train(required_param) with no func_args must raise a ValueError."""
+        with pytest.raises(ValueError, match=r"User-defined train\(\) requires parameters but no func_args were provided"):
+            self._run_wrapped_train(
+                """
+                    import builtins
+                    def train(required_param):
+                        builtins._kubeflow_mcp_train_marker.append("ran")
+                """
+            )
+
+    def test_make_train_func_raises_syntax_error_for_invalid_script(self):
+        """SyntaxError in the user script should be surfaced."""
+        from kubeflow_mcp.trainer.api.training import _make_train_func
+
+        with pytest.raises(SyntaxError, match="Invalid Python script"):
+            _make_train_func("def train():\n    pass\n  invalid syntax")
+
+    def test_make_train_func_raises_value_error_for_mismatched_func_args(self):
+        """train() with no args but func_args provided should raise ValueError."""
+        with pytest.raises(ValueError, match=r"User-defined train\(\) signature does not accept"):
+            self._run_wrapped_train(
+                """
+                    def train():
+                        pass
+                """,
+                func_args={"lr": 0.01}
+            )
+
+    def test_make_train_func_adds_pass_for_empty_script(self):
+        """An empty or whitespace-only script should generate a valid def train(): pass."""
+        from kubeflow_mcp.trainer.api.training import _make_train_func
+
+        train_func = _make_train_func("   \n  \t  \n")
+        assert callable(train_func)
+        train_func()  # Should run without Error
 
     def test_make_train_func_async_train_executes(self):
         """async def train() should be invoked via asyncio.run()."""

--- a/kubeflow_mcp/trainer/api/sdk_contracts_test.py
+++ b/kubeflow_mcp/trainer/api/sdk_contracts_test.py
@@ -641,6 +641,29 @@ class TestMCPToSDKConversions:
 
         assert marker == [(0.01, 3)]
 
+    def test_make_train_func_skips_call_for_required_params(self):
+        """train(required_param) with no func_args must NOT auto-append a call."""
+        marker = self._run_wrapped_train(
+            """
+                import builtins
+                def train(required_param):
+                    builtins._kubeflow_mcp_train_marker.append("ran")
+            """
+        )
+        # train() was NOT called because required_param cannot be supplied
+        assert marker == []
+
+    def test_make_train_func_async_train_executes(self):
+        """async def train() should be invoked via asyncio.run()."""
+        marker = self._run_wrapped_train(
+            """
+                import builtins
+                async def train():
+                    builtins._kubeflow_mcp_train_marker.append("async_ran")
+            """
+        )
+        assert marker == ["async_ran"]
+
     def test_resources_dict_format(self):
         """Test resources_per_node dict format is valid for SDK."""
         resources = {"gpu": 2, "cpu": 8, "memory": "32Gi"}

--- a/kubeflow_mcp/trainer/api/sdk_contracts_test.py
+++ b/kubeflow_mcp/trainer/api/sdk_contracts_test.py
@@ -10,7 +10,9 @@ Tests validate:
 - Ensure dataclass fields match our usage
 """
 
+import builtins
 import inspect
+import textwrap
 from dataclasses import fields
 from typing import get_type_hints
 
@@ -547,11 +549,11 @@ class TestMCPToSDKConversions:
 
     def test_custom_training_script_to_callable(self):
         """Test that script string can become a callable for CustomTrainer."""
-        script = """
-def train_func():
-    import torch
-    print("Training...")
-"""
+        script = textwrap.dedent("""
+                def train_func():
+                    import torch
+                    print("Training...")
+                """)
         local_vars = {}
         exec(script, {}, local_vars)
         train_func = local_vars["train_func"]
@@ -563,6 +565,81 @@ def train_func():
         )
 
         assert callable(trainer.func)
+
+    def _run_wrapped_train(
+        self,
+        script: str,
+        func_args: dict | None = None,
+        **kwargs,
+    ):
+        from kubeflow_mcp.trainer.api.training import _make_train_func
+
+        builtins._kubeflow_mcp_train_marker = []
+        try:
+            train_func = _make_train_func(script, func_args=func_args)
+            train_func(**kwargs)
+            return builtins._kubeflow_mcp_train_marker
+        finally:
+            del builtins._kubeflow_mcp_train_marker
+
+    def test_make_train_func_calls_user_defined_train(self):
+        """A script-defined train() should run when the generated wrapper runs."""
+        marker = self._run_wrapped_train(
+            """
+                import builtins
+                def train():
+                    builtins._kubeflow_mcp_train_marker.append("ran")
+            """
+        )
+
+        assert marker == ["ran"]
+
+    def test_make_train_func_does_not_double_call_user_defined_train(self):
+        """A script that already calls train() should not run twice."""
+        marker = self._run_wrapped_train(
+            """
+                import builtins
+                def train():
+                    builtins._kubeflow_mcp_train_marker.append("ran")
+                train()
+            """
+        )
+
+        assert marker == ["ran"]
+
+    @pytest.mark.parametrize(
+        "train_call",
+        [
+            "result = train()",
+            "if True:\n    train()",
+            "print(train())",
+        ],
+    )
+    def test_make_train_func_detects_existing_train_calls(self, train_call):
+        """Existing train() calls in module-level code should not be duplicated."""
+        script = textwrap.dedent("""
+                import builtins
+                def train():
+                    builtins._kubeflow_mcp_train_marker.append("ran")
+        """) + train_call + "\n"
+        marker = self._run_wrapped_train(script)
+
+        assert marker == ["ran"]
+
+    def test_make_train_func_forwards_func_args_to_user_defined_train(self):
+        """Generated train() should forward matching func_args to a user-defined train()."""
+        marker = self._run_wrapped_train(
+            """
+                import builtins
+                def train(lr=None, epochs=None):
+                    builtins._kubeflow_mcp_train_marker.append((lr, epochs))
+            """,
+            func_args={"lr": 0.01, "epochs": 3},
+            lr=0.01,
+            epochs=3,
+        )
+
+        assert marker == [(0.01, 3)]
 
     def test_resources_dict_format(self):
         """Test resources_per_node dict format is valid for SDK."""

--- a/kubeflow_mcp/trainer/api/training.py
+++ b/kubeflow_mcp/trainer/api/training.py
@@ -117,9 +117,9 @@ def _make_train_func(script: str, func_args: dict[str, Any] | None = None) -> Ca
     for line in lines:
         wrapped += f"    {line}\n"
 
-    train_call = _uncalled_train_call(stripped_script, func_args)
-    if train_call:
-        wrapped += f"    {train_call}\n"
+    train_lines = _uncalled_train_call(stripped_script, func_args)
+    for tl in train_lines:
+        wrapped += f"    {tl}\n"
 
     script_dir = _get_script_dir()
     script_path = os.path.join(script_dir, f"_mcp_train_{uuid.uuid4().hex[:8]}.py")
@@ -131,35 +131,48 @@ def _make_train_func(script: str, func_args: dict[str, Any] | None = None) -> Ca
     exec(code, ns)  # noqa: S102
     return ns[func_name]
 
-def _uncalled_train_call(script: str, func_args: dict[str, Any] | None = None) -> str | None:
-    """Return the train call to append when a script defines but does not call train."""
+def _uncalled_train_call(
+    script: str, func_args: dict[str, Any] | None = None
+) -> list[str]:
+    """Return lines to append when a script defines but does not call train.
+
+    Returns an empty list when no call needs to be appended.
+    """
     try:
         tree = ast.parse(script)
     except SyntaxError:
-        return None
+        return []
 
     train_defs = (
-        node for node in tree.body
-        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
         and node.name == "train"
     )
     train_def = next(train_defs, None)
     if train_def is None or _has_train_call(tree.body):
-        return None
+        return []
+
+    # Guard: if train() has required params and no func_args are provided,
+    # we cannot safely generate a call skip auto-append.
+    if not func_args and _has_required_params(train_def):
+        return []
 
     forwarded_args = _forwarded_train_args(train_def, func_args)
-    call_str = f"train({forwarded_args})" if forwarded_args else "train()"
+    call_str = (
+        f"train({forwarded_args})" if forwarded_args else "train()"
+    )
 
     if isinstance(train_def, ast.AsyncFunctionDef):
-        return f"import asyncio\n    asyncio.run({call_str})"
-    return call_str
+        return ["import asyncio", f"asyncio.run({call_str})"]
+    return [call_str]
 
 
 def _has_train_call(nodes: list[ast.stmt]) -> bool:
-    """Return True when module-level code calls ``train`` directly or indirectly."""
+    """Return True when module-level code calls ``train()`` directly."""
     for node in nodes:
         # Only module-level execution can run before the generated wrapper returns.
-        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
             continue
         for child in ast.walk(node):
             if (
@@ -168,6 +181,22 @@ def _has_train_call(nodes: list[ast.stmt]) -> bool:
                 and child.func.id == "train"
             ):
                 return True
+    return False
+
+
+def _has_required_params(
+    train_def: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> bool:
+    """Return True when ``train()`` has parameters without defaults."""
+    args_node = train_def.args
+    num_args = len(args_node.args)
+    num_defaults = len(args_node.defaults)
+    if num_args > num_defaults:
+        return True
+    # keyword-only args without defaults
+    for _, kwonly in enumerate(args_node.kw_defaults):
+        if kwonly is None:
+            return True
     return False
 
 
@@ -183,13 +212,16 @@ def _forwarded_train_args(
         forwarded = func_args
     else:
         accepted_names = {
-            arg.arg for arg in [*train_def.args.args, *train_def.args.kwonlyargs]
+            arg.arg
+            for arg in [*train_def.args.args, *train_def.args.kwonlyargs]
         }
-        unaccepted = [key for key in func_args if key not in accepted_names]
+        unaccepted = [
+            key for key in func_args if key not in accepted_names
+        ]
         if unaccepted:
             raise ValueError(
-                "User-defined train() signature does not accept provided func_args: "
-                f"{', '.join(unaccepted)}"
+                "User-defined train() signature does not accept "
+                f"provided func_args: {', '.join(unaccepted)}"
             )
         forwarded = func_args
 

--- a/kubeflow_mcp/trainer/api/training.py
+++ b/kubeflow_mcp/trainer/api/training.py
@@ -14,9 +14,11 @@
 
 """Training submission tools: fine_tune, run_custom_training, run_container_training."""
 
+import ast
 import logging
 import os
 import tempfile
+import textwrap
 import uuid
 from collections.abc import Callable
 from typing import Any
@@ -104,7 +106,8 @@ def _make_train_func(script: str, func_args: dict[str, Any] | None = None) -> Ca
     keyword parameters so the trainer can pass them at runtime.
     """
     func_name = "train"
-    lines = script.strip().splitlines()
+    stripped_script = textwrap.dedent(script).strip()
+    lines = stripped_script.splitlines()
 
     if func_args:
         params = ", ".join(f"{k}=None" for k in func_args)
@@ -113,6 +116,10 @@ def _make_train_func(script: str, func_args: dict[str, Any] | None = None) -> Ca
         wrapped = f"def {func_name}():\n"
     for line in lines:
         wrapped += f"    {line}\n"
+
+    train_call = _uncalled_train_call(stripped_script, func_args)
+    if train_call:
+        wrapped += f"    {train_call}\n"
 
     script_dir = _get_script_dir()
     script_path = os.path.join(script_dir, f"_mcp_train_{uuid.uuid4().hex[:8]}.py")
@@ -124,6 +131,69 @@ def _make_train_func(script: str, func_args: dict[str, Any] | None = None) -> Ca
     exec(code, ns)  # noqa: S102
     return ns[func_name]
 
+def _uncalled_train_call(script: str, func_args: dict[str, Any] | None = None) -> str | None:
+    """Return the train call to append when a script defines but does not call train."""
+    try:
+        tree = ast.parse(script)
+    except SyntaxError:
+        return None
+
+    train_defs = (
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+        and node.name == "train"
+    )
+    train_def = next(train_defs, None)
+    if train_def is None or _has_train_call(tree.body):
+        return None
+
+    forwarded_args = _forwarded_train_args(train_def, func_args)
+    call_str = f"train({forwarded_args})" if forwarded_args else "train()"
+
+    if isinstance(train_def, ast.AsyncFunctionDef):
+        return f"import asyncio\n    asyncio.run({call_str})"
+    return call_str
+
+
+def _has_train_call(nodes: list[ast.stmt]) -> bool:
+    """Return True when module-level code calls ``train`` directly or indirectly."""
+    for node in nodes:
+        # Only module-level execution can run before the generated wrapper returns.
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            continue
+        for child in ast.walk(node):
+            if (
+                isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Name)
+                and child.func.id == "train"
+            ):
+                return True
+    return False
+
+
+def _forwarded_train_args(
+    train_def: ast.FunctionDef | ast.AsyncFunctionDef,
+    func_args: dict[str, Any] | None,
+) -> str:
+    """Build keyword forwarding for user-defined train parameters."""
+    if not func_args:
+        return ""
+
+    if train_def.args.kwarg is not None:
+        forwarded = func_args
+    else:
+        accepted_names = {
+            arg.arg for arg in [*train_def.args.args, *train_def.args.kwonlyargs]
+        }
+        unaccepted = [key for key in func_args if key not in accepted_names]
+        if unaccepted:
+            raise ValueError(
+                "User-defined train() signature does not accept provided func_args: "
+                f"{', '.join(unaccepted)}"
+            )
+        forwarded = func_args
+
+    return ", ".join(f"{key}={key}" for key in forwarded)
 
 def _get_client(namespace: str | None = None) -> Any:
     """Return a client targeting the given namespace.

--- a/kubeflow_mcp/trainer/api/training.py
+++ b/kubeflow_mcp/trainer/api/training.py
@@ -109,6 +109,10 @@ def _make_train_func(script: str, func_args: dict[str, Any] | None = None) -> Ca
     stripped_script = textwrap.dedent(script).strip()
     lines = stripped_script.splitlines()
 
+    if not lines:
+        lines = ["pass"]
+
+
     if func_args:
         params = ", ".join(f"{k}=None" for k in func_args)
         wrapped = f"def {func_name}({params}):\n"
@@ -140,8 +144,8 @@ def _uncalled_train_call(
     """
     try:
         tree = ast.parse(script)
-    except SyntaxError:
-        return []
+    except SyntaxError as e:
+        raise SyntaxError(f"Invalid Python script: {e}") from e
 
     train_defs = (
         node
@@ -154,9 +158,10 @@ def _uncalled_train_call(
         return []
 
     # Guard: if train() has required params and no func_args are provided,
-    # we cannot safely generate a call skip auto-append.
     if not func_args and _has_required_params(train_def):
-        return []
+        raise ValueError(
+            "User-defined train() requires parameters but no func_args were provided."
+        )
 
     forwarded_args = _forwarded_train_args(train_def, func_args)
     call_str = (
@@ -169,7 +174,11 @@ def _uncalled_train_call(
 
 
 def _has_train_call(nodes: list[ast.stmt]) -> bool:
-    """Return True when module-level code calls ``train()`` directly."""
+    """Return True when module-level code calls ``train()`` directly.
+
+    Note: This only detects direct calls to `train()`. It does not detect
+    aliased calls (e.g., `t = train; t()`) or attribute-based calls.
+    """
     for node in nodes:
         # Only module-level execution can run before the generated wrapper returns.
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):


### PR DESCRIPTION
# Description
This PR fixes a silent failure issue where training scripts that define a top-level `train()` function were nested inside the generated wrapper but never executed.

## Type of Change
- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] revert: Revert a change
- [ ] chore: Maintenance / tooling

## Checklist
- [x] Tests pass locally (make test-python)
- [x] Linting passes (make verify)
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow conventional format

## Related Issues
Closes #19

## Problem
`_make_train_func()` always wraps the submitted script in a generated `def train():` wrapper. When a user's script already defines a top-level `train()`, it becomes nested and is never called silently skipping training.

## Fix
* Use `ast.parse` to detect top-level `def train()` (sync and async).
* If found and `func_args` match the signature → call it with forwarded arguments.
* If found but `func_args` are missing from the signature or do not match → raise a clear `ValueError` instead of silently failing.
* If not found → wrap as before (existing behavior unchanged).

## Tests Added
* Plain script gets wrapped correctly
* Async `train()` detected and executable
* Matching `func_args` work correctly
* Missing params raise `ValueError`
