### PR TITLE
chore: add jaiakash and Krishna-kg732 as reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,5 @@ approvers:
   - kramaranya
 reviewers:
   - szaher
+  - jaiakash
+  - Krishna-kg732


### PR DESCRIPTION
## Description

Add @jaiakash and @Krishna-kg732 as reviewers
Both have been actively contributing to the MCP Server project:
- **@jaiakash** — GSoC 2026 Mentor for the Kubeflow MCP project, Kubeflow community member
- **@Krishna-kg732** — Active contributor with open PRs (#28, #48) including the Katib/optimizer client and PyPI release workflow

Adding them as reviewers enables Prow to auto-assign them for code reviews and recognizes their ongoing involvement.


cc: @andreyvelich @kubeflow/kubeflow-sdk-team @kubeflow/wg-ml-experience-chairs 