### PR TITLE
chore(trainer): add unit tests for platform runtime tools

### DIFF
--- a/kubeflow_mcp/conftest.py
+++ b/kubeflow_mcp/conftest.py
@@ -132,18 +132,13 @@ def mock_k8s_apis():
         "items": [create_mock_trainjob()],
     }
 
-    apiext_mock.list_custom_resource_definition.return_value = MagicMock(
-        items=[
-            MagicMock(
-                metadata=MagicMock(name="trainjobs.trainer.kubeflow.org"),
-                spec=MagicMock(
-                    group="trainer.kubeflow.org",
-                    versions=[MagicMock(name="v1", served=True, storage=True)],
-                ),
-                status=MagicMock(conditions=[]),
-            )
-        ]
-    )
+    crd = MagicMock()
+    crd.metadata.name = "trainjobs.trainer.kubeflow.org"
+    crd.spec.group = "trainer.kubeflow.org"
+    crd.spec.scope = "Namespaced"
+    crd.spec.versions = [MagicMock(name="v1", served=True, storage=True)]
+    crd.status.conditions = []
+    apiext_mock.list_custom_resource_definition.return_value = MagicMock(items=[crd])
 
     with (
         patch(

--- a/kubeflow_mcp/trainer/api/platform_test.py
+++ b/kubeflow_mcp/trainer/api/platform_test.py
@@ -12,18 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for trainer/api/platform.py — CRD inspection, runtime CRUD.
-
-Covers input validation for platform admin tools.
-K8s API interaction tests require mocking and are marked as TODOs.
-"""
+"""Tests for trainer/api/platform.py — CRD inspection and runtime CRUD."""
 
 from __future__ import annotations
 
 import pytest
-from tests.common import FAILED, SUCCESS, VALIDATION_ERROR, TestCase, assert_test_case
+from kubeflow.trainer.constants import constants as trainer_constants
+from kubernetes.client.exceptions import ApiException
+from tests.common import (
+    FAILED,
+    KUBERNETES_ERROR,
+    RESOURCE_NOT_FOUND,
+    SUCCESS,
+    VALIDATION_ERROR,
+    TestCase,
+    assert_test_case,
+)
 
-from kubeflow_mcp.trainer.api.platform import create_runtime, patch_runtime
+from kubeflow_mcp.common import utils as mcp_utils
+from kubeflow_mcp.conftest import create_mock_trainjob, verify_tool_error, verify_tool_success
+from kubeflow_mcp.core.policy import get_allowed_tools
+from kubeflow_mcp.trainer.api.platform import create_runtime, delete_runtime, patch_runtime
+
+# ─── Validation ─────────────────────────────────────────────────────────────
 
 
 @pytest.mark.parametrize(
@@ -82,15 +93,142 @@ def test_create_runtime_validation(test_case):
     assert_test_case(test_case, create_runtime)
 
 
+# ─── Runtime CRUD ───────────────────────────────────────────────────────────
+
+
+def test_patch_runtime_confirmed_applies_strategic_patch(mock_k8s_apis):
+    api = mock_k8s_apis["custom"]
+    api.patch_cluster_custom_object.return_value = {
+        "metadata": {"resourceVersion": "123"},
+    }
+    patch_body = {"spec": {"template": {"spec": {"numNodes": 2}}}}
+
+    result = patch_runtime("torchtune-llama", patch=patch_body, confirmed=True)
+
+    data = verify_tool_success(result)
+    assert data["runtime"] == "torchtune-llama"
+    assert data["patched"] is True
+    assert data["resource_version"] == "123"
+    api.patch_cluster_custom_object.assert_called_once_with(
+        group=trainer_constants.GROUP,
+        version=trainer_constants.VERSION,
+        plural="clustertrainingruntimes",
+        name="torchtune-llama",
+        body=patch_body,
+        _request_timeout=mcp_utils.K8S_TIMEOUT,
+    )
+
+
+def test_patch_runtime_invalid_runtime_name_returns_not_found(mock_k8s_apis):
+    api = mock_k8s_apis["custom"]
+    api.patch_cluster_custom_object.side_effect = ApiException(status=404, reason="Not Found")
+
+    result = patch_runtime(
+        "missing-runtime",
+        patch={"spec": {"labels": {"env": "test"}}},
+        confirmed=True,
+    )
+
+    error = verify_tool_error(result, error_code=RESOURCE_NOT_FOUND)
+    assert "missing-runtime" in error["error"]
+
+
+def test_create_runtime_confirmed_creates_runtime(mock_k8s_apis):
+    api = mock_k8s_apis["custom"]
+    api.create_cluster_custom_object.return_value = {
+        "metadata": {"resourceVersion": "9"},
+    }
+    spec = {"template": {"spec": {"numNodes": 1}}}
+
+    result = create_runtime("new-runtime", spec=spec, confirmed=True)
+
+    data = verify_tool_success(result)
+    assert data["runtime"] == "new-runtime"
+    assert data["created"] is True
+    assert data["resource_version"] == "9"
+    api.create_cluster_custom_object.assert_called_once_with(
+        group=trainer_constants.GROUP,
+        version=trainer_constants.VERSION,
+        plural="clustertrainingruntimes",
+        body={
+            "apiVersion": f"{trainer_constants.GROUP}/{trainer_constants.VERSION}",
+            "kind": "ClusterTrainingRuntime",
+            "metadata": {"name": "new-runtime"},
+            "spec": spec,
+        },
+        _request_timeout=mcp_utils.K8S_TIMEOUT,
+    )
+
+
+def test_create_runtime_name_collision_returns_kubernetes_error(mock_k8s_apis):
+    api = mock_k8s_apis["custom"]
+    collision = ApiException(status=409, reason="Already Exists")
+    api.create_cluster_custom_object.side_effect = collision
+
+    result = create_runtime(
+        "existing-runtime",
+        spec={"labels": {"team": "ml"}},
+        confirmed=True,
+    )
+
+    error = verify_tool_error(result, error_code=KUBERNETES_ERROR)
+    assert error["details"]["message"] == str(collision)
+
+
+def test_delete_runtime_preview_lists_dependent_trainjobs(mock_k8s_apis):
+    api = mock_k8s_apis["custom"]
+    api.list_cluster_custom_object.return_value = {
+        "items": [
+            create_mock_trainjob(name="job-a", namespace="ml"),
+            create_mock_trainjob(name="job-b", namespace="ml"),
+        ],
+    }
+
+    result = delete_runtime("torchtune-llama", confirmed=False)
+
+    data = verify_tool_success(result)
+    assert data["dependent_count"] == 2
+    assert data["dependent_jobs"] == [
+        {"name": "job-a", "namespace": "ml"},
+        {"name": "job-b", "namespace": "ml"},
+    ]
+    assert "2 TrainJob(s)" in data["warning"]
+    api.delete_cluster_custom_object.assert_not_called()
+
+
+def test_delete_runtime_confirmed_removes_runtime(mock_k8s_apis):
+    api = mock_k8s_apis["custom"]
+    api.list_cluster_custom_object.return_value = {
+        "items": [create_mock_trainjob(name="job-a", namespace="ml")],
+    }
+
+    result = delete_runtime("torchtune-llama", confirmed=True)
+
+    data = verify_tool_success(result)
+    assert data["runtime"] == "torchtune-llama"
+    assert data["deleted"] is True
+    assert data["dependent_jobs_affected"] == 1
+    api.delete_cluster_custom_object.assert_called_once_with(
+        group=trainer_constants.GROUP,
+        version=trainer_constants.VERSION,
+        plural="clustertrainingruntimes",
+        name="torchtune-llama",
+        _request_timeout=mcp_utils.K8S_TIMEOUT,
+    )
+
+
+def test_non_admin_persona_cannot_manage_runtimes():
+    allowed_tools = get_allowed_tools("ml-engineer")
+
+    assert allowed_tools is not None
+    assert "patch_runtime" not in allowed_tools
+    assert "create_runtime" not in allowed_tools
+    assert "delete_runtime" not in allowed_tools
+
+
+# Remaining TODOs are outside this PR's runtime CRUD slice.
 # TODO(test): test inspect_crd — lists all Trainer CRDs
 # TODO(test): test inspect_crd(name) — returns CRD schema and conditions
 # TODO(test): test inspect_crd — invalid CRD name
 # TODO(test): test inspect_controller(view="logs") — returns controller logs
 # TODO(test): test inspect_controller(view="events") — returns controller events
-# TODO(test): test patch_runtime — confirmed=True applies strategic merge patch
-# TODO(test): test patch_runtime — invalid runtime name rejected
-# TODO(test): test create_runtime — confirmed=True creates runtime
-# TODO(test): test create_runtime — name collision error
-# TODO(test): test delete_runtime — preview lists dependent TrainJobs
-# TODO(test): test delete_runtime — confirmed=True removes runtime
-# TODO(test): test delete_runtime — non-admin persona rejected

--- a/kubeflow_mcp/trainer/api/platform_test.py
+++ b/kubeflow_mcp/trainer/api/platform_test.py
@@ -224,3 +224,11 @@ def test_non_admin_persona_cannot_manage_runtimes():
     assert "patch_runtime" not in allowed_tools
     assert "create_runtime" not in allowed_tools
     assert "delete_runtime" not in allowed_tools
+
+
+# Remaining TODOs are outside this PR's runtime CRUD slice.
+# TODO(test): test inspect_crd — lists all Trainer CRDs
+# TODO(test): test inspect_crd(name) — returns CRD schema and conditions
+# TODO(test): test inspect_crd — invalid CRD name
+# TODO(test): test inspect_controller(view="logs") — returns controller logs
+# TODO(test): test inspect_controller(view="events") — returns controller events

--- a/kubeflow_mcp/trainer/api/platform_test.py
+++ b/kubeflow_mcp/trainer/api/platform_test.py
@@ -224,11 +224,3 @@ def test_non_admin_persona_cannot_manage_runtimes():
     assert "patch_runtime" not in allowed_tools
     assert "create_runtime" not in allowed_tools
     assert "delete_runtime" not in allowed_tools
-
-
-# Remaining TODOs are outside this PR's runtime CRUD slice.
-# TODO(test): test inspect_crd — lists all Trainer CRDs
-# TODO(test): test inspect_crd(name) — returns CRD schema and conditions
-# TODO(test): test inspect_crd — invalid CRD name
-# TODO(test): test inspect_controller(view="logs") — returns controller logs
-# TODO(test): test inspect_controller(view="events") — returns controller events


### PR DESCRIPTION
## Summary
Part of #68 — platform section.

Adds unit coverage for runtime CRUD tools with mocked CustomObjects API:

### `patch_runtime`
- missing patch / invalid top-level keys
- preview when `confirmed=False`
- success when confirmed
- not-found + generic Kubernetes error

### `create_runtime`
- missing spec / invalid top-level keys
- preview body construction
- success when confirmed
- generic error

### `delete_runtime`
- preview lists dependent TrainJobs
- preview with no dependents
- success when confirmed
- not-found + generic error

## Testing
```bash
uv run pytest -q tests/unit/trainer/test_platform.py
# 16 passed
```