### PR TITLE
chore(ci): bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -33,7 +33,7 @@ jobs:
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -41,7 +41,7 @@ jobs:
 
       - name: Extract image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -18,7 +18,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -29,7 +29,7 @@ jobs:
   security-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -53,7 +53,7 @@ jobs:
     name: Test (Python ${{ matrix.python-version }})
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4


### PR DESCRIPTION
## chore(ci): bump GitHub Actions to latest major versions

Resolves failing `Build and Push Docker Image` and `Unit Test - Python` PR checks caused by deprecated action versions.

### Changes

| Action | Before | After | Affected Workflow |
|--------|--------|-------|-------------------|
| `actions/checkout` | v4 | v7 | `docker-publish.yaml`, `test-python.yaml` |
| `docker/login-action` | v3 | v4 | `docker-publish.yaml` |
| `docker/metadata-action` | v5 | v6 | `docker-publish.yaml` |
| `docker/build-push-action` | v6 | v7 | `docker-publish.yaml` |


