### PR TITLE
chore(docs): add ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,8 @@
+# Adopters of Kubeflow MCP Server
+
+Below are the adopters of Kubeflow MCP Server. If you are using this project in your organization, please add your name to the list by submitting a pull request: this will help foster the Kubeflow community. Kindly ensure the list remains in alphabetical order.
+If you are using other Kubeflow components, consider adding your name as well to the overall [Kubeflow Community Adopters file](https://github.com/kubeflow/community/blob/master/ADOPTERS.md).
+
+| Organization | Contact (GitHub User Name) | Environment | Description of Use |
+|------------------------------------|----------------------------------------|---------------|----------------------------------------------------------------------------------------------|
+| *your organization* | *your GitHub handle* | *your setup* | *brief description* |


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
Add `ADOPTERS.md` listing organizations using the Kubeflow MCP Server, following the kubeflow/sdk pattern. Includes a placeholder row so adopters can self-register via PR. Helps CNCF graduation evidence and community visibility.

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #57

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)
