### PR TITLE
fix(core): mask bare token fields in audit logs

### DIFF
--- a/kubeflow_mcp/core/security.py
+++ b/kubeflow_mcp/core/security.py
@@ -305,7 +305,13 @@ def validate_training_bounds(
     return None
 
 
-_SENSITIVE_EXACT = {"hf_token", "access_token", "secret_access_key", "s3_secret_access_key"}
+_SENSITIVE_EXACT = {
+    "token",
+    "hf_token",
+    "access_token",
+    "secret_access_key",
+    "s3_secret_access_key",
+}
 _SENSITIVE_SUBSTRINGS = {
     "password",
     "secret",

--- a/tests/unit/core/test_security.py
+++ b/tests/unit/core/test_security.py
@@ -51,3 +51,28 @@ TODO: Implement the following test categories:
    - JWTVerifier validates JWKS signatures
    - Unauthenticated HTTP requests rejected with 401
 """
+
+from __future__ import annotations
+
+from kubeflow_mcp.core.security import mask_sensitive_data
+
+
+def test_mask_sensitive_data_masks_sensitive_exact_fields() -> None:
+    data = {
+        "model": "llama",
+        "token": "ghp_xxxxxxxxxxxx",
+        "hf_token": "hf_secret",
+        "access_token": "at_secret",
+        "secret_access_key": "sak_secret",
+        "s3_secret_access_key": "s3_secret",
+        "api_token": "api_secret",
+    }
+    assert mask_sensitive_data(data) == {
+        "model": "llama",
+        "token": "***",
+        "hf_token": "***",
+        "access_token": "***",
+        "secret_access_key": "***",
+        "s3_secret_access_key": "***",
+        "api_token": "***",
+    }


### PR DESCRIPTION

## Description

Add "token" to _SENSITIVE_EXACT so cleartext secrets are not written by _audit_wrap.

<!-- What does this PR do? -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes https://github.com/kubeflow/mcp-server/issues/92

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [x] Unit tests
- [x] Integration tests
- [x] E2E tests
- [x] Manually tested (describe below)
