### PR TITLE
fix(trainer): detect OpenShift pip permission error and document work…

### DIFF
--- a/kubeflow_mcp/trainer/__init__.py
+++ b/kubeflow_mcp/trainer/__init__.py
@@ -370,6 +370,7 @@ TRAINING RULES:
 
 PLATFORM:
 - If pre_flight() returns platform=openshift, ALWAYS pass emptyDir volumes for /.local, /.cache, /tmp — without these, jobs fail on read-only filesystem. Read trainer://guides/platform-fixes for copy-paste JSON
+- OpenShift packages restriction: if platform=openshift, do NOT use the packages parameter in run_custom_training() as the pre-script pip install step will fail with PermissionError on /.local. Instead, install packages inside your training script to /workspace/lib using subprocess and append to sys.path
 - Gated HuggingFace models require hf_token parameter
 - Training jobs consume GPU resources — be conservative with num_nodes
 - Use get_training_events() to debug stuck/failed jobs. Read trainer://guides/troubleshooting for error-to-fix tables""",

--- a/kubeflow_mcp/trainer/api/monitoring.py
+++ b/kubeflow_mcp/trainer/api/monitoring.py
@@ -59,6 +59,14 @@ _FAILURE_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
         "Check dataset/model paths and volume mounts.",
     ),
     (
+        re.compile(
+            r"PermissionError: \[Errno 13\] Permission denied: '/\.local|Permission denied: '/\.local",
+            re.IGNORECASE,
+        ),
+        "OPENSHIFT_PIP_ERROR",
+        "On OpenShift under a restricted SCC, pip install --user fails on read-only /.local. Do NOT use the 'packages' parameter in run_custom_training(). Instead, install packages inside your script to /workspace/lib using subprocess and append to sys.path. Read trainer://guides/platform-fixes for details.",
+    ),
+    (
         re.compile(r"PermissionError|Access Denied", re.IGNORECASE),
         "PERMISSION_ERROR",
         "Check service account permissions and storage credentials.",

--- a/kubeflow_mcp/trainer/resources/platform-fixes.md
+++ b/kubeflow_mcp/trainer/resources/platform-fixes.md
@@ -96,7 +96,24 @@ For `fine_tune()`, these volumes apply to ALL replicated jobs (node, dataset-ini
 "env": {"NCCL_P2P_DISABLE": "1", "NCCL_SHM_DISABLE": "1"}
 ```
 
-**4. If emptyDirs are not enough** — escalate to cluster admin:
+**4. Pip package installation permission denied in run_custom_training()** — when using `run_custom_training(packages=[...])` on OpenShift under a restricted SCC, the SDK's pre-script pip install step attempts to run `pip install --user` which writes to `/.local`. Since user-defined emptyDir volumes are not mounted on the training container during this step, the job will fail immediately with:
+`PermissionError: [Errno 13] Permission denied: '/.local'`
+
+*Workaround*: Do **NOT** use the `packages` parameter on OpenShift. Instead, write a workaround directly in your training script to install the required packages to `/workspace/lib` (which is a writable emptyDir) and append it to `sys.path`:
+
+```python
+import subprocess, sys, os
+lib_dir = '/workspace/lib'
+os.makedirs(lib_dir, exist_ok=True)
+subprocess.run([
+    sys.executable, '-m', 'pip', 'install',
+    '--target', lib_dir, '--quiet',
+    'transformers', 'peft', 'trl'
+], check=True)
+sys.path.insert(0, lib_dir)
+```
+
+**5. If emptyDirs are not enough** — escalate to cluster admin:
 
 ```bash
 oc adm policy add-scc-to-user anyuid -z <service-account> -n <namespace>

--- a/kubeflow_mcp/trainer/resources/platform-fixes.md
+++ b/kubeflow_mcp/trainer/resources/platform-fixes.md
@@ -18,7 +18,8 @@ Error-based detection (from `get_training_logs()`):
 | Error pattern | Platform | Fix |
 |---------------|----------|-----|
 | "Read-only file system" | OpenShift (restricted SCC) | Add emptyDir volumes below |
-| "Permission denied" on /.local or /.cache | OpenShift (restricted SCC) | Add emptyDir volumes below |
+| "Permission denied" on /.local or /.cache (at runtime) | OpenShift (restricted SCC) | Add emptyDir volumes below |
+| "Permission denied" on /.local (during packages install in run_custom_training) | OpenShift (restricted SCC) | Do NOT use `packages` parameter. Use Workaround #4 below |
 
 ## OpenShift emptyDir Volumes
 
@@ -41,7 +42,7 @@ ALWAYS pass when `platform=openshift`. Copy-paste ready — pass directly as `vo
 
 Random UIDs (e.g. 1000660000). Do NOT assume root. Implications:
 - HOME may not be writable — use `/tmp` for outputs
-- `/.local` emptyDir fixes most pip issues
+- `/.local` emptyDir fixes most runtime pip issues (but does not apply to `packages` pre-script; see Workaround #4)
 - Avoid `chmod` / `chown` in training scripts
 
 ## GPU Tolerations
@@ -88,7 +89,7 @@ For `fine_tune()`, these volumes apply to ALL replicated jobs (node, dataset-ini
 **2. Non-root UID issues** — avoid commands that assume root. In scripts:
 - Write outputs to `/tmp` instead of `/root` or `/home`
 - Do NOT use `chmod`, `chown`, or write to `/etc`
-- Use `/.local` for pip user installs (already covered by emptyDir above)
+- Use `/.local` for runtime pip user installs (already covered by emptyDir above; for `packages` parameter use Workaround #4)
 
 **3. Network restrictions** — some SCCs block host networking. For multi-node training, pass env vars to `run_custom_training()` or `run_container_training()`:
 
@@ -96,7 +97,24 @@ For `fine_tune()`, these volumes apply to ALL replicated jobs (node, dataset-ini
 "env": {"NCCL_P2P_DISABLE": "1", "NCCL_SHM_DISABLE": "1"}
 ```
 
-**4. If emptyDirs are not enough** — escalate to cluster admin:
+**4. Pip package installation permission denied in run_custom_training()** — when using `run_custom_training(packages=[...])` on OpenShift under a restricted SCC, the SDK's pre-script pip install step attempts to run `pip install --user` which writes to `/.local`. Since user-defined emptyDir volumes are not mounted on the training container during this step, the job will fail immediately with:
+`PermissionError: [Errno 13] Permission denied: '/.local'`
+
+*Workaround*: Do **NOT** use the `packages` parameter on OpenShift. Instead, write a workaround directly in your training script to install the required packages to `/workspace/lib` (which is a writable emptyDir) and append it to `sys.path`:
+
+```python
+import subprocess, sys, os
+lib_dir = '/workspace/lib'
+os.makedirs(lib_dir, exist_ok=True)
+subprocess.run([
+    sys.executable, '-m', 'pip', 'install',
+    '--target', lib_dir, '--quiet',
+    'transformers', 'peft', 'trl'
+], check=True)
+sys.path.insert(0, lib_dir)
+```
+
+**5. If emptyDirs are not enough** — escalate to cluster admin:
 
 ```bash
 oc adm policy add-scc-to-user anyuid -z <service-account> -n <namespace>

--- a/kubeflow_mcp/trainer/resources/troubleshooting.md
+++ b/kubeflow_mcp/trainer/resources/troubleshooting.md
@@ -21,7 +21,8 @@ Diagnostic workflows, error-to-fix tables, and known tool limitations.
 | NCCL timeout | Multi-node communication failure | Pass `env={"NCCL_TIMEOUT": "1800"}`, try gloo backend, check network |
 | 403 Forbidden (HuggingFace) | Gated model, no token | Accept model license, pass `hf_token` |
 | Read-only file system | Platform with read-only root FS | Add emptyDir volumes (see trainer://guides/platform-fixes) |
-| Permission denied /.local | Read-only root filesystem | Add dot-local emptyDir volume |
+| Permission denied /.local (at runtime) | Read-only root filesystem | Add dot-local emptyDir volume |
+| Permission denied /.local (during packages install) | run_custom_training pre-script restriction | Do NOT use `packages` parameter. See Workaround #4 in trainer://guides/platform-fixes |
 | ProcessGroupNCCL...no GPUs | torchtune on CPU cluster | Use `run_custom_training()` with gloo backend instead |
 | BackOff (crash loop) | Container keeps crashing | Check `get_training_logs()` for the root error |
 | Script syntax error | Invalid Python in `run_custom_training` | Script is wrapped into function body — no top-level indentation errors, no `if __name__` guards |

--- a/tests/unit/trainer/test_monitoring.py
+++ b/tests/unit/trainer/test_monitoring.py
@@ -1,0 +1,64 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for log monitoring and failure pattern extraction."""
+
+from kubeflow_mcp.trainer.api.monitoring import _extract_failure_hint
+
+
+def test_extract_failure_hint_openshift_pip_error():
+    # Test exact PermissionError trace
+    logs = (
+        "Installing collected packages: torch\n"
+        "PermissionError: [Errno 13] Permission denied: '/.local'\n"
+        "ERROR: Job failed"
+    )
+    hint = _extract_failure_hint(logs)
+    assert hint is not None
+    assert hint["category"] == "OPENSHIFT_PIP_ERROR"
+    assert "On OpenShift under a restricted SCC" in hint["suggestion"]
+    assert "Do NOT use the 'packages' parameter" in hint["suggestion"]
+
+    # Test generic permission denied on /.local
+    logs_generic = "Permission denied: '/.local/bin/pip'"
+    hint_generic = _extract_failure_hint(logs_generic)
+    assert hint_generic is not None
+    assert hint_generic["category"] == "OPENSHIFT_PIP_ERROR"
+
+
+def test_extract_failure_hint_generic_permission_error():
+    # Test a generic permission error does not trigger OpenShift pip error
+    logs = "PermissionError: [Errno 13] Permission denied: '/workspace/data.csv'"
+    hint = _extract_failure_hint(logs)
+    assert hint is not None
+    assert hint["category"] == "PERMISSION_ERROR"
+    assert "Check service account permissions" in hint["suggestion"]
+
+
+def test_extract_failure_hint_other_patterns():
+    # Test CUDA OOM
+    oom_logs = "RuntimeError: CUDA out of memory. Tried to allocate 2.00 GiB"
+    oom_hint = _extract_failure_hint(oom_logs)
+    assert oom_hint is not None
+    assert oom_hint["category"] == "OOM"
+
+    # Test Missing Module
+    module_logs = "ModuleNotFoundError: No module named 'peft'"
+    module_hint = _extract_failure_hint(module_logs)
+    assert module_hint is not None
+    assert module_hint["category"] == "MISSING_MODULE"
+
+    # Test no match
+    clean_logs = "Training completed successfully. Epoch 5/5 finished."
+    assert _extract_failure_hint(clean_logs) is None


### PR DESCRIPTION
## fix(trainer): detect OpenShift pip permission error and document workaround

### Problem 
fixes : https://github.com/kubeflow/mcp-server/issues/41
On OpenShift clusters with a restricted Security Context Constraint (SCC), the root filesystem is read-only. Running `run_custom_training(packages=[...])` executes `pip install --user` (writing to `/.local`), which fails with a `PermissionError: [Errno 13] Permission denied: '/.local'` because user-defined volumes are not mounted during the pre-script installation step.

### Changes
* **Log Parser (`kubeflow_mcp/trainer/api/monitoring.py`)**: Added an OpenShift-specific pattern to `_FAILURE_PATTERNS` to catch permission errors on `/.local` and return the workaround suggestion.
* **Agent Instructions (`kubeflow_mcp/trainer/__init__.py`)**: Added prompt guidance under `INSTRUCTION_SECTIONS["training"]` advising AI agents to avoid the `packages` parameter on OpenShift.
* **Documentation (`kubeflow_mcp/trainer/resources/platform-fixes.md`)**: Documented the issue and the target-directory workaround.
* **Tests (`tests/unit/trainer/test_monitoring.py`)**: Added a new test suite to verify the parser correctly matches and prioritizes the OpenShift error over generic permission errors.

### Workaround
Do not use the `packages` parameter on OpenShift. Instead, run the installation within the training script using:
```python
import subprocess, sys, os
lib_dir = '/workspace/lib'
os.makedirs(lib_dir, exist_ok=True)
subprocess.run([sys.executable, '-m', 'pip', 'install', '--target', lib_dir, '--quiet', 'transformers', 'peft', 'trl'], check=True)
sys.path.insert(0, lib_dir)
```

### Verification
* All 147 unit tests pass.
* Ruff checks and formatting pass with zero violations.
