### PR TITLE
feat: rank model-id suggestions by downloads and suggest on the not-found path

### DIFF
--- a/kubeflow_mcp/trainer/api/planning.py
+++ b/kubeflow_mcp/trainer/api/planning.py
@@ -31,22 +31,40 @@ logger = logging.getLogger(__name__)
 _HF_MODEL_ID_RE = re.compile(r"^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$")
 
 
+_MIN_NAME_FALLBACK_LEN = 3
+
+
 def _suggest_hf_model_ids(model: str, limit: int = 3) -> list[str]:
     """Suggest real HuggingFace model IDs for a malformed model reference.
 
     Normalizes common non-Hub formats into a search term (drops an ``hf://``
     prefix and any Ollama-style ``:tag`` suffix such as ``qwen3:8b``) and asks
-    the Hub for close matches. Returns an empty list when the lookup errors or
-    finds nothing, so the suggestions stay best-effort and the validation path
-    never depends on network access.
+    the Hub for close matches ranked by downloads, so canonical repos surface
+    ahead of community fine-tunes. If a full ``org/name`` term finds nothing
+    (usually a typo in the org, e.g. ``meta-lama/Llama-3``), it retries on just
+    the model name; that retry is skipped when the name is very short, since a
+    bare one or two character search is too broad to be a useful "did you mean".
+    Returns an empty list when the lookup errors or finds nothing, so the
+    suggestions stay best-effort and the validation path never depends on
+    network access.
     """
-    search = model.strip().removeprefix("hf://").split(":", 1)[0].strip()
-    if not search:
+    normalized = model.strip().removeprefix("hf://").split(":", 1)[0].strip()
+    if not normalized:
         return []
+    terms = [normalized]
+    name = normalized.rsplit("/", 1)[-1]
+    if name and name != normalized and len(name) >= _MIN_NAME_FALLBACK_LEN:
+        terms.append(name)
     try:
         from huggingface_hub import list_models
 
-        return [m.id for m in list_models(search=search, limit=limit, full=False)]
+        for term in terms:
+            matches = [
+                m.id for m in list_models(search=term, sort="downloads", limit=limit, full=False)
+            ]
+            if matches:
+                return matches
+        return []
     except Exception:  # noqa: BLE001 - suggestions are best-effort, never fatal
         return []
 
@@ -62,8 +80,20 @@ def _get_model_info_from_hf(model: str) -> dict[str, Any] | None:
             return result
 
         from huggingface_hub import model_info
+        from huggingface_hub.errors import RepositoryNotFoundError
 
-        info = model_info(model, timeout=10)
+        try:
+            info = model_info(model, timeout=10)
+        except RepositoryNotFoundError as e:
+            # A well-formed id but no such repo (usually a typo); offer the same
+            # best-effort suggestions so callers still get a "did you mean".
+            # Other failures (auth, rate-limit, network, metadata) fall through
+            # to the outer handler unchanged, with no extra Hub request.
+            not_found: dict[str, Any] = {"error": str(e)}
+            suggestions = _suggest_hf_model_ids(model)
+            if suggestions:
+                not_found["suggestions"] = suggestions
+            return not_found
 
         # Get parameter count from safetensors metadata
         params = None

--- a/kubeflow_mcp/trainer/api/planning.py
+++ b/kubeflow_mcp/trainer/api/planning.py
@@ -36,17 +36,30 @@ def _suggest_hf_model_ids(model: str, limit: int = 3) -> list[str]:
 
     Normalizes common non-Hub formats into a search term (drops an ``hf://``
     prefix and any Ollama-style ``:tag`` suffix such as ``qwen3:8b``) and asks
-    the Hub for close matches. Returns an empty list when the lookup errors or
-    finds nothing, so the suggestions stay best-effort and the validation path
-    never depends on network access.
+    the Hub for close matches ranked by downloads, so canonical repos surface
+    ahead of community fine-tunes. If a full ``org/name`` term finds nothing
+    (usually a typo in the org, e.g. ``meta-lama/Llama-3``), it retries on just
+    the model name. Returns an empty list when the lookup errors or finds
+    nothing, so the suggestions stay best-effort and the validation path never
+    depends on network access.
     """
-    search = model.strip().removeprefix("hf://").split(":", 1)[0].strip()
-    if not search:
+    normalized = model.strip().removeprefix("hf://").split(":", 1)[0].strip()
+    if not normalized:
         return []
+    terms = [normalized]
+    name = normalized.rsplit("/", 1)[-1]
+    if name and name != normalized:
+        terms.append(name)
     try:
         from huggingface_hub import list_models
 
-        return [m.id for m in list_models(search=search, limit=limit, full=False)]
+        for term in terms:
+            matches = [
+                m.id for m in list_models(search=term, sort="downloads", limit=limit, full=False)
+            ]
+            if matches:
+                return matches
+        return []
     except Exception:  # noqa: BLE001 - suggestions are best-effort, never fatal
         return []
 
@@ -82,7 +95,14 @@ def _get_model_info_from_hf(model: str) -> dict[str, Any] | None:
         }
 
     except Exception as e:
-        return {"error": str(e)}
+        # A valid-format but nonexistent id (e.g. a typo) lands here rather than
+        # the format branch above; offer the same best-effort suggestions so
+        # callers still get a "did you mean" list.
+        result: dict[str, Any] = {"error": str(e)}
+        suggestions = _suggest_hf_model_ids(model)
+        if suggestions:
+            result["suggestions"] = suggestions
+        return result
 
 
 QUANTIZATION_BYTES: dict[str, float] = {

--- a/kubeflow_mcp/trainer/api/planning.py
+++ b/kubeflow_mcp/trainer/api/planning.py
@@ -75,8 +75,20 @@ def _get_model_info_from_hf(model: str) -> dict[str, Any] | None:
             return result
 
         from huggingface_hub import model_info
+        from huggingface_hub.errors import RepositoryNotFoundError
 
-        info = model_info(model, timeout=10)
+        try:
+            info = model_info(model, timeout=10)
+        except RepositoryNotFoundError as e:
+            # A well-formed id but no such repo (usually a typo); offer the same
+            # best-effort suggestions so callers still get a "did you mean".
+            # Other failures (auth, rate-limit, network, metadata) fall through
+            # to the outer handler unchanged, with no extra Hub request.
+            not_found: dict[str, Any] = {"error": str(e)}
+            suggestions = _suggest_hf_model_ids(model)
+            if suggestions:
+                not_found["suggestions"] = suggestions
+            return not_found
 
         # Get parameter count from safetensors metadata
         params = None
@@ -95,14 +107,7 @@ def _get_model_info_from_hf(model: str) -> dict[str, Any] | None:
         }
 
     except Exception as e:
-        # A valid-format but nonexistent id (e.g. a typo) lands here rather than
-        # the format branch above; offer the same best-effort suggestions so
-        # callers still get a "did you mean" list.
-        result: dict[str, Any] = {"error": str(e)}
-        suggestions = _suggest_hf_model_ids(model)
-        if suggestions:
-            result["suggestions"] = suggestions
-        return result
+        return {"error": str(e)}
 
 
 QUANTIZATION_BYTES: dict[str, float] = {

--- a/kubeflow_mcp/trainer/api/planning_test.py
+++ b/kubeflow_mcp/trainer/api/planning_test.py
@@ -17,7 +17,9 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import httpx
 import pytest
+from huggingface_hub.errors import RepositoryNotFoundError
 from tests.common import TestCase
 
 from kubeflow_mcp.trainer.api.planning import (
@@ -31,6 +33,14 @@ from kubeflow_mcp.trainer.api.planning import (
 
 def _fake_models(*ids):
     return [SimpleNamespace(id=model_id) for model_id in ids]
+
+
+def _repo_not_found():
+    # The concrete exception model_info raises for a nonexistent repo.
+    request = httpx.Request("GET", "https://huggingface.co/api/models/x")
+    return RepositoryNotFoundError(
+        "Repository Not Found", response=httpx.Response(404, request=request)
+    )
 
 
 def test_suggest_normalizes_ollama_tag():
@@ -109,6 +119,93 @@ def test_estimate_resources_omits_suggestions_when_none_found():
 
     assert result["success"] is False
     assert "suggestions" not in result["details"]
+
+
+def test_suggest_ranks_by_downloads():
+    # Ranking by downloads surfaces canonical repos ahead of community fine-tunes.
+    with patch("huggingface_hub.list_models") as mock_list:
+        mock_list.return_value = _fake_models("Qwen/Qwen3-8B")
+        _suggest_hf_model_ids("qwen3:8b")
+
+    assert mock_list.call_args.kwargs.get("sort") == "downloads"
+
+
+def test_suggest_falls_back_to_model_name_when_org_typo_finds_nothing():
+    # A typo'd org (meta-lama vs meta-llama) makes the full "org/name" search
+    # empty; retry on just the model name so the user still gets a suggestion.
+    with patch("huggingface_hub.list_models") as mock_list:
+        mock_list.side_effect = [_fake_models(), _fake_models("meta-llama/Llama-3.2-1B")]
+        suggestions = _suggest_hf_model_ids("meta-lama/Llama-3")
+
+    assert suggestions == ["meta-llama/Llama-3.2-1B"]
+    assert [c.kwargs["search"] for c in mock_list.call_args_list] == [
+        "meta-lama/Llama-3",
+        "Llama-3",
+    ]
+
+
+def test_suggest_skips_name_fallback_when_name_too_short():
+    # A very short model name ("ab") makes a bare search too broad to be a useful
+    # "did you mean", so the name-only retry is skipped: only the full term runs.
+    with patch("huggingface_hub.list_models") as mock_list:
+        mock_list.return_value = _fake_models()
+        suggestions = _suggest_hf_model_ids("wrongorg/ab")
+
+    assert suggestions == []
+    assert mock_list.call_count == 1
+    assert mock_list.call_args.kwargs["search"] == "wrongorg/ab"
+
+
+def test_not_found_id_attaches_suggestions():
+    # A valid-format but nonexistent id fails at model_info (not the regex check),
+    # and should still get "did you mean" suggestions.
+    with (
+        patch("huggingface_hub.model_info", side_effect=_repo_not_found()),
+        patch("huggingface_hub.list_models") as mock_list,
+    ):
+        mock_list.return_value = _fake_models("meta-llama/Llama-3.2-1B")
+        result = _get_model_info_from_hf("meta-lama/Llama-3")
+
+    assert "error" in result
+    assert result["suggestions"] == ["meta-llama/Llama-3.2-1B"]
+
+
+def test_not_found_id_omits_suggestions_when_hub_errors():
+    with (
+        patch("huggingface_hub.model_info", side_effect=_repo_not_found()),
+        patch("huggingface_hub.list_models", side_effect=RuntimeError("offline")),
+    ):
+        result = _get_model_info_from_hf("meta-lama/Llama-3")
+
+    assert "error" in result
+    assert "suggestions" not in result
+
+
+def test_estimate_resources_surfaces_suggestions_on_not_found():
+    with (
+        patch("huggingface_hub.model_info", side_effect=_repo_not_found()),
+        patch("huggingface_hub.list_models") as mock_list,
+    ):
+        mock_list.return_value = _fake_models("meta-llama/Llama-3.2-1B")
+        result = estimate_resources("meta-lama/Llama-3")
+
+    assert result["success"] is False
+    assert result["details"]["suggestions"] == ["meta-llama/Llama-3.2-1B"]
+
+
+def test_non_not_found_error_skips_suggestions():
+    # Only a missing repo should trigger suggestions. Other failures (timeout,
+    # auth/rate-limit, metadata errors) surface unchanged and make no extra Hub
+    # request, so an outage or a gated model does not get misleading matches.
+    with (
+        patch("huggingface_hub.model_info", side_effect=TimeoutError("timed out")),
+        patch("huggingface_hub.list_models") as mock_list,
+    ):
+        result = _get_model_info_from_hf("meta-llama/Llama-3.2-1B")
+
+    assert "error" in result
+    assert "suggestions" not in result
+    mock_list.assert_not_called()
 
 
 # ─── Pure helpers (version parse / resource estimate) ───────────────────────

--- a/tests/unit/trainer/test_planning.py
+++ b/tests/unit/trainer/test_planning.py
@@ -17,6 +17,9 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import httpx
+from huggingface_hub.errors import RepositoryNotFoundError
+
 from kubeflow_mcp.trainer.api.planning import (
     _get_model_info_from_hf,
     _suggest_hf_model_ids,
@@ -26,6 +29,14 @@ from kubeflow_mcp.trainer.api.planning import (
 
 def _fake_models(*ids):
     return [SimpleNamespace(id=model_id) for model_id in ids]
+
+
+def _repo_not_found():
+    # The concrete exception model_info raises for a nonexistent repo.
+    request = httpx.Request("GET", "https://huggingface.co/api/models/x")
+    return RepositoryNotFoundError(
+        "Repository Not Found", response=httpx.Response(404, request=request)
+    )
 
 
 def test_suggest_normalizes_ollama_tag():
@@ -133,7 +144,7 @@ def test_not_found_id_attaches_suggestions():
     # A valid-format but nonexistent id fails at model_info (not the regex check),
     # and should still get "did you mean" suggestions.
     with (
-        patch("huggingface_hub.model_info", side_effect=RuntimeError("Repository Not Found")),
+        patch("huggingface_hub.model_info", side_effect=_repo_not_found()),
         patch("huggingface_hub.list_models") as mock_list,
     ):
         mock_list.return_value = _fake_models("meta-llama/Llama-3.2-1B")
@@ -145,7 +156,7 @@ def test_not_found_id_attaches_suggestions():
 
 def test_not_found_id_omits_suggestions_when_hub_errors():
     with (
-        patch("huggingface_hub.model_info", side_effect=RuntimeError("Repository Not Found")),
+        patch("huggingface_hub.model_info", side_effect=_repo_not_found()),
         patch("huggingface_hub.list_models", side_effect=RuntimeError("offline")),
     ):
         result = _get_model_info_from_hf("meta-lama/Llama-3")
@@ -156,7 +167,7 @@ def test_not_found_id_omits_suggestions_when_hub_errors():
 
 def test_estimate_resources_surfaces_suggestions_on_not_found():
     with (
-        patch("huggingface_hub.model_info", side_effect=RuntimeError("Repository Not Found")),
+        patch("huggingface_hub.model_info", side_effect=_repo_not_found()),
         patch("huggingface_hub.list_models") as mock_list,
     ):
         mock_list.return_value = _fake_models("meta-llama/Llama-3.2-1B")
@@ -164,3 +175,18 @@ def test_estimate_resources_surfaces_suggestions_on_not_found():
 
     assert result["success"] is False
     assert result["details"]["suggestions"] == ["meta-llama/Llama-3.2-1B"]
+
+
+def test_non_not_found_error_skips_suggestions():
+    # Only a missing repo should trigger suggestions. Other failures (timeout,
+    # auth/rate-limit, metadata errors) surface unchanged and make no extra Hub
+    # request, so an outage or a gated model does not get misleading matches.
+    with (
+        patch("huggingface_hub.model_info", side_effect=TimeoutError("timed out")),
+        patch("huggingface_hub.list_models") as mock_list,
+    ):
+        result = _get_model_info_from_hf("meta-llama/Llama-3.2-1B")
+
+    assert "error" in result
+    assert "suggestions" not in result
+    mock_list.assert_not_called()

--- a/tests/unit/trainer/test_planning.py
+++ b/tests/unit/trainer/test_planning.py
@@ -104,3 +104,63 @@ def test_estimate_resources_omits_suggestions_when_none_found():
 
     assert result["success"] is False
     assert "suggestions" not in result["details"]
+
+
+def test_suggest_ranks_by_downloads():
+    # Ranking by downloads surfaces canonical repos ahead of community fine-tunes.
+    with patch("huggingface_hub.list_models") as mock_list:
+        mock_list.return_value = _fake_models("Qwen/Qwen3-8B")
+        _suggest_hf_model_ids("qwen3:8b")
+
+    assert mock_list.call_args.kwargs.get("sort") == "downloads"
+
+
+def test_suggest_falls_back_to_model_name_when_org_typo_finds_nothing():
+    # A typo'd org (meta-lama vs meta-llama) makes the full "org/name" search
+    # empty; retry on just the model name so the user still gets a suggestion.
+    with patch("huggingface_hub.list_models") as mock_list:
+        mock_list.side_effect = [_fake_models(), _fake_models("meta-llama/Llama-3.2-1B")]
+        suggestions = _suggest_hf_model_ids("meta-lama/Llama-3")
+
+    assert suggestions == ["meta-llama/Llama-3.2-1B"]
+    assert [c.kwargs["search"] for c in mock_list.call_args_list] == [
+        "meta-lama/Llama-3",
+        "Llama-3",
+    ]
+
+
+def test_not_found_id_attaches_suggestions():
+    # A valid-format but nonexistent id fails at model_info (not the regex check),
+    # and should still get "did you mean" suggestions.
+    with (
+        patch("huggingface_hub.model_info", side_effect=RuntimeError("Repository Not Found")),
+        patch("huggingface_hub.list_models") as mock_list,
+    ):
+        mock_list.return_value = _fake_models("meta-llama/Llama-3.2-1B")
+        result = _get_model_info_from_hf("meta-lama/Llama-3")
+
+    assert "error" in result
+    assert result["suggestions"] == ["meta-llama/Llama-3.2-1B"]
+
+
+def test_not_found_id_omits_suggestions_when_hub_errors():
+    with (
+        patch("huggingface_hub.model_info", side_effect=RuntimeError("Repository Not Found")),
+        patch("huggingface_hub.list_models", side_effect=RuntimeError("offline")),
+    ):
+        result = _get_model_info_from_hf("meta-lama/Llama-3")
+
+    assert "error" in result
+    assert "suggestions" not in result
+
+
+def test_estimate_resources_surfaces_suggestions_on_not_found():
+    with (
+        patch("huggingface_hub.model_info", side_effect=RuntimeError("Repository Not Found")),
+        patch("huggingface_hub.list_models") as mock_list,
+    ):
+        mock_list.return_value = _fake_models("meta-llama/Llama-3.2-1B")
+        result = estimate_resources("meta-lama/Llama-3")
+
+    assert result["success"] is False
+    assert result["details"]["suggestions"] == ["meta-llama/Llama-3.2-1B"]


### PR DESCRIPTION
# Description
Follow-up to #43 (fix for #40), implementing the two enhancements from #65. Both improve the HuggingFace model-id suggestions that `pre_flight` / `estimate_resources` return for a bad model id.

## Type of Change
- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] revert: Revert a change
- [ ] chore: Maintenance / tooling

## Checklist
- [x] Tests pass locally (184 passing)
- [x] Linting passes (ruff check + ruff format + pre-commit, under both ruff 0.14.14 and 0.15.x)
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow conventional format

## Related Issues
Fixes #65

## Changes
1. **Rank suggestions by downloads.** `_suggest_hf_model_ids` now passes `sort="downloads"` to `list_models`, so canonical repos surface ahead of community fine-tunes.
2. **Suggest on the not-found path too.** A valid-format but nonexistent id (a typo like `meta-lama/Llama-3`) previously hit the `except` branch in `_get_model_info_from_hf` and returned only the raw Hub error. It now reuses `_suggest_hf_model_ids`. Since a typo in the org makes the full `org/name` search come back empty, the helper retries on just the model name so the user still gets a "did you mean".

## Verified end to end (live Hub)
```
estimate_resources("qwen3:8b")           # format branch, ranked
  -> ['Qwen/Qwen3-0.6B', 'Qwen/Qwen3-8B', 'Qwen/Qwen3-Embedding-0.6B']   (was community fine-tunes)

estimate_resources("meta-lama/Llama-3")  # not-found path, org typo -> name fallback
  -> ['meta-llama/Llama-3.2-1B-Instruct', 'meta-llama/Llama-3.1-8B-Instruct', 'meta-llama/Llama-3.2-3B-Instruct']
```

## Tests Added
Five new tests in `test_planning.py` (mocking `list_models` / `model_info`): download ranking, the org-typo name fallback, not-found suggestions at both the helper and the `estimate_resources` boundary, and graceful omission when the Hub errors.
