### PR TITLE
chore: add demo video, Coveralls badge, and DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubeflow MCP Server
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue)](https://www.python.org) [![Join Slack](https://img.shields.io/badge/Join_Slack-blue?logo=slack)](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue)](https://www.python.org) [![Join Slack](https://img.shields.io/badge/Join_Slack-blue?logo=slack)](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels) [![Coverage Status](https://coveralls.io/repos/github/kubeflow/mcp-server/badge.svg?branch=main)](https://coveralls.io/github/kubeflow/mcp-server?branch=main) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kubeflow/mcp-server)
 
 Proposal: [KEP-936](https://github.com/kubeflow/community/tree/master/proposals/936-kubeflow-mcp-server) · [ROADMAP](ROADMAP.md) · [SECURITY](SECURITY.md) · [CONTRIBUTING](CONTRIBUTING.md)
 
@@ -17,6 +17,10 @@ The Kubeflow MCP Server exposes Kubeflow Training operations as [Model Context P
 - **Multi-Platform**: Auto-detects OpenShift, EKS, GKE with platform-specific guidance
 - **Token-Efficient**: Progressive/semantic modes compress 23 tools into 2-3 meta-tools
 - **Extensible**: Plugin architecture for additional Kubeflow clients (TODO: optimizer, hub)
+
+## Demo
+
+[![Kubeflow MCP Server](https://img.youtube.com/vi/cZ2BP5hQjc8/0.jpg)](https://youtu.be/cZ2BP5hQjc8)
 
 ## Get Started
 


### PR DESCRIPTION
## Description

Adds Coveralls and DeepWiki badges to the badge row, and a Demo section (embedding the YouTube walkthrough) placed after Overview, before Get Started — following the exact pattern kubeflow/sdk's README already uses for both.

## Related Issue

Fixes #53

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`) — not applicable, doc-only change
- [x] Linting passes (`make verify`) — not applicable, doc-only change
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

Verified both new badge URLs resolve (Coveralls page exists for this repo, DeepWiki page exists for this repo) and confirmed the YouTube video ID renders correctly as a thumbnail-link, matching the kubeflow/sdk README's demo section format.