### PR TITLE
fix: unify make verify with pre-commit and document uv setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,12 +18,18 @@ We encourage the judicious use of AI/LLM tools; please refer to the [Kubeflow AI
    cd mcp-server
    ```
 
-3. Set up development environment:
+3. Install the [uv](https://docs.astral.sh/uv/) CLI if you do not already have it:
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+   (`make install-dev` can also auto-install uv via the `make uv` target.)
+
+4. Set up development environment:
    ```bash
    make install-dev
    ```
 
-4. Create a branch:
+5. Create a branch:
    ```bash
    git checkout -b feat/your-feature
    ```
@@ -42,7 +48,7 @@ uv run pre-commit install
 
 The pre-commit hooks ensure code quality and consistency (linting and formatting with `ruff`). They are also executed in CI.
 
-To run verification checks locally:
+To run verification checks locally (matches CI: lockfile check + `pre-commit run --all-files`):
 
 ```bash
 make verify

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,10 @@ install-dev: uv ## Install all development dependencies
 
 ##@ Quality
 
-verify: ## Run linting and formatting checks
+verify: install-dev ## Run the same checks CI runs (pre-commit + lockfile)
 	@uv lock --check
-	@uv run --group dev ruff check .
-	@uv run --group dev ruff format --check .
+	@uv run pre-commit run --all-files
+	@echo "All checks passed!"
 
 format: ## Auto-format and fix lint issues
 	@uv run --group dev ruff check --fix .


### PR DESCRIPTION
## Summary
Fixes #96

### Changes
1. **`make verify`** now matches CI:
   - `uv lock --check`
   - `uv run pre-commit run --all-files`
   - depends on `install-dev` so hooks/deps are present
2. **`CONTRIBUTING.md`**
   - explicit `uv` install one-liner
   - note that `make install-dev` can auto-install via `make uv`
   - clarify that `make verify` runs the full pre-commit suite

### Why
CI already runs pre-commit (trailing whitespace, EOF newline, YAML, ruff). Local `make verify` only ran ruff, so contributors could pass locally and fail CI.

## Testing
```bash
make verify
# pre-commit hooks passed + \"All checks passed!\"
```