### PR TITLE
chore(ci): align pre-commit config with Kubeflow-SDK Introduced check-added-large-files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,3 @@ repos:
         args: [--fix]
       # Format after fixes
       - id: ruff-format
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,13 @@ repos:
         args: [--allow-multiple-documents]
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: check-added-large-files
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.14
     hooks:
       # Lint + auto-fix (must run before format)
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       # Format after fixes
       - id: ruff-format
+


### PR DESCRIPTION
## Description

Update `.pre-commit-config.yaml` to match kubeflow/sdk and close the remaining gaps from #60:

- Add `check-added-large-files`
- Rename deprecated `ruff` hook id to `ruff-check`

Note: the config file already existed; this PR completes the issue requirements rather than adding it from scratch.

## Related Issue

Fixes #60

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

Ran `uv run pre-commit run --all-files` (or `make verify`) after the hook id change.