### PR TITLE
feat(ci): add MCP protocol conformance tests

### DIFF
--- a/.github/scripts/compare_versions.py
+++ b/.github/scripts/compare_versions.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+Compare PEP 440 versions.
+
+Usage:
+    python compare_versions.py <current_version> <target_version>
+
+Exit codes:
+    0 - current_version < target_version (upgrade needed)
+    1 - current_version >= target_version (no upgrade needed)
+    2 - error parsing versions
+"""
+
+import sys
+
+from packaging.version import InvalidVersion, Version
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: compare_versions.py <current_version> <target_version>", file=sys.stderr)
+        sys.exit(2)
+
+    current_str = sys.argv[1]
+    target_str = sys.argv[2]
+
+    try:
+        current = Version(current_str)
+        target = Version(target_str)
+
+        # Exit 0 if current < target (upgrade needed)
+        # Exit 1 if current >= target (no upgrade needed)
+        sys.exit(0 if current < target else 1)
+    except InvalidVersion as e:
+        print(f"Error: Invalid version format - {e}", file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/extract_version.py
+++ b/.github/scripts/extract_version.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+Extract package version from uv tree output.
+
+This script parses uv tree output to extract the full version
+(including pre-release, post-release, dev versions) of a package.
+
+Usage:
+    uv tree --package <package> | python extract_version.py <package>
+
+Exit codes:
+    0 - version found and printed to stdout
+    1 - version not found or error
+"""
+
+import re
+import sys
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: uv tree --package <pkg> | extract_version.py <pkg>", file=sys.stderr)
+        sys.exit(1)
+
+    package_name = sys.argv[1]
+
+    # Read from stdin (piped from uv tree)
+    tree_output = sys.stdin.read()
+
+    # Look for pattern: "package_name vX.Y.Z"
+    # Using non-greedy match to get version until whitespace
+    pattern = rf"{re.escape(package_name)}\s+v([^\s]+)"
+    match = re.search(pattern, tree_output)
+
+    if match:
+        version = match.group(1)
+        print(version)
+        sys.exit(0)
+    else:
+        print(f"Error: Could not find version for {package_name}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/update_overrides.py
+++ b/.github/scripts/update_overrides.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Update override-dependencies in pyproject.toml.
+
+This script manages the [tool.uv] override-dependencies section by:
+1. Reading existing overrides
+2. Adding or updating a package override
+3. Rewriting the entire section in consistent multi-line format
+
+Usage:
+    python update_overrides.py <package> <target> <date> <advisory_url>
+
+Example:
+    python update_overrides.py requests "requests==2.31.0" "2025-01-15" "https://..."
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def parse_existing_overrides(content):
+    """Parse existing [tool.uv] override-dependencies into {pkg_name: (spec, comment)}.
+
+    Handles both single-line (`override-dependencies = ["pkg==1.0"]`) and
+    multi-line array formats. Returns an empty dict when no overrides exist.
+    """
+    overrides = {}
+    if "override-dependencies" not in content:
+        return overrides
+
+    in_override = False
+    last_comment = None
+    for line in content.split("\n"):
+        if "override-dependencies" in line and "=" in line:
+            in_override = True
+            # Check if it's a single-line array: override-dependencies = ["pkg1", "pkg2"]
+            single_line_match = re.search(r"override-dependencies\s*=\s*\[(.*?)\]", line)
+            if single_line_match:
+                # Parse all packages from single line
+                for pkg_match in re.finditer(r'"([^"]+)"', single_line_match.group(1)):
+                    spec = pkg_match.group(1)
+                    pkg_name = spec.split("==")[0] if "==" in spec else spec.split("[")[0]
+                    overrides[pkg_name] = (spec, None)
+                break  # Single-line format, done parsing
+            continue
+        if in_override:
+            if line.strip() == "]":
+                break
+            # Check for comment lines
+            if line.strip().startswith("#"):
+                last_comment = line.strip()
+                continue
+            # Extract package spec
+            match = re.search(r'"([^"]+)"', line)
+            if match:
+                spec = match.group(1)
+                pkg_name = spec.split("==")[0] if "==" in spec else spec.split("[")[0]
+                overrides[pkg_name] = (spec, last_comment)
+                last_comment = None
+    return overrides
+
+
+def main():
+    if len(sys.argv) != 5:
+        print(
+            "Usage: update_overrides.py <package> <target> <date> <advisory_url>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    package = sys.argv[1]
+    target = sys.argv[2]
+    current_date = sys.argv[3]
+    advisory_url = sys.argv[4]
+
+    pyproject_path = Path("pyproject.toml")
+    if not pyproject_path.exists():
+        print(f"Error: {pyproject_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    # Read current pyproject.toml
+    content = pyproject_path.read_text()
+
+    comment = f"# {target} - Added {current_date} for security fix - {advisory_url}"
+
+    # Extract existing override-dependencies
+    has_tool_uv = "[tool.uv]" in content
+    has_overrides = "override-dependencies" in content
+    overrides = parse_existing_overrides(content)
+
+    # Add or update the current package
+    overrides[package] = (target, comment)
+
+    # Rebuild pyproject.toml
+    if not has_tool_uv:
+        # Add a bare [tool.uv] section at the end; the header comment and
+        # override-dependencies array are inserted by the logic below. (Adding
+        # the header here too would duplicate the whole block -> invalid TOML.)
+        content += "\n[tool.uv]\n"
+        has_tool_uv = True
+
+    if has_overrides:
+        # Remove old override-dependencies section (handles both single-line and multi-line)
+        # Single-line: override-dependencies = ["pkg==1.0"]
+        # Multi-line: override-dependencies = [\n    "pkg",\n]
+        content = re.sub(
+            r"^override-dependencies\s*=\s*\[.*?\]",
+            "",
+            content,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        # Also remove any orphaned comments before override-dependencies
+        content = re.sub(
+            r"^# Security overrides.*?\n(?:[ \t]*\n)?",
+            "",
+            content,
+            flags=re.MULTILINE,
+        )
+
+        # Re-add the header after [tool.uv] so insertion logic stays consistent
+        content = re.sub(
+            r"(\[tool\.uv\]\r?\n)",
+            r"\1# Security overrides - Review periodically and remove "
+            r"if parent constraints allow natural upgrade\n",
+            content,
+            count=1,
+        )
+
+    # Find [tool.uv] and insert override-dependencies
+    if not has_overrides and has_tool_uv:
+        # Insert after [tool.uv]
+        content = re.sub(
+            r"(\[tool\.uv\]\r?\n)",
+            r"\1# Security overrides - Review periodically and remove if parent constraints allow natural upgrade\n",
+            content,
+        )
+
+    # Build override-dependencies array
+    override_lines = ["override-dependencies = ["]
+    for _pkg_name, (spec, pkg_comment) in sorted(overrides.items()):
+        if pkg_comment:
+            override_lines.append(f"    {pkg_comment}")
+        override_lines.append(f'    "{spec}",')
+    override_lines.append("]")
+    override_block = "\n".join(override_lines)
+
+    # Insert after [tool.uv] or the header comment
+    if "# Security overrides" in content:
+        content = re.sub(r"(# Security overrides.*?\r?\n)", r"\1" + override_block + "\n", content)
+    else:
+        content = re.sub(r"(\[tool\.uv\]\r?\n)", r"\1" + override_block + "\n", content, count=1)
+
+    # Write back
+    pyproject_path.write_text(content)
+    print(f"Updated override-dependencies with {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/update_overrides.py
+++ b/.github/scripts/update_overrides.py
@@ -104,15 +104,17 @@ def main():
         # Remove old override-dependencies section (handles both single-line and multi-line)
         # Single-line: override-dependencies = ["pkg==1.0"]
         # Multi-line: override-dependencies = [\n    "pkg",\n]
+        # Leading [ \t]* so an indented key (valid TOML) is still matched and
+        # removed; otherwise the old block survives and we emit a duplicate key.
         content = re.sub(
-            r"^override-dependencies\s*=\s*\[.*?\]",
+            r"^[ \t]*override-dependencies\s*=\s*\[.*?\]",
             "",
             content,
             flags=re.MULTILINE | re.DOTALL,
         )
         # Also remove any orphaned comments before override-dependencies
         content = re.sub(
-            r"^# Security overrides.*?\n(?:[ \t]*\n)?",
+            r"^[ \t]*# Security overrides.*?\n(?:[ \t]*\n)?",
             "",
             content,
             flags=re.MULTILINE,

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -1,0 +1,77 @@
+name: MCP Conformance
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    name: Protocol conformance (streamable HTTP)
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install package
+        run: uv sync --all-extras
+
+      # Start the server over streamable HTTP with no kubeconfig / no cluster.
+      # health_check and all tools degrade gracefully when K8s is unreachable,
+      # so the server starts and answers initialize/tools-list without a cluster.
+      - name: Start MCP server
+        env:
+          KUBECONFIG: /nonexistent
+        run: |
+          uv run kubeflow-mcp serve --transport http --no-banner > server.log 2>&1 &
+          echo $! > server.pid
+
+      # FastMCP streamable-HTTP has no plain health endpoint, so probe the MCP
+      # endpoint with a real initialize request and wait for HTTP 200.
+      - name: Wait for server
+        run: |
+          timeout 60 bash -c 'until curl -sf -o /dev/null \
+            http://localhost:8000/mcp \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\",\"capabilities\":{},\"clientInfo\":{\"name\":\"ci\",\"version\":\"1\"}}}"; \
+            do sleep 1; done'
+
+      - name: Run MCP conformance suite
+        uses: modelcontextprotocol/conformance@v0.1.16
+        with:
+          mode: server
+          url: http://localhost:8000/mcp
+          suite: active
+          expected-failures: tests/conformance/expected-failures.yaml
+          node-version: 22
+
+      - name: Dump server logs
+        if: always()
+        run: cat server.log || true
+
+      - name: Stop MCP server
+        if: always()
+        run: |
+          if [ -f server.pid ]; then
+            kill "$(cat server.pid)" 2>/dev/null || true
+          fi

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -1,0 +1,235 @@
+name: OSV-Scanner Vulnerability Scan
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  osv-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install OSV-Scanner
+        # Bump cadence: check https://github.com/google/osv-scanner/releases monthly
+        # Dependabot cannot bump curl-installed binaries — update version + checksum manually
+        run: |
+          OSV_VERSION="2.3.8"
+          EXPECTED_SHA="bc98e15319ed0d515e3f9235287ba53cdc5535d576d24fd573978ecfe9ab92dc"
+          curl -fsSL "https://github.com/google/osv-scanner/releases/download/v${OSV_VERSION}/osv-scanner_linux_amd64" -o osv-scanner
+          ACTUAL_SHA=$(sha256sum osv-scanner | awk '{print $1}')
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::OSV-Scanner checksum mismatch! Expected ${EXPECTED_SHA}, got ${ACTUAL_SHA}"
+            exit 1
+          fi
+          chmod +x osv-scanner
+          sudo mv osv-scanner /usr/local/bin/
+
+      - name: Run OSV-Scanner (SARIF for Security Tab)
+        # continue-on-error so a SARIF failure doesn't block the JSON scan + auto-fix below
+        continue-on-error: true
+        run: |
+          rc=0
+          osv-scanner scan \
+            --format sarif \
+            --output osv-results.sarif \
+            -L uv.lock || rc=$?
+          # Exit code 1 = vulns found (expected), 0 = clean. Any other code is a real failure.
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+            echo "::error::OSV-Scanner failed with unexpected exit code $rc"
+            exit 1
+          fi
+
+      - name: Upload SARIF to GitHub Security tab
+        if: always() && hashFiles('osv-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: osv-results.sarif
+          category: kubeflow-mcp-osv-scanner
+
+      - name: Run OSV-Scanner (JSON for auto-fix)
+        run: |
+          rc=0
+          osv-scanner scan \
+            --format json \
+            --output osv-results.json \
+            -L uv.lock || rc=$?
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+            echo "::error::OSV-Scanner failed with unexpected exit code $rc"
+            exit 1
+          fi
+          # Validate JSON output is parseable before downstream steps consume it
+          if [ -f osv-results.json ] && [ -s osv-results.json ]; then
+            jq empty osv-results.json
+          fi
+
+      - name: Process vulnerabilities and apply fixes
+        id: fixer
+        run: |
+          if [ ! -f osv-results.json ] || [ ! -s osv-results.json ]; then
+            echo "No scan results found."
+            echo "updates_found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          CURRENT_DATE=$(date +%Y-%m-%d)
+
+          # Extract fixable vulnerabilities: package name, current version, fix version, advisory ID, URL
+          # The OSV JSON embeds full advisory objects; fixed versions are in affected[].ranges[].events
+          # Use group_by + last to deduplicate: keep the highest fix version per package+advisory pair
+          FIX_DATA=$(jq -r '
+            [
+              .results[]?.packages[]? |
+              .package as $pkg |
+              .vulnerabilities[]? |
+              . as $vuln |
+              .affected[]? |
+              select(.package.name == $pkg.name) |
+              .ranges[]? |
+              .events[] |
+              select(.fixed != null) |
+              {
+                pkg: $pkg.name,
+                ver: $pkg.version,
+                fix: .fixed,
+                id: $vuln.id,
+                url: ($vuln.references[0].url // "https://osv.dev/vulnerability/\($vuln.id)")
+              }
+            ] |
+            group_by([.pkg, .id]) |
+            map(sort_by(.fix | split(".") | map(tonumber? // 0)) | last) |
+            .[] |
+            "\(.pkg)|\(.ver)|\(.fix)|\(.id)|\(.url)"
+          ' osv-results.json 2>/dev/null | sort -u)
+
+          if [ -z "$FIX_DATA" ]; then
+            echo "No fixable vulnerabilities found."
+            echo "updates_found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Fixable vulnerabilities found:"
+          echo "$FIX_DATA"
+          echo ""
+
+          rm -f applied_fixes.txt
+
+          while IFS='|' read -r pkg current_ver fix_ver advisory_id advisory_url; do
+            [ -z "$pkg" ] && continue
+
+            echo ""
+            echo "=== Processing: $pkg $current_ver -> $fix_ver ($advisory_id) ==="
+
+            # Try natural upgrade first
+            echo "Attempting: uv lock --upgrade-package $pkg"
+            LOCK_RC=0
+            uv lock --upgrade-package "$pkg" 2>&1 || LOCK_RC=$?
+            if [ "$LOCK_RC" -ne 0 ]; then
+              echo "Warning: uv lock failed for $pkg (exit code $LOCK_RC), skipping"
+              continue
+            fi
+
+            # Check resulting version
+            TREE_RC=0
+            TREE_OUTPUT=$(uv tree --package "$pkg" 2>&1) || TREE_RC=$?
+            if [ "$TREE_RC" -ne 0 ]; then
+              echo "Warning: uv tree failed for $pkg (exit code $TREE_RC), skipping"
+              continue
+            fi
+            EXTRACT_RC=0
+            NATURAL_VER=$(echo "$TREE_OUTPUT" | uv run python3 .github/scripts/extract_version.py "$pkg") || EXTRACT_RC=$?
+            if [ "$EXTRACT_RC" -ne 0 ]; then
+              echo "Warning: Could not parse version for $pkg from uv tree output, skipping"
+              continue
+            fi
+
+            if [ -z "$NATURAL_VER" ]; then
+              echo "Warning: Could not determine version for $pkg after upgrade"
+              continue
+            fi
+
+            echo "Natural upgrade resulted in version: $NATURAL_VER"
+
+            # Compare: does natural version meet the fix?
+            # compare_versions.py exits: 0 = upgrade needed, 1 = sufficient, 2 = parse error
+            CMP_EXIT=0
+            uv run python3 .github/scripts/compare_versions.py "$NATURAL_VER" "$fix_ver" || CMP_EXIT=$?
+
+            if [ "$CMP_EXIT" -eq 2 ]; then
+              echo "Warning: Could not parse versions for $pkg ($NATURAL_VER vs $fix_ver), skipping"
+              continue
+            elif [ "$CMP_EXIT" -eq 0 ]; then
+              # NATURAL_VER < fix_ver — natural upgrade insufficient, add override
+              echo "Natural upgrade insufficient ($NATURAL_VER < $fix_ver). Adding override..."
+              uv run python3 .github/scripts/update_overrides.py "$pkg" "${pkg}==${fix_ver}" "$CURRENT_DATE" "$advisory_url"
+              LOCK_RC=0
+              uv lock --upgrade-package "$pkg" 2>&1 || LOCK_RC=$?
+              if [ "$LOCK_RC" -ne 0 ]; then
+                echo "Warning: uv lock failed after adding override for $pkg (exit code $LOCK_RC), skipping"
+                continue
+              fi
+              printf '%s\n' "- ${pkg}==${fix_ver} (override) | [$advisory_id]($advisory_url)" >> applied_fixes.txt
+            else
+              # NATURAL_VER >= fix_ver — natural upgrade worked
+              echo "Natural upgrade sufficient ($NATURAL_VER >= $fix_ver)"
+              printf '%s\n' "- ${pkg}==${NATURAL_VER} (upgraded) | [$advisory_id]($advisory_url)" >> applied_fixes.txt
+            fi
+          done <<< "$FIX_DATA"
+
+          if [ ! -s applied_fixes.txt ]; then
+            echo "No fixes were applied."
+            echo "updates_found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "updates_found=true" >> $GITHUB_OUTPUT
+          {
+            echo "fix_details<<EOF"
+            cat applied_fixes.txt
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.fixer.outputs.updates_found == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "fix: nightly automated dependency update for security vulnerabilities"
+          title: "fix: nightly security dependency updates"
+          add-paths: |
+            pyproject.toml
+            uv.lock
+          body: |
+            ## Security Update
+
+            This is an automated PR triggered by the nightly OSV-Scanner security scan.
+
+            The following dependencies were updated to resolve known vulnerabilities:
+
+            | Package & Version | Advisory Link |
+            | :--- | :--- |
+            ${{ steps.fixer.outputs.fix_details }}
+
+            **Verification:** Updated via `uv lock --upgrade-package` or `override-dependencies`.
+
+            > **Note:** This PR was created with `GITHUB_TOKEN`, which does not trigger `pull_request` workflows.
+            > CI checks will not run automatically. Push an empty commit (`git commit --allow-empty -m "trigger CI"`)
+            > to kick off CI before merging.
+            >
+            > **TODO:** Migrate to a GitHub App token via `actions/create-github-app-token` to trigger CI automatically.
+          branch: security-nightly-updates
+          delete-branch: true
+          labels: |
+            area/security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,12 +80,19 @@ it to answer `initialize`, then runs the conformance `active` suite against
 
 **Baseline file.** `tests/conformance/expected-failures.yaml` lists scenarios
 that are allowed to fail — these are known spec gaps for this server (mostly
-scenarios that assume the reference server's test fixtures, a few unadvertised
-capabilities, and one DNS-rebinding hardening follow-up). Every scenario *not*
-listed must pass, and CI also fails if a listed scenario unexpectedly starts
-passing. When you add protocol features, remove the now-passing scenarios from
-the baseline; if you intentionally change behavior, update the list with a
-one-line reason.
+scenarios that assume the reference server's test fixtures, plus a few
+unadvertised capabilities). Every scenario *not* listed must pass, and CI also
+fails if a listed scenario unexpectedly starts passing. When you add protocol
+features, remove the now-passing scenarios from the baseline; if you
+intentionally change behavior, update the list with a one-line reason.
+
+**DNS rebinding protection.** The HTTP/SSE transports validate the `Host` and
+`Origin` headers (`kubeflow_mcp/core/transport_security.py`) so a locally-bound
+server cannot be reached by a malicious web page via DNS rebinding. Protection
+is on by default and allows loopback hosts; override the allowlists with
+`KUBEFLOW_MCP_ALLOWED_HOSTS` / `KUBEFLOW_MCP_ALLOWED_ORIGINS` (comma-separated,
+`:*` port wildcard supported) when serving on a non-loopback address, or set
+`KUBEFLOW_MCP_DNS_REBINDING_PROTECTION=false` to disable it (not recommended).
 
 ## Commit Messages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,34 @@ To run unit tests locally, use the following `make` command:
 make test-python
 ```
 
+### Conformance Testing
+
+We validate that the server correctly implements the MCP protocol
+(`initialize`, `tools/list`, `tools/call`, etc.) using the official
+[MCP conformance framework](https://github.com/modelcontextprotocol/conformance).
+This runs in CI on every PR (`.github/workflows/conformance.yaml`) and needs
+**no Kubernetes cluster and no LLM** — the server starts against an unreachable
+cluster and its tools degrade gracefully.
+
+To run the same suite locally (requires Node.js 20+):
+
+```bash
+make conformance
+```
+
+This starts `kubeflow-mcp serve --transport http` in the background, waits for
+it to answer `initialize`, then runs the conformance `active` suite against
+`http://localhost:8000/mcp`.
+
+**Baseline file.** `tests/conformance/expected-failures.yaml` lists scenarios
+that are allowed to fail — these are known spec gaps for this server (mostly
+scenarios that assume the reference server's test fixtures, a few unadvertised
+capabilities, and one DNS-rebinding hardening follow-up). Every scenario *not*
+listed must pass, and CI also fails if a listed scenario unexpectedly starts
+passing. When you add protocol features, remove the now-passing scenarios from
+the baseline; if you intentionally change behavior, update the list with a
+one-line reason.
+
 ## Commit Messages
 
 We use [Conventional Commits](https://www.conventionalcommits.org/):

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,18 @@ install-dev: uv ## Install dependencies and tools
 	@uv sync --all-extras
 	@echo "Environment is ready."
 
+.PHONY: conformance
+conformance: install-dev ## Run MCP protocol conformance suite against a local HTTP server
+	@echo "Starting kubeflow-mcp on http://localhost:8000/mcp (no cluster required)..."
+	@KUBECONFIG=/nonexistent uv run kubeflow-mcp serve --transport http --no-banner > /tmp/kubeflow-mcp-conformance.log 2>&1 & \
+	  SERVER_PID=$$!; \
+	  trap "kill $$SERVER_PID 2>/dev/null || true" EXIT; \
+	  timeout 60 bash -c 'until curl -sf -o /dev/null http://localhost:8000/mcp -X POST -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\",\"capabilities\":{},\"clientInfo\":{\"name\":\"make\",\"version\":\"1\"}}}"; do sleep 1; done'; \
+	  npx -y @modelcontextprotocol/conformance@0.1.16 server \
+	    --url http://localhost:8000/mcp \
+	    --suite active \
+	    --expected-failures tests/conformance/expected-failures.yaml
+
 TRANSPORT ?= stdio
 
 .PHONY: inspector

--- a/kubeflow_mcp/cli.py
+++ b/kubeflow_mcp/cli.py
@@ -151,6 +151,7 @@ def serve(
     )
 
     auth_provider = None
+    http_middleware = None
     if transport != "stdio":
         auth_provider = build_auth_provider(cfg.auth)
         if auth_provider is None:
@@ -158,6 +159,27 @@ def serve(
                 "HTTP transport with no auth configured — server is open. "
                 "Set --auth-token or KUBEFLOW_MCP_AUTH_TOKEN for bearer auth, "
                 "or KUBEFLOW_MCP_JWKS_URI for JWT verification."
+            )
+
+        from starlette.middleware import Middleware
+
+        from kubeflow_mcp.core.transport_security import (
+            DNSRebindingProtectionMiddleware,
+            build_transport_security_settings,
+        )
+
+        security_settings = build_transport_security_settings(cfg.security)
+        if security_settings.enable_dns_rebinding_protection:
+            http_middleware = [
+                Middleware(
+                    DNSRebindingProtectionMiddleware,
+                    settings=security_settings,
+                )
+            ]
+        else:
+            logger.warning(
+                "DNS rebinding protection is disabled — set "
+                "KUBEFLOW_MCP_DNS_REBINDING_PROTECTION=true to re-enable it."
             )
 
     client_list = [c.strip() for c in clients.split(",")]
@@ -173,9 +195,13 @@ def serve(
     if transport == "stdio":
         server.run(show_banner=show_banner)
     elif transport == "sse":
-        server.run(transport="sse", show_banner=show_banner)
+        server.run(transport="sse", show_banner=show_banner, middleware=http_middleware)
     else:
-        server.run(transport="streamable-http", show_banner=show_banner)
+        server.run(
+            transport="streamable-http",
+            show_banner=show_banner,
+            middleware=http_middleware,
+        )
 
 
 @cli.command()

--- a/kubeflow_mcp/core/config.py
+++ b/kubeflow_mcp/core/config.py
@@ -112,6 +112,23 @@ class AuthConfig(BaseModel):
     audience: str | None = Field(default=None)
 
 
+class SecurityConfig(BaseModel):
+    """HTTP transport security (DNS rebinding protection).
+
+    Validates the ``Host`` and ``Origin`` headers of incoming HTTP requests so a
+    malicious web page cannot use DNS rebinding to reach a locally-bound server.
+    Only applies to the ``http``/``sse`` transports; ``stdio`` has no HTTP surface.
+
+    ``allowed_hosts``/``allowed_origins`` support an exact match or a ``:*`` port
+    wildcard (e.g. ``localhost:*``). When left empty they default to loopback
+    values, which is correct for the default ``127.0.0.1`` bind used in dev and CI.
+    """
+
+    enable_dns_rebinding_protection: bool = Field(default=True)
+    allowed_hosts: list[str] = Field(default_factory=list)
+    allowed_origins: list[str] = Field(default_factory=list)
+
+
 class ResilienceConfig(BaseModel):
     """Rate limiter and circuit breaker tuning."""
 
@@ -140,6 +157,7 @@ class Config(BaseModel):
 
     server: ServerConfig = Field(default_factory=ServerConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
+    security: SecurityConfig = Field(default_factory=SecurityConfig)
     resilience: ResilienceConfig = Field(default_factory=ResilienceConfig)
     trainer: TrainerConfig = Field(default_factory=TrainerConfig)
     optimizer: OptimizerConfig = Field(default_factory=OptimizerConfig)
@@ -254,6 +272,29 @@ def load_config(config_path: Path | None = None) -> Config:
         audience=os.getenv("KUBEFLOW_MCP_JWT_AUDIENCE", auth_file.get("audience")),
     )
 
+    security_file = file_config.get("security", {})
+
+    def _csv_env(name: str, file_default: list[str]) -> list[str]:
+        raw = os.getenv(name)
+        if raw is None:
+            return list(file_default)
+        return [item.strip() for item in raw.split(",") if item.strip()]
+
+    dns_protect_env = os.getenv("KUBEFLOW_MCP_DNS_REBINDING_PROTECTION")
+    security = SecurityConfig(
+        enable_dns_rebinding_protection=(
+            dns_protect_env.strip().lower() not in {"0", "false", "no", "off"}
+            if dns_protect_env is not None
+            else security_file.get("enable_dns_rebinding_protection", True)
+        ),
+        allowed_hosts=_csv_env(
+            "KUBEFLOW_MCP_ALLOWED_HOSTS", security_file.get("allowed_hosts", [])
+        ),
+        allowed_origins=_csv_env(
+            "KUBEFLOW_MCP_ALLOWED_ORIGINS", security_file.get("allowed_origins", [])
+        ),
+    )
+
     resilience_file = file_config.get("resilience", {})
     resilience = ResilienceConfig(
         rate_limit=float(
@@ -279,6 +320,7 @@ def load_config(config_path: Path | None = None) -> Config:
     return Config(
         server=server,
         auth=auth,
+        security=security,
         resilience=resilience,
         trainer=trainer,
         optimizer=optimizer,

--- a/kubeflow_mcp/core/transport_security.py
+++ b/kubeflow_mcp/core/transport_security.py
@@ -1,0 +1,102 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DNS rebinding protection for the HTTP/SSE transports.
+
+FastMCP's streamable-HTTP transport does not validate the ``Host``/``Origin``
+headers by default, so a page loaded in a victim's browser could use DNS
+rebinding to reach a locally-bound server. This module rejects requests whose
+``Host``/``Origin`` are not on an allowlist before they reach the MCP handler.
+
+The header validation itself is delegated to the MCP SDK's reference
+implementation (:class:`mcp.server.transport_security.TransportSecurityMiddleware`)
+so behaviour matches the protocol conformance suite: an invalid ``Host`` yields
+``421``, an invalid ``Origin`` yields ``403``, and a POST without a JSON
+``Content-Type`` yields ``400``.
+
+The middleware is implemented as a pure-ASGI wrapper (rather than
+``BaseHTTPMiddleware``) so it does not buffer the streaming SSE responses the
+transport relies on — it only inspects request headers and either short-circuits
+with an error response or passes the untouched send/receive channels through.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from mcp.server.transport_security import (
+    TransportSecurityMiddleware,
+    TransportSecuritySettings,
+)
+from starlette.requests import Request
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+if TYPE_CHECKING:
+    from kubeflow_mcp.core.config import SecurityConfig
+
+logger = logging.getLogger(__name__)
+
+# Loopback defaults used when no explicit allowlist is configured. These cover
+# the default 127.0.0.1 bind used in local development and CI. The ``:*`` suffix
+# matches any port. An absent Origin (typical for non-browser MCP clients) is
+# always allowed by the SDK validator.
+_DEFAULT_ALLOWED_HOSTS = ["127.0.0.1", "localhost", "127.0.0.1:*", "localhost:*"]
+_DEFAULT_ALLOWED_ORIGINS = [
+    "http://127.0.0.1",
+    "http://localhost",
+    "http://127.0.0.1:*",
+    "http://localhost:*",
+]
+
+
+def build_transport_security_settings(
+    config: SecurityConfig,
+) -> TransportSecuritySettings:
+    """Translate our ``SecurityConfig`` into the SDK's transport settings.
+
+    Falls back to loopback defaults when the allowlists are left empty so
+    protection is on out of the box for the default bind.
+    """
+    allowed_hosts = config.allowed_hosts or _DEFAULT_ALLOWED_HOSTS
+    allowed_origins = config.allowed_origins or _DEFAULT_ALLOWED_ORIGINS
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=config.enable_dns_rebinding_protection,
+        allowed_hosts=allowed_hosts,
+        allowed_origins=allowed_origins,
+    )
+
+
+class DNSRebindingProtectionMiddleware:
+    """Pure-ASGI middleware that validates Host/Origin before the MCP handler."""
+
+    def __init__(self, app: ASGIApp, settings: TransportSecuritySettings) -> None:
+        self.app = app
+        self._validator = TransportSecurityMiddleware(settings)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Reading headers off the scope does not consume the receive channel, so
+        # the downstream app still gets the full request body.
+        request = Request(scope, receive)
+        is_post = scope.get("method") == "POST"
+        error = await self._validator.validate_request(request, is_post=is_post)
+        if error is not None:
+            await error(scope, receive, send)
+            return
+
+        await self.app(scope, receive, send)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dev = [
     "pytest-asyncio>=0.23",
     "pytest-cov>=4.0",
     "ruff>=0.9",
-    "pip-audit>=2.7",
 ]
 docs = [
     "sphinx>=7.0",

--- a/tests/conformance/expected-failures.yaml
+++ b/tests/conformance/expected-failures.yaml
@@ -1,0 +1,65 @@
+# MCP conformance baseline — known spec gaps for kubeflow-mcp.
+#
+# The conformance runner (modelcontextprotocol/conformance) executes the
+# "active" suite against the running server over streamable HTTP. Scenarios
+# listed here are allowed to fail without failing CI; every scenario NOT listed
+# here must pass. The runner also fails if a listed scenario starts *passing*,
+# so this file catches both regressions and unexpected improvements.
+#
+# How to regenerate: run `make conformance` locally (see CONTRIBUTING.md), then
+# move any newly-failing scenario into this list with a one-line reason, or
+# remove a scenario that now passes.
+#
+# Every entry below is a legitimate gap for THIS server, not a protocol bug:
+#   - Most "active" scenarios assume the reference test server's fixtures
+#     (a resource named `test://static-text`, a prompt `test_simple_prompt`,
+#     tools that return images/audio/progress, etc.). kubeflow-mcp exposes real
+#     Kubeflow tools instead, so these fixture-driven scenarios can never pass.
+#   - A few exercise MCP capabilities this server does not advertise
+#     (completions, sampling, elicitation).
+#   - One (dns-rebinding-protection) is a real hardening gap in the FastMCP
+#     streamable-HTTP default — tracked as a follow-up, see reason below.
+
+server:
+  # --- Capabilities not advertised by this server ---
+  # Completions capability is not implemented (JSON-RPC -32601 Method not found).
+  - completion-complete
+  # Server never issues sampling requests from within a tool call.
+  - tools-call-sampling
+  # Server never issues elicitation requests from within a tool call.
+  - tools-call-elicitation
+  - elicitation-sep1034-defaults
+  - elicitation-sep1330-enums
+
+  # --- Fixture-driven tool scenarios (no matching tool on this server) ---
+  # These expect reference-server tools that return specific content types or
+  # emit progress/logging notifications; kubeflow-mcp's tools return text.
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-with-logging
+  - tools-call-with-progress
+
+  # --- Fixture-driven resource scenarios (reference-server URIs absent) ---
+  # e.g. resources-read-text expects `test://static-text`. This server exposes
+  # its own Kubeflow resources and does not implement resource subscriptions.
+  - resources-read-text
+  - resources-read-binary
+  - resources-templates-read
+  - resources-subscribe
+  - resources-unsubscribe
+
+  # --- Fixture-driven prompt scenarios (reference-server prompts absent) ---
+  # e.g. prompts-get-simple expects `test_simple_prompt`.
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image
+
+  # --- Real hardening gap (follow-up) ---
+  # FastMCP's streamable-HTTP transport does not validate the Host/Origin header,
+  # so it accepts requests with a non-localhost Host (HTTP 200 instead of 4xx),
+  # leaving a localhost, unauthenticated server open to DNS-rebinding attacks.
+  # See: https://github.com/modelcontextprotocol/typescript-sdk/security/advisories/GHSA-w48q-cv73-mx4w
+  - dns-rebinding-protection

--- a/tests/conformance/expected-failures.yaml
+++ b/tests/conformance/expected-failures.yaml
@@ -17,8 +17,10 @@
 #     Kubeflow tools instead, so these fixture-driven scenarios can never pass.
 #   - A few exercise MCP capabilities this server does not advertise
 #     (completions, sampling, elicitation).
-#   - One (dns-rebinding-protection) is a real hardening gap in the FastMCP
-#     streamable-HTTP default — tracked as a follow-up, see reason below.
+#
+# Note: dns-rebinding-protection is intentionally NOT baselined — this server
+# enforces Host/Origin validation (see kubeflow_mcp/core/transport_security.py),
+# so that scenario is a required pass and CI must flag any regression.
 
 server:
   # --- Capabilities not advertised by this server ---
@@ -56,10 +58,3 @@ server:
   - prompts-get-with-args
   - prompts-get-embedded-resource
   - prompts-get-with-image
-
-  # --- Real hardening gap (follow-up) ---
-  # FastMCP's streamable-HTTP transport does not validate the Host/Origin header,
-  # so it accepts requests with a non-localhost Host (HTTP 200 instead of 4xx),
-  # leaving a localhost, unauthenticated server open to DNS-rebinding attacks.
-  # See: https://github.com/modelcontextprotocol/typescript-sdk/security/advisories/GHSA-w48q-cv73-mx4w
-  - dns-rebinding-protection

--- a/tests/unit/core/test_transport_security.py
+++ b/tests/unit/core/test_transport_security.py
@@ -1,0 +1,115 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for DNS rebinding protection on the HTTP transport."""
+
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from kubeflow_mcp.core.config import SecurityConfig
+from kubeflow_mcp.core.transport_security import (
+    DNSRebindingProtectionMiddleware,
+    build_transport_security_settings,
+)
+
+
+def _make_client(config: SecurityConfig) -> TestClient:
+    async def ok(_request):
+        return JSONResponse({"ok": True})
+
+    settings = build_transport_security_settings(config)
+    app = Starlette(
+        routes=[Route("/mcp", ok, methods=["GET", "POST"])],
+        middleware=[Middleware(DNSRebindingProtectionMiddleware, settings=settings)],
+    )
+    # raise_server_exceptions keeps behaviour close to a real ASGI server.
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_defaults_allow_loopback_host():
+    client = _make_client(SecurityConfig())
+    resp = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+        headers={"host": "localhost:8000"},
+    )
+    assert resp.status_code == 200
+
+
+def test_rejects_unknown_host_with_421():
+    client = _make_client(SecurityConfig())
+    resp = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+        headers={"host": "attacker.example.com"},
+    )
+    assert resp.status_code == 421
+
+
+def test_rejects_unknown_origin_with_403():
+    client = _make_client(SecurityConfig())
+    resp = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+        headers={"host": "localhost:8000", "origin": "http://evil.example.com"},
+    )
+    assert resp.status_code == 403
+
+
+def test_rejects_non_json_post_with_400():
+    client = _make_client(SecurityConfig())
+    resp = client.post(
+        "/mcp",
+        content=b"not json",
+        headers={"host": "localhost:8000", "content-type": "text/plain"},
+    )
+    assert resp.status_code == 400
+
+
+def test_disabled_protection_allows_any_host():
+    client = _make_client(SecurityConfig(enable_dns_rebinding_protection=False))
+    resp = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+        headers={"host": "attacker.example.com"},
+    )
+    assert resp.status_code == 200
+
+
+def test_custom_allowlist_is_honored():
+    client = _make_client(SecurityConfig(allowed_hosts=["mcp.internal:8000"]))
+    allowed = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+        headers={"host": "mcp.internal:8000"},
+    )
+    assert allowed.status_code == 200
+
+    # Loopback is no longer implicitly allowed once an explicit list is set.
+    rejected = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+        headers={"host": "localhost:8000"},
+    )
+    assert rejected.status_code == 421
+
+
+def test_get_stream_without_origin_allowed():
+    # SSE GET streams carry no Origin header from non-browser MCP clients.
+    client = _make_client(SecurityConfig())
+    resp = client.get("/mcp", headers={"host": "127.0.0.1:8000"})
+    assert resp.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -310,33 +310,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
-]
-
-[[package]]
-name = "boolean-py"
-version = "5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
-]
-
-[[package]]
-name = "cachecontrol"
-version = "0.14.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "msgpack" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
-]
-
-[package.optional-dependencies]
-filecache = [
-    { name = "filelock" },
 ]
 
 [[package]]
@@ -773,22 +746,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cyclonedx-python-lib"
-version = "11.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "license-expression" },
-    { name = "packageurl-python" },
-    { name = "py-serializable" },
-    { name = "sortedcontainers" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/0d/64f02d3fd9c116d6f50a540d04d1e4f2e3c487f5062d2db53733ddb25917/cyclonedx_python_lib-11.7.0.tar.gz", hash = "sha256:fb1bc3dedfa31208444dbd743007f478ab6984010a184e5bd466bffd969e936e", size = 1411174, upload-time = "2026-03-17T15:19:16.606Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/09/fe0e3bc32bd33707c519b102fc064ad2a2ce5a1b53e2be38b86936b476b1/cyclonedx_python_lib-11.7.0-py3-none-any.whl", hash = "sha256:02fa4f15ddbba21ac9093039f8137c0d1813af7fe88b760c5dcd3311a8da2178", size = 513041, upload-time = "2026-03-17T15:19:14.369Z" },
-]
-
-[[package]]
 name = "cyclopts"
 version = "4.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -803,15 +760,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/2c/fced34890f6e5a93a4b7afb2c71e8eee2a0719fb26193a0abf159ecb714d/cyclopts-4.10.2.tar.gz", hash = "sha256:d7b950457ef2563596d56331f80cbbbf86a2772535fb8b315c4f03bc7e6127f1", size = 166664, upload-time = "2026-04-08T23:57:45.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/bd/05055d8360cef0757d79367157f3b15c0a0715e81e08f86a04018ec045f0/cyclopts-4.10.2-py3-none-any.whl", hash = "sha256:a1f2d6f8f7afac9456b48f75a40b36658778ddc9c6d406b520d017ae32c990fe", size = 204314, upload-time = "2026-04-08T23:57:46.969Z" },
-]
-
-[[package]]
-name = "defusedxml"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -1500,7 +1448,6 @@ all = [
     { name = "kubeflow", extra = ["hub", "spark"] },
 ]
 dev = [
-    { name = "pip-audit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1533,7 +1480,6 @@ requires-dist = [
     { name = "kubeflow", extras = ["hub"], marker = "extra == 'hub'", specifier = ">=0.4.0" },
     { name = "kubeflow", extras = ["spark"], marker = "extra == 'all'", specifier = ">=0.4.0" },
     { name = "kubeflow", extras = ["spark"], marker = "extra == 'spark'", specifier = ">=0.4.0" },
-    { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
@@ -1588,18 +1534,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602, upload-time = "2026-01-16T01:05:25.991Z" },
-]
-
-[[package]]
-name = "license-expression"
-version = "30.4.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "boolean-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
 ]
 
 [[package]]
@@ -1757,67 +1691,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
-]
-
-[[package]]
-name = "msgpack"
-version = "1.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/a2/3b68a9e769db68668b25c6108444a35f9bd163bb848c0650d516761a59c0/msgpack-1.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0051fffef5a37ca2cd16978ae4f0aef92f164df86823871b5162812bebecd8e2", size = 81318, upload-time = "2025-10-08T09:14:38.722Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e1/2b720cc341325c00be44e1ed59e7cfeae2678329fbf5aa68f5bda57fe728/msgpack-1.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a605409040f2da88676e9c9e5853b3449ba8011973616189ea5ee55ddbc5bc87", size = 83786, upload-time = "2025-10-08T09:14:40.082Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e5/c2241de64bfceac456b140737812a2ab310b10538a7b34a1d393b748e095/msgpack-1.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b696e83c9f1532b4af884045ba7f3aa741a63b2bc22617293a2c6a7c645f251", size = 398240, upload-time = "2025-10-08T09:14:41.151Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/09/2a06956383c0fdebaef5aa9246e2356776f12ea6f2a44bd1368abf0e46c4/msgpack-1.1.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:365c0bbe981a27d8932da71af63ef86acc59ed5c01ad929e09a0b88c6294e28a", size = 406070, upload-time = "2025-10-08T09:14:42.821Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/74/2957703f0e1ef20637d6aead4fbb314330c26f39aa046b348c7edcf6ca6b/msgpack-1.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:41d1a5d875680166d3ac5c38573896453bbbea7092936d2e107214daf43b1d4f", size = 393403, upload-time = "2025-10-08T09:14:44.38Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/09/3bfc12aa90f77b37322fc33e7a8a7c29ba7c8edeadfa27664451801b9860/msgpack-1.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:354e81bcdebaab427c3df4281187edc765d5d76bfb3a7c125af9da7a27e8458f", size = 398947, upload-time = "2025-10-08T09:14:45.56Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/4f/05fcebd3b4977cb3d840f7ef6b77c51f8582086de5e642f3fefee35c86fc/msgpack-1.1.2-cp310-cp310-win32.whl", hash = "sha256:e64c8d2f5e5d5fda7b842f55dec6133260ea8f53c4257d64494c534f306bf7a9", size = 64769, upload-time = "2025-10-08T09:14:47.334Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/3e/b4547e3a34210956382eed1c85935fff7e0f9b98be3106b3745d7dec9c5e/msgpack-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:db6192777d943bdaaafb6ba66d44bf65aa0e9c5616fa1d2da9bb08828c6b39aa", size = 71293, upload-time = "2025-10-08T09:14:48.665Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/97/560d11202bcd537abca693fd85d81cebe2107ba17301de42b01ac1677b69/msgpack-1.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2e86a607e558d22985d856948c12a3fa7b42efad264dca8a3ebbcfa2735d786c", size = 82271, upload-time = "2025-10-08T09:14:49.967Z" },
-    { url = "https://files.pythonhosted.org/packages/83/04/28a41024ccbd67467380b6fb440ae916c1e4f25e2cd4c63abe6835ac566e/msgpack-1.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:283ae72fc89da59aa004ba147e8fc2f766647b1251500182fac0350d8af299c0", size = 84914, upload-time = "2025-10-08T09:14:50.958Z" },
-    { url = "https://files.pythonhosted.org/packages/71/46/b817349db6886d79e57a966346cf0902a426375aadc1e8e7a86a75e22f19/msgpack-1.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61c8aa3bd513d87c72ed0b37b53dd5c5a0f58f2ff9f26e1555d3bd7948fb7296", size = 416962, upload-time = "2025-10-08T09:14:51.997Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e0/6cc2e852837cd6086fe7d8406af4294e66827a60a4cf60b86575a4a65ca8/msgpack-1.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:454e29e186285d2ebe65be34629fa0e8605202c60fbc7c4c650ccd41870896ef", size = 426183, upload-time = "2025-10-08T09:14:53.477Z" },
-    { url = "https://files.pythonhosted.org/packages/25/98/6a19f030b3d2ea906696cedd1eb251708e50a5891d0978b012cb6107234c/msgpack-1.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7bc8813f88417599564fafa59fd6f95be417179f76b40325b500b3c98409757c", size = 411454, upload-time = "2025-10-08T09:14:54.648Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/cd/9098fcb6adb32187a70b7ecaabf6339da50553351558f37600e53a4a2a23/msgpack-1.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bafca952dc13907bdfdedfc6a5f579bf4f292bdd506fadb38389afa3ac5b208e", size = 422341, upload-time = "2025-10-08T09:14:56.328Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/ae/270cecbcf36c1dc85ec086b33a51a4d7d08fc4f404bdbc15b582255d05ff/msgpack-1.1.2-cp311-cp311-win32.whl", hash = "sha256:602b6740e95ffc55bfb078172d279de3773d7b7db1f703b2f1323566b878b90e", size = 64747, upload-time = "2025-10-08T09:14:57.882Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/79/309d0e637f6f37e83c711f547308b91af02b72d2326ddd860b966080ef29/msgpack-1.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:d198d275222dc54244bf3327eb8cbe00307d220241d9cec4d306d49a44e85f68", size = 71633, upload-time = "2025-10-08T09:14:59.177Z" },
-    { url = "https://files.pythonhosted.org/packages/73/4d/7c4e2b3d9b1106cd0aa6cb56cc57c6267f59fa8bfab7d91df5adc802c847/msgpack-1.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:86f8136dfa5c116365a8a651a7d7484b65b13339731dd6faebb9a0242151c406", size = 64755, upload-time = "2025-10-08T09:15:00.48Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
-    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
-    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
-    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
-    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
-    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
-    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
-    { url = "https://files.pythonhosted.org/packages/67/32/f3cd1667028424fa7001d82e10ee35386eea1408b93d399b09fb0aa7875f/msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c", size = 65037, upload-time = "2025-10-08T09:15:21.416Z" },
-    { url = "https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9", size = 72631, upload-time = "2025-10-08T09:15:22.431Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/db/0314e4e2db56ebcf450f277904ffd84a7988b9e5da8d0d61ab2d057df2b6/msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84", size = 64118, upload-time = "2025-10-08T09:15:23.402Z" },
-    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
-    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
-    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
-    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
-    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
-    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
-    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
-    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
-    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
 ]
 
 [[package]]
@@ -2157,15 +2030,6 @@ wheels = [
 ]
 
 [[package]]
-name = "packageurl-python"
-version = "0.17.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2316,61 +2180,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
-]
-
-[[package]]
-name = "pip"
-version = "26.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
-]
-
-[[package]]
-name = "pip-api"
-version = "0.0.34"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pip" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369, upload-time = "2024-07-09T20:32:29.099Z" },
-]
-
-[[package]]
-name = "pip-audit"
-version = "2.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cachecontrol", extra = ["filecache"] },
-    { name = "cyclonedx-python-lib" },
-    { name = "packaging" },
-    { name = "pip-api" },
-    { name = "pip-requirements-parser" },
-    { name = "platformdirs" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "tomli" },
-    { name = "tomli-w" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/89/0e999b413facab81c33d118f3ac3739fd02c0622ccf7c4e82e37cebd8447/pip_audit-2.10.0.tar.gz", hash = "sha256:427ea5bf61d1d06b98b1ae29b7feacc00288a2eced52c9c58ceed5253ef6c2a4", size = 53776, upload-time = "2025-12-01T23:42:40.612Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/f3/4888f895c02afa085630a3a3329d1b18b998874642ad4c530e9a4d7851fe/pip_audit-2.10.0-py3-none-any.whl", hash = "sha256:16e02093872fac97580303f0848fa3ad64f7ecf600736ea7835a2b24de49613f", size = 61518, upload-time = "2025-12-01T23:42:39.193Z" },
-]
-
-[[package]]
-name = "pip-requirements-parser"
-version = "32.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pyparsing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
 ]
 
 [[package]]
@@ -2543,18 +2352,6 @@ keyring = [
 ]
 memory = [
     { name = "cachetools" },
-]
-
-[[package]]
-name = "py-serializable"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "defusedxml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
 ]
 
 [[package]]
@@ -2806,15 +2603,6 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
-]
-
-[[package]]
-name = "pyparsing"
-version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -3298,15 +3086,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sortedcontainers"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
-]
-
-[[package]]
 name = "soupsieve"
 version = "2.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3614,15 +3393,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
-]
-
-[[package]]
-name = "tomli-w"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this PR does

Adds MCP protocol conformance tests to CI using the official [MCP conformance framework](https://github.com/modelcontextprotocol/conformance), validating that the server correctly implements the protocol (`initialize`, `tools/list`, `tools/call`, etc.) on every PR — with **no Kubernetes cluster and no LLM**.

Running the suite also surfaced a real hardening gap, fixed here in a second commit: the FastMCP streamable-HTTP transport accepts requests with an arbitrary `Host`/`Origin` header by default, leaving a locally-bound, unauthenticated server reachable from a malicious web page via DNS rebinding.

Fixes #62

## Changes

**`feat(ci): add MCP protocol conformance tests`**
- `.github/workflows/conformance.yaml` — starts `kubeflow-mcp serve --transport http` with no kubeconfig, waits for it to answer `initialize`, then runs `modelcontextprotocol/conformance@v0.1.16` (`active` suite) against `http://localhost:8000/mcp`. Server logs are dumped on failure.
- `tests/conformance/expected-failures.yaml` — baseline seeded from real runner output. Every entry is a legitimate gap for this server (scenarios assuming the reference server's fixtures, plus unadvertised capabilities), each with a one-line reason. CI fails on regressions **and** on baselined scenarios that unexpectedly start passing.
- `make conformance` — run the same suite locally (Node.js 20+).
- CONTRIBUTING.md — documents the workflow and how to maintain the baseline.

**`fix(security): enforce Host/Origin validation on HTTP transport`**
- `kubeflow_mcp/core/transport_security.py` — pure-ASGI middleware (no response buffering, SSE-safe) that validates `Host`/`Origin` before requests reach the MCP handler, delegating header checks to the MCP SDK's reference `TransportSecurityMiddleware`: **421** invalid Host, **403** invalid Origin, **400** non-JSON POST.
- Wired into the `http`/`sse` transports only; `stdio` untouched. On by default with loopback allowlists (correct for the default `127.0.0.1` bind); configurable via `KUBEFLOW_MCP_ALLOWED_HOSTS` / `KUBEFLOW_MCP_ALLOWED_ORIGINS` (comma-separated, `:*` port wildcard) and `KUBEFLOW_MCP_DNS_REBINDING_PROTECTION`.
- `dns-rebinding-protection` is intentionally **not** baselined — it is a required pass, so CI guards against regression.
- 7 unit tests covering allow/reject/disable/custom-allowlist paths.

## Verification

All run locally against the exact committed code:

- `make verify` — clean (uv lock, ruff check, ruff format)
- Unit tests — **140 passed** (incl. 7 new transport-security tests)
- Conformance `active` suite with baseline — **exit 0**: `Baseline check passed: all failures are expected.`

Key scenario results:

| Scenario | Result |
|---|---|
| server-initialize | ✅ pass |
| ping | ✅ pass |
| tools-list | ✅ pass |
| tools-call-simple-text | ✅ pass |
| tools-call-error | ✅ pass |
| resources-list / prompts-list | ✅ pass |
| server-sse-multiple-streams | ✅ pass (2/2) |
| **dns-rebinding-protection** | ✅ **pass (2/2)** — was failing before the fix |

Manual probe against the live server:

```text
POST /mcp (legit)                          → 200
POST /mcp Host: attacker.example.com       → 421
POST /mcp Origin: http://evil.example.com  → 403
```

## References

- Conformance framework: https://github.com/modelcontextprotocol/conformance
- SDK integration guide: https://github.com/modelcontextprotocol/conformance/blob/main/SDK_INTEGRATION.md
- DNS rebinding advisory (TypeScript SDK, same class of issue): GHSA-w48q-cv73-mx4w
