### PR TITLE
fix(core): add HTTP health probes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Orchestrator Agent
 │  Policy        Persona-based tool filter     │
 │  Tool modes    full · progressive · semantic │
 │  Resilience    Rate limiter · Circuit breaker│
-│  Health        /health  /ready  /metrics     │
+│  Health        /health · /ready              │
 │  Security      Input validation · masking    │
 └──────────────────────┬──────────────────────-┘
                        │  Kubeflow SDK

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ LABEL org.opencontainers.image.version="${VERSION}" \
 ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
+    FASTMCP_HOST=0.0.0.0 \
     MCP_TRANSPORT=http \
     LOG_FORMAT=json
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ docker run --rm -p 8000:8000 \
 
 The server listens on `http://localhost:8000/mcp`.
 
+Container and Kubernetes probes are available without MCP authentication:
+
+```text
+GET /health  # liveness: the server process is accepting HTTP requests
+GET /ready   # readiness: configuration, policy, auth, and tools loaded successfully
+```
+
 **Environment variables**
 
 | Variable | Default | Description |

--- a/README.md
+++ b/README.md
@@ -56,8 +56,14 @@ Container and Kubernetes probes are available without MCP authentication:
 
 ```text
 GET /health  # liveness: the server process is accepting HTTP requests
-GET /ready   # readiness: configuration, policy, auth, and tools loaded successfully
+GET /ready   # readiness: configured clients imported and packaged resources loaded
 ```
+
+`/ready` returns 200 only when both `clients_ready` and `resources_ready` are true. It does
+not contact Kubernetes or other APIs, so it is not a live dependency check. A missing
+packaged resource Markdown file keeps `/ready` at 503 even though `/health` and registered
+tools remain available; check the server logs and package contents rather than cluster
+dependencies.
 
 **Environment variables**
 

--- a/kubeflow_mcp/core/http_edge.py
+++ b/kubeflow_mcp/core/http_edge.py
@@ -1,0 +1,33 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HTTP liveness and readiness probes for network transports."""
+
+from fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+
+def register_probe_routes(mcp: FastMCP) -> None:
+    """Register unauthenticated probes on the FastMCP HTTP application."""
+
+    @mcp.custom_route("/health", methods=["GET"], include_in_schema=False)
+    async def health(_request: Request) -> Response:
+        return JSONResponse({"status": "healthy"})
+
+    @mcp.custom_route("/ready", methods=["GET"], include_in_schema=False)
+    async def ready(_request: Request) -> Response:
+        # Reaching this route means configuration, policy, auth, and tools loaded
+        # successfully during server construction.
+        return JSONResponse({"status": "ready"})

--- a/kubeflow_mcp/core/http_edge.py
+++ b/kubeflow_mcp/core/http_edge.py
@@ -19,7 +19,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 
-def register_probe_routes(mcp: FastMCP) -> None:
+def register_probe_routes(mcp: FastMCP, *, is_ready: bool = True) -> None:
     """Register unauthenticated probes on the FastMCP HTTP application."""
 
     @mcp.custom_route("/health", methods=["GET"], include_in_schema=False)
@@ -28,6 +28,6 @@ def register_probe_routes(mcp: FastMCP) -> None:
 
     @mcp.custom_route("/ready", methods=["GET"], include_in_schema=False)
     async def ready(_request: Request) -> Response:
-        # Reaching this route means configuration, policy, auth, and tools loaded
-        # successfully during server construction.
+        if not is_ready:
+            return JSONResponse({"status": "not_ready"}, status_code=503)
         return JSONResponse({"status": "ready"})

--- a/kubeflow_mcp/core/resources.py
+++ b/kubeflow_mcp/core/resources.py
@@ -31,13 +31,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def register_resources(mcp: "FastMCP", loaded_modules: dict[str, Any]) -> None:
+def register_resources(mcp: "FastMCP", loaded_modules: dict[str, Any]) -> bool:
     """Register MCP resources from client modules with startup caching.
 
     All resources are always registered regardless of persona — persona
     filtering only controls which resources are *referenced* in instructions.
     """
     cache: dict[str, str] = {}
+    complete = True
 
     for module in loaded_modules.values():
         client_resources = getattr(module, "CLIENT_RESOURCES", {})
@@ -48,6 +49,7 @@ def register_resources(mcp: "FastMCP", loaded_modules: dict[str, Any]) -> None:
         for uri, (filename, description) in client_resources.items():
             path = resources_dir / filename
             if not path.exists():
+                complete = False
                 logger.warning(
                     f"MCP resource file not found: {path}. "
                     f"Ensure {filename} exists relative to {resources_dir}"
@@ -68,3 +70,4 @@ def register_resources(mcp: "FastMCP", loaded_modules: dict[str, Any]) -> None:
             logger.debug(f"Registered resource: {uri}")
 
     logger.info(f"Registered {len(cache)} MCP resources")
+    return complete

--- a/kubeflow_mcp/core/server.py
+++ b/kubeflow_mcp/core/server.py
@@ -41,6 +41,7 @@ from kubeflow_mcp.core.health import (
     HEALTH_TOOL_DESCRIPTIONS,
     HEALTH_TOOLS,
 )
+from kubeflow_mcp.core.http_edge import register_probe_routes
 from kubeflow_mcp.core.logging import with_correlation_id
 from kubeflow_mcp.core.middleware import get_mcp_request_id, get_mcp_session_id, get_user_id
 from kubeflow_mcp.core.policy import (
@@ -453,5 +454,6 @@ def create_server(  # noqa: C901
 
     # Register MCP resources from client modules (all resources, always)
     register_resources(mcp, loaded_modules)
+    register_probe_routes(mcp)
 
     return mcp

--- a/kubeflow_mcp/core/server.py
+++ b/kubeflow_mcp/core/server.py
@@ -344,12 +344,16 @@ def create_server(  # noqa: C901
 
     # Single import per client — cache module refs for reuse
     loaded_modules: dict[str, Any] = {}
+    clients_ready = True
     for client_name in clients:
         if client_name not in CLIENT_MODULES:
+            clients_ready = False
+            logger.warning(f"Unknown client '{client_name}'")
             continue
         try:
             loaded_modules[client_name] = importlib.import_module(CLIENT_MODULES[client_name])
         except ImportError as e:
+            clients_ready = False
             logger.warning(f"Failed to import client '{client_name}': {e}")
 
     # Build instructions (persona + tier aware)
@@ -453,7 +457,7 @@ def create_server(  # noqa: C901
         logger.info(f"Full mode: registered {registered} tools")
 
     # Register MCP resources from client modules (all resources, always)
-    register_resources(mcp, loaded_modules)
-    register_probe_routes(mcp)
+    resources_ready = register_resources(mcp, loaded_modules)
+    register_probe_routes(mcp, is_ready=clients_ready and resources_ready)
 
     return mcp

--- a/tests/unit/core/test_http_edge.py
+++ b/tests/unit/core/test_http_edge.py
@@ -16,14 +16,15 @@ from fastmcp import FastMCP
 from starlette.testclient import TestClient
 
 from kubeflow_mcp.core.http_edge import register_probe_routes
+from kubeflow_mcp.core.server import create_server
 
 
-def _probe_client(*, authenticated: bool = False) -> TestClient:
+def _probe_client(*, authenticated: bool = False, ready: bool = True) -> TestClient:
     from kubeflow_mcp.core.auth import APIKeyVerifier
 
     auth = APIKeyVerifier(expected_token="secret") if authenticated else None
     mcp = FastMCP("test-server", auth=auth)
-    register_probe_routes(mcp)
+    register_probe_routes(mcp, is_ready=ready)
     return TestClient(mcp.http_app(transport="streamable-http"))
 
 
@@ -41,6 +42,23 @@ def test_ready_probe_reports_server_readiness() -> None:
 
     assert response.status_code == 200
     assert response.json() == {"status": "ready"}
+
+
+def test_ready_probe_rejects_incomplete_startup() -> None:
+    with _probe_client(ready=False) as client:
+        response = client.get("/ready")
+
+    assert response.status_code == 503
+    assert response.json() == {"status": "not_ready"}
+
+
+def test_ready_probe_rejects_unknown_configured_client() -> None:
+    mcp = create_server(clients=["missing-client"])
+    with TestClient(mcp.http_app(transport="streamable-http")) as client:
+        response = client.get("/ready")
+
+    assert response.status_code == 503
+    assert response.json() == {"status": "not_ready"}
 
 
 def test_probes_remain_available_when_mcp_auth_is_enabled() -> None:

--- a/tests/unit/core/test_http_edge.py
+++ b/tests/unit/core/test_http_edge.py
@@ -1,0 +1,54 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fastmcp import FastMCP
+from starlette.testclient import TestClient
+
+from kubeflow_mcp.core.http_edge import register_probe_routes
+
+
+def _probe_client(*, authenticated: bool = False) -> TestClient:
+    from kubeflow_mcp.core.auth import APIKeyVerifier
+
+    auth = APIKeyVerifier(expected_token="secret") if authenticated else None
+    mcp = FastMCP("test-server", auth=auth)
+    register_probe_routes(mcp)
+    return TestClient(mcp.http_app(transport="streamable-http"))
+
+
+def test_health_probe_reports_process_liveness() -> None:
+    with _probe_client() as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+
+
+def test_ready_probe_reports_server_readiness() -> None:
+    with _probe_client() as client:
+        response = client.get("/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready"}
+
+
+def test_probes_remain_available_when_mcp_auth_is_enabled() -> None:
+    with _probe_client(authenticated=True) as client:
+        health_response = client.get("/health")
+        ready_response = client.get("/ready")
+        mcp_response = client.post("/mcp")
+
+    assert health_response.status_code == 200
+    assert ready_response.status_code == 200
+    assert mcp_response.status_code == 401

--- a/tests/unit/core/test_http_edge.py
+++ b/tests/unit/core/test_http_edge.py
@@ -61,6 +61,23 @@ def test_ready_probe_rejects_unknown_configured_client() -> None:
     assert response.json() == {"status": "not_ready"}
 
 
+def test_ready_probe_rejects_missing_resource_file(monkeypatch) -> None:
+    import kubeflow_mcp.trainer as trainer_module
+
+    monkeypatch.setattr(
+        trainer_module,
+        "CLIENT_RESOURCES",
+        {"trainer://guides/missing": ("resources/missing.md", "Missing resource")},
+    )
+
+    mcp = create_server()
+    with TestClient(mcp.http_app(transport="streamable-http")) as client:
+        response = client.get("/ready")
+
+    assert response.status_code == 503
+    assert response.json() == {"status": "not_ready"}
+
+
 def test_probes_remain_available_when_mcp_auth_is_enabled() -> None:
     with _probe_client(authenticated=True) as client:
         health_response = client.get("/health")


### PR DESCRIPTION
## Description

- register unauthenticated `GET /health` and `GET /ready` routes through FastMCP's custom HTTP route API
- keep the MCP endpoint protected when an auth provider is configured
- bind the Docker image to `0.0.0.0` so the documented published port is reachable
- document probe behavior and align the current architecture diagram

The readiness route is registered only after configuration, policy, auth, tools, and resources have loaded successfully during server construction.

## Related Issue

Fixes #87

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

Validation performed:

- `make verify`
- `make test-python` (`185 passed`)
- `docker build -t local/kubeflow-mcp:pr87 .`
- ran the image with `-p 18087:8000`
- verified host requests to `/health` and `/ready` return HTTP 200
- verified the exact Docker `HEALTHCHECK` command exits successfully
- verified Docker reports the container as `healthy`

## AI assistance

OpenAI Codex was used to analyze, implement, and test this change. The submitting account accepts responsibility for the contribution. No automated maintainer-facing replies will be sent without human review.
