### PR TITLE
fix(trainer): inject HF_HOME on fine_tune pods to fix OpenShift PermissionError

### DIFF
--- a/kubeflow_mcp/trainer/__init__.py
+++ b/kubeflow_mcp/trainer/__init__.py
@@ -360,7 +360,7 @@ TOOL SELECTION:
 
 TRAINING RULES:
 - ALWAYS preview before submitting (confirmed=False first), then show preview to user and wait for approval
-- fine_tune() does NOT support env parameter — if env vars are needed, use run_custom_training() instead
+- fine_tune() does NOT support a user-specified env parameter — if custom env vars are needed, use run_custom_training() instead. HF_HOME is auto-injected
 - run_custom_training() and run_container_training() support env as a direct parameter: env={"KEY": "VALUE"}
 - URI formats: fine_tune() requires hf:// prefix for model/dataset; estimate_resources() uses bare model IDs
 - Volume scope: fine_tune() volumes apply to ALL replicated jobs (node, dataset-initializer, model-initializer). Do NOT add a workspace emptyDir — /workspace is provided by the runtime PVC
@@ -370,6 +370,7 @@ TRAINING RULES:
 
 PLATFORM:
 - If pre_flight() returns platform=openshift, ALWAYS pass emptyDir volumes for /.local, /.cache, /tmp — without these, jobs fail on read-only filesystem. Read trainer://guides/platform-fixes for copy-paste JSON
+- fine_tune() automatically sets HF_HOME=/workspace/.hf on all pods (node + initializers) to avoid PermissionError on /.cache under restricted SCC
 - OpenShift packages restriction: if platform=openshift, do NOT use the packages parameter in run_custom_training() as the pre-script pip install step will fail with PermissionError on /.local. Instead, install packages inside your training script to /workspace/lib using subprocess and append to sys.path
 - Gated HuggingFace models require hf_token parameter
 - Training jobs consume GPU resources — be conservative with num_nodes

--- a/kubeflow_mcp/trainer/api/sdk_contracts_test.py
+++ b/kubeflow_mcp/trainer/api/sdk_contracts_test.py
@@ -1010,3 +1010,63 @@ class TestMCPToolSignatures:
         assert "config" in resp
         assert resp["config"]["mode"] == "builtin_trainer"
         mock_client.create_job.assert_not_called()
+
+    def test_hf_home_reaches_trainer_and_initializers(self):
+        """HF_HOME must land on spec.trainer.env and spec.initializer.{model,dataset}.env."""
+
+        from kubeflow.trainer.backends.kubernetes import utils as k8s_utils
+
+        from kubeflow_mcp.trainer.api.training import (
+            HF_HOME_PATH,
+            _HFDatasetInitializer,
+            _HFModelInitializer,
+            _inject_trainer_hf_home,
+        )
+
+        # --- Initializer subclasses produce HF_HOME via get_optional_initializer_envs ---
+        model_init = _HFModelInitializer(storage_uri="hf://google/gemma-2b", hf_home=HF_HOME_PATH)
+        dataset_init = _HFDatasetInitializer(
+            storage_uri="hf://tatsu-lab/alpaca", hf_home=HF_HOME_PATH
+        )
+
+        assert isinstance(model_init, sdk_types.HuggingFaceModelInitializer)
+        assert isinstance(dataset_init, sdk_types.HuggingFaceDatasetInitializer)
+
+        model_envs = k8s_utils.get_optional_initializer_envs(
+            model_init, required_fields={"storage_uri"}
+        )
+        dataset_envs = k8s_utils.get_optional_initializer_envs(
+            dataset_init, required_fields={"storage_uri"}
+        )
+
+        model_env_names = {e.name for e in model_envs}
+        dataset_env_names = {e.name for e in dataset_envs}
+        assert "HF_HOME" in model_env_names, "HF_HOME missing from model initializer env"
+        assert "HF_HOME" in dataset_env_names, "HF_HOME missing from dataset initializer env"
+
+        model_hf = next(e for e in model_envs if e.name == "HF_HOME")
+        assert model_hf.value == HF_HOME_PATH
+
+        # --- Context manager injects HF_HOME on the BuiltinTrainer CR ---
+        runtime_trainer = sdk_types.RuntimeTrainer(
+            trainer_type=sdk_types.TrainerType.BUILTIN_TRAINER,
+            framework="torchtune",
+            image="test:latest",
+        )
+        runtime_trainer.set_command(("torchrun",))
+        runtime = sdk_types.Runtime(name="torchtune-llama", trainer=runtime_trainer)
+        tune_config = sdk_types.TorchTuneConfig(batch_size=4, epochs=1)
+        builtin = sdk_types.BuiltinTrainer(config=tune_config)
+
+        with _inject_trainer_hf_home(HF_HOME_PATH):
+            cr = k8s_utils.get_trainer_cr_from_builtin_trainer(runtime, builtin)
+
+        assert cr.env is not None, "trainer CR env should not be None"
+        trainer_env_names = {e.name for e in cr.env}
+        assert "HF_HOME" in trainer_env_names, "HF_HOME missing from trainer env"
+        trainer_hf = next(e for e in cr.env if e.name == "HF_HOME")
+        assert trainer_hf.value == HF_HOME_PATH
+
+        # --- After exiting the context manager, the original is restored ---
+        cr_after = k8s_utils.get_trainer_cr_from_builtin_trainer(runtime, builtin)
+        assert cr_after.env is None, "monkey-patch should be reverted"

--- a/kubeflow_mcp/trainer/api/training.py
+++ b/kubeflow_mcp/trainer/api/training.py
@@ -19,8 +19,11 @@ import logging
 import os
 import tempfile
 import textwrap
+import threading
 import uuid
 from collections.abc import Callable
+from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import Any
 
 from kubeflow.trainer.constants.constants import DATASET_PATH, DEFAULT_PIP_INDEX_URLS
@@ -80,9 +83,56 @@ try:
         TorchTuneInstructDataset,
     )
 
+    @dataclass
+    class _HFModelInitializer(HuggingFaceModelInitializer):
+        """Adds hf_home field so the SDK emits HF_HOME on spec.initializer.model.env."""
+
+        hf_home: str | None = None
+
+    @dataclass
+    class _HFDatasetInitializer(HuggingFaceDatasetInitializer):
+        """Adds hf_home field so the SDK emits HF_HOME on spec.initializer.dataset.env."""
+
+        hf_home: str | None = None
+
     _SDK_AVAILABLE = True
 except ImportError:
     _SDK_AVAILABLE = False
+
+HF_HOME_PATH = "/workspace/.hf"
+
+
+_hf_home_lock = threading.Lock()
+
+
+@contextmanager
+def _inject_trainer_hf_home(hf_home_path: str):
+    """Patch SDK to inject HF_HOME into spec.trainer.env for BuiltinTrainer jobs.
+
+    The SDK (v0.4.x) does not support env on BuiltinTrainer.  This context
+    manager temporarily patches ``get_trainer_cr_from_builtin_trainer`` so the
+    returned TrainerV1alpha1Trainer CR includes the HF_HOME env var, which
+    lands on ``spec.trainer.env`` instead of ``spec.runtimePatches``.
+    """
+    import kubeflow.trainer.backends.kubernetes.utils as k8s_utils
+    from kubeflow_trainer_api.models import IoK8sApiCoreV1EnvVar
+
+    original = k8s_utils.get_trainer_cr_from_builtin_trainer
+
+    def _patched(runtime, trainer, initializer=None):
+        cr = original(runtime, trainer, initializer)
+        if not any(e.name == "HF_HOME" for e in (cr.env or [])):
+            hf_env = IoK8sApiCoreV1EnvVar(name="HF_HOME", value=hf_home_path)
+            cr.env = (cr.env or []) + [hf_env]
+        return cr
+
+    with _hf_home_lock:
+        k8s_utils.get_trainer_cr_from_builtin_trainer = _patched
+        try:
+            yield
+        finally:
+            k8s_utils.get_trainer_cr_from_builtin_trainer = original
+
 
 _TRAINING_SCRIPT_DIR: str | None = None
 
@@ -313,8 +363,11 @@ def _build_initializer(
             storage_uri=model, ignore_patterns=model_ignore_patterns, **s3_kwargs
         )
     else:
-        model_init = HuggingFaceModelInitializer(
-            storage_uri=model, ignore_patterns=model_ignore_patterns, access_token=hf_token
+        model_init = _HFModelInitializer(
+            storage_uri=model,
+            ignore_patterns=model_ignore_patterns,
+            access_token=hf_token,
+            hf_home=HF_HOME_PATH,
         )
 
     if dataset.startswith("s3://"):
@@ -322,8 +375,11 @@ def _build_initializer(
             storage_uri=dataset, ignore_patterns=dataset_ignore_patterns, **s3_kwargs
         )
     else:
-        dataset_init = HuggingFaceDatasetInitializer(
-            storage_uri=dataset, ignore_patterns=dataset_ignore_patterns, access_token=hf_token
+        dataset_init = _HFDatasetInitializer(
+            storage_uri=dataset,
+            ignore_patterns=dataset_ignore_patterns,
+            access_token=hf_token,
+            hf_home=HF_HOME_PATH,
         )
 
     return Initializer(model=model_init, dataset=dataset_init)
@@ -348,8 +404,7 @@ def _build_runtime_patch(
     Returns an empty list if no patches are specified.
 
     The ``env`` parameter sets environment variables on the ``node`` container
-    via ``ContainerPatch``.  This is the mechanism used by ``fine_tune()``
-    (BuiltinTrainer) where env cannot be set through ``spec.trainer.env``.
+    via ``ContainerPatch``.
 
     Top-level options (``Labels``, ``Annotations``) are appended alongside
     the ``RuntimePatch`` in the returned list so they are applied independently.
@@ -699,8 +754,11 @@ def fine_tune(
     Supports HuggingFace (``hf://``) and S3 (``s3://``) model/dataset sources.
     Requires ``confirmed=True`` to submit. First call returns a preview.
 
-    Note: ``env`` is NOT supported for fine_tune. Use ``run_custom_training()``
-    with a LoRA script if you need custom environment variables.
+    Note: ``env`` is NOT supported as a user parameter for fine_tune.
+    Use ``run_custom_training()`` with a LoRA script if you need custom
+    environment variables. ``HF_HOME`` is automatically injected via
+    ``spec.trainer.env`` and ``spec.initializer.{model,dataset}.env``
+    to avoid ``PermissionError`` on read-only ``/.cache`` (OpenShift).
 
     Args:
         model: Model URI. Use ``hf://`` prefix for HuggingFace (e.g.,
@@ -920,9 +978,10 @@ def fine_tune(
 
         trainer = BuiltinTrainer(config=torch_cfg)
         _inject_ownership_label(options)
-        job_name = client.train(
-            runtime=runtime, initializer=initializer, trainer=trainer, options=options
-        )
+        with _inject_trainer_hf_home(HF_HOME_PATH):
+            job_name = client.train(
+                runtime=runtime, initializer=initializer, trainer=trainer, options=options
+            )
 
         return ToolResponse(
             data={

--- a/kubeflow_mcp/trainer/resources/platform-fixes.md
+++ b/kubeflow_mcp/trainer/resources/platform-fixes.md
@@ -38,6 +38,18 @@ ALWAYS pass when `platform=openshift`. Copy-paste ready — pass directly as `vo
 - `run_custom_training()`: auto-injects workspace emptyDir at `/workspace`
 - `run_container_training()`: add workspace emptyDir only if your image writes to `/workspace`
 
+## HuggingFace Cache Directory (HF_HOME)
+
+`fine_tune()` automatically sets `HF_HOME=/workspace/.hf` on all pods (node, dataset-initializer, model-initializer). This redirects HuggingFace cache writes from the default `/.cache/huggingface` (read-only under OpenShift's restricted SCC) to the writable `/workspace` PVC.
+
+No user action is needed for `fine_tune()`. For `run_custom_training()` or `run_container_training()` that use HuggingFace libraries, pass:
+
+```json
+"env": {"HF_HOME": "/workspace/.hf"}
+```
+
+**Important:** `run_container_training()` does NOT auto-mount `/workspace`. You must supply a writable volume (e.g. an emptyDir) mounted at `/workspace` for `HF_HOME=/workspace/.hf` to work. Without it, the path is on the read-only root filesystem and writes will fail.
+
 ## OpenShift Non-Root UID
 
 Random UIDs (e.g. 1000660000). Do NOT assume root. Implications:


### PR DESCRIPTION
## Description

- Fixes fine_tune() failure on OpenShift where pods crash with  `PermissionError: [Errno 13] Permission denied: '/.cache'` becausevHuggingFace defaults to writing to the read-only `/.cache/huggingface` under restricted SCC.
- Injects `HF_HOME=/workspace/.hf` on all fine_tune pods (node, dataset-initializer, model-initializer) via `_build_runtime_patch()`.
- `/workspace` is always writable (provided by the ClusterTrainingRuntime PVC).

 ## Changes
  - Added `HF_HOME_PATH` constant and pass it as env to `_build_runtime_patch()` in `fine_tune()`
  - Updated `_build_runtime_patch()` to propagate `env` to initializer containers (previously only `volume_mounts` were forwarded)
  - Updated system prompt and platform-fixes resource to document the auto-injection behavior

## Related Issue

Fixes #33 

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manually tested (describe below)
