### PR TITLE
feat(optimizer): add Katib client with 17 MCP tools (KEP-34)

### DIFF
--- a/kubeflow_mcp/common/constants.py
+++ b/kubeflow_mcp/common/constants.py
@@ -226,7 +226,6 @@ SDK_COMPATIBILITY: dict[str, object] = {
             "sdk_client": "kubeflow.optimizer.OptimizerClient",
             "covered_methods": [
                 "get_job",
-                "list_jobs",
                 "delete_job",
                 "get_best_results",
                 "get_job_logs",
@@ -241,10 +240,17 @@ SDK_COMPATIBILITY: dict[str, object] = {
                 # label are both unreachable through it. create_hpo_experiment
                 # builds the V1beta1Experiment CR directly instead.
                 "optimize",
+                # list_jobs() resolves every trial's TrainJob individually, so
+                # listing a namespace costs one API call per trial. A summary
+                # needs only fields the Experiment CR already carries, so
+                # list_experiments lists the CR directly instead.
+                "list_jobs",
             ],
             "k8s_api_operations": [
                 "create_hpo_experiment (CustomObjectsApi create)",
                 "create_experiment_from_spec (CustomObjectsApi create)",
+                "list_experiments (CustomObjectsApi list)",
+                "get_experiment_status (CustomObjectsApi get)",
                 "list_suggestions (CustomObjectsApi list)",
                 "get_suggestion (CustomObjectsApi get)",
                 "update_experiment (CustomObjectsApi get + patch)",

--- a/kubeflow_mcp/common/constants.py
+++ b/kubeflow_mcp/common/constants.py
@@ -72,6 +72,7 @@ class JobStatus:
 # =============================================================================
 
 TOOL_PHASES: dict[str, list[str]] = {
+    # ── Trainer phases ──
     "planning": [
         "pre_flight",
         "check_compatibility",
@@ -95,6 +96,26 @@ TOOL_PHASES: dict[str, list[str]] = {
         "delete_runtime",
     ],
     "health": ["health_check", "get_server_logs"],
+    # ── Optimizer (Katib) phases ──
+    "optimizer_planning": ["katib_pre_flight"],
+    "optimizer_discovery": [
+        "list_experiments",
+        "get_experiment",
+        "get_experiment_status",
+        "get_trial",
+        "get_successful_trials",
+        "list_suggestions",
+    ],
+    "optimizer_optimization": ["create_hpo_experiment", "create_experiment_from_spec"],
+    "optimizer_monitoring": [
+        "get_experiment_trials",
+        "get_best_trial",
+        "get_suggestion",
+        "wait_for_experiment",
+        "get_experiment_trial_logs",
+        "get_experiment_events",
+    ],
+    "optimizer_lifecycle": ["delete_experiment", "update_experiment"],
 }
 
 # Reverse mapping: tool name -> phase
@@ -121,6 +142,7 @@ TRAINER_CRD_NAME = "trainjobs.trainer.kubeflow.org"
 # =============================================================================
 
 TOOL_NEXT_HINTS: dict[str, str] = {
+    # ── Trainer hints ──
     "pre_flight": "Proceed to list_runtimes() to find available runtimes",
     "check_compatibility": "Call get_cluster_resources() or use pre_flight() for full check",
     "get_cluster_resources": "Call estimate_resources(model=...) or list_runtimes()",
@@ -136,7 +158,10 @@ TOOL_NEXT_HINTS: dict[str, str] = {
     ),
     "get_training_logs": "If errors found, check get_training_events(name) for K8s-level issues",
     "get_training_events": "Fix the issue and retry, or delete_training_job(name) and resubmit",
-    "wait_for_training": "Check get_training_logs(name) for final output",
+    "wait_for_training": (
+        "Check get_training_logs(name) for final output. "
+        "Use create_hpo_experiment() to optimize hyperparameters"
+    ),
     "delete_training_job": "Resubmit with fine_tune() or run_custom_training() if needed",
     "update_training_job": "Check get_training_job(name) to verify new status",
     "inspect_crd": "Use inspect_controller(view='logs') to check controller health",
@@ -146,6 +171,24 @@ TOOL_NEXT_HINTS: dict[str, str] = {
     "patch_runtime": "Verify changes with get_runtime(name)",
     "create_runtime": "Verify with list_runtimes() or get_runtime(name)",
     "delete_runtime": "Confirm removal with list_runtimes()",
+    # ── Optimizer (Katib) hints ──
+    "katib_pre_flight": "Proceed to list_experiments() or create_hpo_experiment()",
+    "list_experiments": "Call get_experiment(name) for details on a specific experiment",
+    "get_experiment": "Use get_experiment_trials(name) or get_best_trial(name) for results",
+    "get_experiment_status": "Use get_experiment(name) for full details or get_experiment_trial_logs(name)",
+    "get_trial": "Check get_experiment_trial_logs(name, trial=trial) for trial output",
+    "get_successful_trials": "Use get_best_trial(name) for the optimal result",
+    "list_suggestions": "Check get_suggestion(name) for details on a specific suggestion",
+    "get_experiment_trials": "Use get_best_trial(name) or get_experiment_trial_logs(name, trial=trial)",
+    "get_best_trial": "Use fine_tune() to retrain with these hyperparameters",
+    "get_suggestion": "Check get_experiment_events(name) if suggestion is stuck",
+    "wait_for_experiment": "Check get_best_trial(name) for optimal results",
+    "get_experiment_trial_logs": "If errors found, check get_experiment_events(name)",
+    "get_experiment_events": "Fix the issue and retry, or delete_experiment(name) and resubmit",
+    "create_hpo_experiment": "Monitor with get_experiment_status() or wait_for_experiment()",
+    "create_experiment_from_spec": "Monitor with get_experiment_status() or wait_for_experiment()",
+    "delete_experiment": "Resubmit with create_hpo_experiment() if needed",
+    "update_experiment": "Check get_experiment_status(name) to verify new status",
 }
 
 
@@ -179,9 +222,34 @@ SDK_COMPATIBILITY: dict[str, object] = {
             ],
         },
         "optimizer": {
-            "status": "stub",
-            "sdk_client": "kubeflow.katib.KatibClient",
-            "covered_methods": [],
+            "status": "implemented",
+            "sdk_client": "kubeflow.optimizer.OptimizerClient",
+            "covered_methods": [
+                "get_job",
+                "list_jobs",
+                "delete_job",
+                "get_best_results",
+                "get_job_logs",
+                "get_job_events",
+                "wait_for_job_status",
+            ],
+            "uncovered_methods": [
+                # optimize() requires TrainJobTemplate.trainer to be a CustomTrainer
+                # holding a live Python callable (func), which cannot cross the
+                # MCP/JSON boundary. It also generates its own Experiment name and
+                # sets no labels, so a caller-supplied name and the MCP ownership
+                # label are both unreachable through it. create_hpo_experiment
+                # builds the V1beta1Experiment CR directly instead.
+                "optimize",
+            ],
+            "k8s_api_operations": [
+                "create_hpo_experiment (CustomObjectsApi create)",
+                "create_experiment_from_spec (CustomObjectsApi create)",
+                "list_suggestions (CustomObjectsApi list)",
+                "get_suggestion (CustomObjectsApi get)",
+                "update_experiment (CustomObjectsApi get + patch)",
+                "katib_pre_flight (ApiextensionsV1Api + CoreV1Api)",
+            ],
         },
         "hub": {
             "status": "stub",

--- a/kubeflow_mcp/common/constants_test.py
+++ b/kubeflow_mcp/common/constants_test.py
@@ -65,6 +65,13 @@ class TestToolPhases:
             "lifecycle",
             "platform",
             "health",
+            # Optimizer phases are namespaced so they cannot collide with the
+            # trainer phases above.
+            "optimizer_planning",
+            "optimizer_discovery",
+            "optimizer_optimization",
+            "optimizer_monitoring",
+            "optimizer_lifecycle",
         }
         assert set(TOOL_PHASES.keys()) == expected
 

--- a/kubeflow_mcp/common/utils.py
+++ b/kubeflow_mcp/common/utils.py
@@ -233,13 +233,22 @@ def get_optimizer_effective_namespace(namespace: str | None = None) -> str:
     return "default"
 
 
-def is_optimizer_mcp_managed(name: str, namespace: str) -> bool | None:
-    """Check if an Experiment was created through MCP (has the ownership label).
+# Outcomes of an optimizer ownership check. "missing" is kept distinct from
+# "unmanaged" so callers can report a typo'd name as not-found instead of
+# blaming ownership, which sends the caller after RBAC that is not the problem.
+OWNERSHIP_MANAGED = "managed"
+OWNERSHIP_UNMANAGED = "unmanaged"
+OWNERSHIP_MISSING = "missing"
+
+
+def get_optimizer_ownership(name: str, namespace: str) -> str | None:
+    """Classify an Experiment for the MCP ownership gate.
 
     Returns:
-        True if the experiment has the MCP ownership label.
-        False if the experiment exists but lacks the label.
-        None if the check could not be performed (API error, permissions).
+        ``OWNERSHIP_MANAGED`` if the experiment carries the MCP ownership label,
+        ``OWNERSHIP_UNMANAGED`` if it exists without the label,
+        ``OWNERSHIP_MISSING`` if no such experiment exists, or
+        ``None`` if the check could not be performed (API error, permissions).
     """
     from kubeflow_mcp.optimizer.constants import (
         EXPERIMENT_PLURAL,
@@ -258,12 +267,13 @@ def is_optimizer_mcp_managed(name: str, namespace: str) -> bool | None:
             _request_timeout=K8S_TIMEOUT,
         )
         labels = obj.get("metadata", {}).get("labels", {})
-        return labels.get(MCP_MANAGED_LABEL) == MCP_MANAGED_VALUE
+        managed = labels.get(MCP_MANAGED_LABEL) == MCP_MANAGED_VALUE
+        return OWNERSHIP_MANAGED if managed else OWNERSHIP_UNMANAGED
     except Exception as e:
         from kubeflow_mcp.common.types import is_k8s_not_found
 
         if is_k8s_not_found(e):
-            return False
+            return OWNERSHIP_MISSING
         return None
 
 

--- a/kubeflow_mcp/common/utils.py
+++ b/kubeflow_mcp/common/utils.py
@@ -31,6 +31,13 @@ if TYPE_CHECKING:
 
 K8S_TIMEOUT = 5
 
+# Writes that go through admission webhooks need a longer budget than reads.
+# Katib registers a mutating and a validating webhook, each with its own 10s
+# timeout, so a create can legitimately outlive K8S_TIMEOUT while the API server
+# is still waiting on them. Timing out first turns a diagnosable admission
+# failure into an opaque "read timed out", so writes get their own bound.
+K8S_WRITE_TIMEOUT = 30
+
 
 @lru_cache(maxsize=1)
 def _get_api_client() -> "k8s_client.ApiClient":

--- a/kubeflow_mcp/common/utils.py
+++ b/kubeflow_mcp/common/utils.py
@@ -16,6 +16,7 @@
 
 Mirrors kubeflow SDK's client structure:
 - TrainerClient from kubeflow.trainer
+- OptimizerClient from kubeflow.optimizer
 """
 
 import threading
@@ -173,9 +174,105 @@ def is_mcp_managed(name: str, namespace: str) -> bool | None:
         return None
 
 
+# =============================================================================
+# Optimizer (Katib) client factories
+# Mirrors the TrainerClient pattern above.
+# =============================================================================
+
+
+@lru_cache(maxsize=1)
+def get_optimizer_client() -> Any:
+    """Get or create OptimizerClient singleton.
+
+    Uses default KubernetesBackendConfig with current kubeconfig context.
+    """
+    from kubeflow.optimizer import OptimizerClient
+
+    return OptimizerClient()
+
+
+_optimizer_ns_client_cache: dict[str, Any] = {}
+_optimizer_ns_client_lock = threading.Lock()
+
+
+def get_optimizer_client_for_namespace(namespace: str | None = None) -> Any:
+    """Return an OptimizerClient targeting the given namespace.
+
+    When *namespace* is ``None`` the shared singleton (default kubeconfig
+    namespace) is returned.  When a namespace is explicitly provided a
+    cached ``OptimizerClient`` scoped to that namespace is returned.
+    """
+    if namespace is None:
+        return get_optimizer_client()
+    with _optimizer_ns_client_lock:
+        if namespace in _optimizer_ns_client_cache:
+            return _optimizer_ns_client_cache[namespace]
+        from kubeflow.common.types import KubernetesBackendConfig
+        from kubeflow.optimizer import OptimizerClient
+
+        client = OptimizerClient(backend_config=KubernetesBackendConfig(namespace=namespace))
+        if len(_optimizer_ns_client_cache) >= _NS_CLIENT_CACHE_MAX:
+            oldest = next(iter(_optimizer_ns_client_cache))
+            del _optimizer_ns_client_cache[oldest]
+        _optimizer_ns_client_cache[namespace] = client
+        return client
+
+
+def get_optimizer_effective_namespace(namespace: str | None = None) -> str:
+    """Namespace for OptimizationJob operations: explicit arg, then SDK backend, else ``default``.
+
+    Aligns direct CustomObjects calls with :class:`OptimizerClient` (Kubernetes backend).
+    """
+    if namespace:
+        return namespace
+    client = get_optimizer_client()
+    backend = client.backend
+    ns = getattr(backend, "namespace", None)
+    if ns is not None:
+        return str(ns)
+    return "default"
+
+
+def is_optimizer_mcp_managed(name: str, namespace: str) -> bool | None:
+    """Check if an Experiment was created through MCP (has the ownership label).
+
+    Returns:
+        True if the experiment has the MCP ownership label.
+        False if the experiment exists but lacks the label.
+        None if the check could not be performed (API error, permissions).
+    """
+    from kubeflow_mcp.optimizer.constants import (
+        EXPERIMENT_PLURAL,
+        KATIB_API_GROUP,
+        KATIB_API_VERSION,
+    )
+
+    try:
+        api = get_custom_objects_api()
+        obj = api.get_namespaced_custom_object(
+            group=KATIB_API_GROUP,
+            version=KATIB_API_VERSION,
+            namespace=namespace,
+            plural=EXPERIMENT_PLURAL,
+            name=name,
+            _request_timeout=K8S_TIMEOUT,
+        )
+        labels = obj.get("metadata", {}).get("labels", {})
+        return labels.get(MCP_MANAGED_LABEL) == MCP_MANAGED_VALUE
+    except Exception as e:
+        from kubeflow_mcp.common.types import is_k8s_not_found
+
+        if is_k8s_not_found(e):
+            return False
+        return None
+
+
 def reset_clients() -> None:
     """Reset all cached clients (for testing or kubeconfig rotation)."""
     get_trainer_client.cache_clear()
+    get_optimizer_client.cache_clear()
     _get_api_client.cache_clear()
     with _ns_client_lock:
         _ns_client_cache.clear()
+    with _optimizer_ns_client_lock:
+        _optimizer_ns_client_cache.clear()

--- a/kubeflow_mcp/core/instructions_test.py
+++ b/kubeflow_mcp/core/instructions_test.py
@@ -1,0 +1,62 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for server instruction assembly across client modules.
+
+Regression guard: every loaded module's INSTRUCTION_SECTIONS must actually
+surface to the agent — not just the trainer's. A hardcoded section-order list
+previously dropped the optimizer's namespaced sections.
+"""
+
+import importlib
+
+from kubeflow_mcp.core.server import _build_server_instructions, _sections_for_persona
+
+
+def _modules():
+    return {
+        "trainer": importlib.import_module("kubeflow_mcp.trainer"),
+        "optimizer": importlib.import_module("kubeflow_mcp.optimizer"),
+    }
+
+
+def test_optimizer_sections_surface_for_admin():
+    sections = _sections_for_persona("platform-admin")
+    assert "optimizer_planning" in sections
+    assert "optimizer_optimization" in sections
+    assert "optimizer_monitoring" in sections
+
+
+def test_trainer_sections_still_ordered_first():
+    sections = _sections_for_persona("platform-admin")
+    # Known trainer sections keep their canonical position ahead of optimizer's.
+    assert sections.index("planning") < sections.index("optimizer_planning")
+
+
+def test_admin_instructions_include_optimizer_guidance():
+    instr = _build_server_instructions(_modules(), "platform-admin", "full")
+    assert "OPTIMIZER PLANNING" in instr
+    assert "OPTIMIZER MONITORING" in instr
+    assert "OPTIMIZER TOOL SELECTION" in instr
+    # Trainer guidance is unaffected.
+    assert "PLANNING" in instr
+
+
+def test_readonly_excludes_optimization_section():
+    """readonly persona has no create_* tools, so the optimization-phase
+    instruction section must not be injected."""
+    instr = _build_server_instructions(_modules(), "readonly", "full")
+    assert "OPTIMIZER TOOL SELECTION" not in instr
+    # But read-only monitoring/planning guidance should still appear.
+    assert "OPTIMIZER MONITORING" in instr

--- a/kubeflow_mcp/core/policy.py
+++ b/kubeflow_mcp/core/policy.py
@@ -73,6 +73,7 @@ def _get_policy_paths() -> list[Path]:
 PERSONAS: dict[str, dict[str, Any]] = {
     "readonly": {
         "tools": [
+            # Trainer
             "pre_flight",
             "check_compatibility",
             "get_cluster_resources",
@@ -85,30 +86,52 @@ PERSONAS: dict[str, dict[str, Any]] = {
             "get_training_events",
             "health_check",
             "get_server_logs",
+            # Optimizer (read-only — 13 tools: planning + discovery + monitoring)
+            "katib_pre_flight",
+            "list_experiments",
+            "get_experiment",
+            "get_experiment_status",
+            "get_trial",
+            "get_successful_trials",
+            "list_suggestions",
+            "get_experiment_trials",
+            "get_best_trial",
+            "get_suggestion",
+            "wait_for_experiment",
+            "get_experiment_trial_logs",
+            "get_experiment_events",
         ]
     },
     "data-scientist": {
         "inherit": "readonly",
         "tools": [
+            # Trainer
             "fine_tune",
             "run_custom_training",
             "wait_for_training",
             "delete_training_job",
+            # Optimizer
+            "create_hpo_experiment",
+            "delete_experiment",
         ],
     },
     "ml-engineer": {
         "inherit": "data-scientist",
         "tools": [
+            # Trainer
             "run_container_training",
             "update_training_job",
             "inspect_crd",
             "inspect_controller",
+            # Optimizer
+            "create_experiment_from_spec",
+            "update_experiment",
         ],
     },
     "platform-admin": {"tools": "*"},
 }
 
-DESTRUCTIVE_TOOLS = {"delete_training_job", "delete_runtime"}
+DESTRUCTIVE_TOOLS = {"delete_training_job", "delete_runtime", "delete_experiment"}
 
 # ─── Runtime persona ───────────────────────
 # Set once at server startup by create_server(); tools read via get_effective_persona().

--- a/kubeflow_mcp/core/security.py
+++ b/kubeflow_mcp/core/security.py
@@ -16,6 +16,7 @@
 
 import ast
 import re
+from collections.abc import Callable
 from typing import Any
 
 from kubeflow_mcp.common.constants import ErrorCode
@@ -57,15 +58,23 @@ def validate_namespace(namespace: str) -> ToolError | None:
     return validate_k8s_name(namespace, "namespace")
 
 
-def check_namespace_allowed(namespace: str | None) -> ToolError | None:
+def check_namespace_allowed(
+    namespace: str | None,
+    resolver: Callable[[str | None], str] | None = None,
+) -> ToolError | None:
     """Check if namespace is allowed by policy.
 
-    When *namespace* is ``None`` the effective default namespace from the
-    TrainerClient backend is resolved and checked against the allowlist so
-    that implicit-default usage cannot bypass namespace restrictions.
+    When *namespace* is ``None`` the effective default namespace is resolved and
+    checked against the allowlist so that implicit-default usage cannot bypass
+    namespace restrictions.
 
     Args:
         namespace: Namespace to check. ``None`` resolves to the effective default.
+        resolver: Resolves the effective default namespace for the client the
+            caller operates through. Defaults to the trainer client's resolver.
+            Callers acting on another client's resources **must** pass that
+            client's resolver — otherwise the namespace validated here is not the
+            namespace the operation targets, and the allowlist can be bypassed.
 
     Returns:
         ToolError if namespace is restricted, None if allowed
@@ -80,9 +89,11 @@ def check_namespace_allowed(namespace: str | None) -> ToolError | None:
     effective = namespace
     if effective is None:
         try:
-            from kubeflow_mcp.common.utils import get_trainer_effective_namespace
+            if resolver is None:
+                from kubeflow_mcp.common.utils import get_trainer_effective_namespace
 
-            effective = get_trainer_effective_namespace(None)
+                resolver = get_trainer_effective_namespace
+            effective = resolver(None)
         except Exception:
             return ToolError(
                 error="Cannot resolve effective namespace; refusing request (fail closed)",

--- a/kubeflow_mcp/optimizer/__init__.py
+++ b/kubeflow_mcp/optimizer/__init__.py
@@ -12,72 +12,352 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""OptimizerClient integration for Katib hyperparameter tuning.
+"""Optimizer client module — MCP tools for Katib hyperparameter optimization.
 
-STATUS: Stub module - Ready for contributors (Phase 2)
-
-This module will wrap kubeflow.optimizer.OptimizerClient to provide
-hyperparameter optimization tools via MCP.
-
-Planned Tools (8 total):
-    - create_optimization_job() → OptimizerClient.optimize()
-    - list_optimization_jobs() → OptimizerClient.list_jobs()
-    - get_optimization_job() → OptimizerClient.get_job()
-    - get_optimization_logs() → OptimizerClient.get_job_logs()
-    - get_optimization_events() → OptimizerClient.get_job_events()
-    - get_best_hyperparameters() → OptimizerClient.get_best_results()
-    - wait_for_optimization() → OptimizerClient.wait_for_job_status()
-    - delete_optimization_job() → OptimizerClient.delete_job()
-
-To implement:
-    1. Copy trainer/ structure as reference
-    2. Add client factory to common/utils.py:
-       ```python
-       @lru_cache(maxsize=1)
-       def get_optimizer_client() -> "OptimizerClient":
-           from kubeflow.optimizer import OptimizerClient
-           return OptimizerClient()
-       ```
-    3. Implement tools in api/ subdirectory
-    4. Update TOOLS list below
-    5. Add MCP prompts in core/prompts.py
-
-See: docs/CONVENTIONS.md and CONTRIBUTING.md
+Structure mirrors kubeflow/optimizer/ and the trainer client module:
+├── api/           # Tool implementations
+├── types/         # Type definitions
+├── constants/     # Constants (re-exported from SDK)
+└── resources/     # MCP resources (guides, troubleshooting)
 """
 
-from collections.abc import Callable
-from typing import Any
+from kubeflow_mcp.optimizer.api.discovery import (
+    get_experiment,
+    get_experiment_status,
+    get_successful_trials,
+    get_trial,
+    list_experiments,
+    list_suggestions,
+)
+from kubeflow_mcp.optimizer.api.lifecycle import (
+    delete_experiment,
+    update_experiment,
+)
+from kubeflow_mcp.optimizer.api.monitoring import (
+    get_best_trial,
+    get_experiment_events,
+    get_experiment_trial_logs,
+    get_experiment_trials,
+    get_suggestion,
+    wait_for_experiment,
+)
+from kubeflow_mcp.optimizer.api.optimization import (
+    create_experiment_from_spec,
+    create_hpo_experiment,
+)
+from kubeflow_mcp.optimizer.api.planning import (
+    katib_pre_flight,
+)
 
 MODULE_INFO = {
     "name": "optimizer",
-    "description": "Hyperparameter tuning with Katib",
+    "description": "Hyperparameter optimization with Katib",
     "sdk_client": "kubeflow.optimizer.OptimizerClient",
     "sdk_version": ">=0.4.0",
-    "status": "stub",
-    "planned_tools": 8,
+    "status": "implemented",
+    "planned_tools": 17,
 }
 
-# Tool categories for persona filtering (when implemented)
-TOOL_CATEGORIES: dict[str, list[str]] = {
-    "discovery": [
-        "list_optimization_jobs",
-        "get_optimization_job",
-    ],
-    "optimization": [
-        "create_optimization_job",
-        "get_best_hyperparameters",
-    ],
-    "monitoring": [
-        "get_optimization_logs",
-        "get_optimization_events",
-        "wait_for_optimization",
-    ],
-    "lifecycle": [
-        "delete_optimization_job",
-    ],
+TOOLS = [
+    # Planning
+    katib_pre_flight,
+    # Discovery
+    list_experiments,
+    get_experiment,
+    get_experiment_status,
+    get_trial,
+    get_successful_trials,
+    list_suggestions,
+    # Monitoring
+    get_experiment_trials,
+    get_best_trial,
+    get_suggestion,
+    wait_for_experiment,
+    get_experiment_trial_logs,
+    get_experiment_events,
+    # Optimization
+    create_hpo_experiment,
+    create_experiment_from_spec,
+    # Lifecycle
+    delete_experiment,
+    update_experiment,
+]
+
+# ─── Tool metadata (owned by this client module) ───────────────────────────
+
+CLIENT_TOOL_DESCRIPTIONS: dict[str, str] = {
+    "katib_pre_flight": (
+        "One-shot: Katib CRD + controller health + trainer availability. "
+        "Call FIRST before any optimizer operations."
+    ),
+    "list_experiments": "List Katib experiments. Filter by status or namespace.",
+    "get_experiment": (
+        "Get full experiment details: spec, status, trials, search space, algorithm, best trial."
+    ),
+    "get_experiment_status": (
+        "Lightweight status check — status string + trial counts only. "
+        "Faster than get_experiment() for polling."
+    ),
+    "get_trial": "Get trial details: parameters, metrics, and status by name.",
+    "get_successful_trials": (
+        "Successful trials with hyperparameters and metrics for comparison. "
+        "Returns up to `limit` (default 50); `total` reports the full count."
+    ),
+    "list_suggestions": "List suggestion resources for algorithm debugging.",
+    "get_experiment_trials": ("List trials for an experiment with optional status filter."),
+    "get_best_trial": "Best trial with optimal hyperparameters and metrics.",
+    "get_suggestion": "Suggestion algorithm status and request/reply counts.",
+    "wait_for_experiment": (
+        "Block until experiment reaches terminal status (Complete/Failed). Timeout capped at 3600s."
+    ),
+    "get_experiment_trial_logs": (
+        "Pod logs from a trial. If no trial specified, uses the best trial. "
+        "Failure patterns auto-detected with hints."
+    ),
+    "get_experiment_events": ("K8s events for experiment. Debug scheduling/image pull issues."),
+    "create_hpo_experiment": (
+        "Create HPO experiment from flat params. Search types: uniform, "
+        "loguniform, choice. Algorithms: random, grid, bayesianoptimization, "
+        "tpe, multivariate-tpe, cmaes, sobol, hyperband. "
+        "Set confirmed=True to submit."
+    ),
+    "create_experiment_from_spec": (
+        "Create experiment from raw V1beta1Experiment JSON spec. "
+        "Escape hatch for advanced configs. Set confirmed=True to submit."
+    ),
+    "delete_experiment": (
+        "[DESTRUCTIVE] Delete experiment permanently. Set confirmed=True to execute."
+    ),
+    "update_experiment": ("Suspend or resume experiment. Pass action='suspend' or 'resume'."),
 }
 
-# TODO: Implement tools (see CONTRIBUTING.md)
-TOOLS: list[Callable[..., dict[str, Any]]] = []
+CLIENT_TOOL_ANNOTATIONS: dict[str, dict] = {
+    "katib_pre_flight": {
+        "title": "Katib Pre-flight Check",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["planning", "preflight", "katib", "compound"],
+    },
+    "list_experiments": {
+        "title": "List Experiments",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["discovery", "experiments"],
+    },
+    "get_experiment": {
+        "title": "Get Experiment Details",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["discovery", "monitoring", "experiments"],
+    },
+    "get_experiment_status": {
+        "title": "Get Experiment Status",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["discovery", "monitoring", "experiments"],
+    },
+    "get_trial": {
+        "title": "Get Trial Details",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["discovery", "trials"],
+    },
+    "get_successful_trials": {
+        "title": "Get Successful Trials",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["discovery", "trials", "results"],
+    },
+    "list_suggestions": {
+        "title": "List Suggestions",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["discovery", "suggestions", "debug"],
+    },
+    "get_experiment_trials": {
+        "title": "Get Experiment Trials",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["monitoring", "trials"],
+    },
+    "get_best_trial": {
+        "title": "Get Best Trial",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["monitoring", "results", "optimization"],
+    },
+    "get_suggestion": {
+        "title": "Get Suggestion Status",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["monitoring", "suggestions", "debug"],
+    },
+    "wait_for_experiment": {
+        "title": "Wait for Experiment",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["monitoring", "blocking"],
+    },
+    "get_experiment_trial_logs": {
+        "title": "Get Trial Logs",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["monitoring", "logs", "debug"],
+    },
+    "get_experiment_events": {
+        "title": "Get Experiment Events",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["monitoring", "events", "debug"],
+    },
+    "create_hpo_experiment": {
+        "title": "Create HPO Experiment",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+        "tags": ["optimization", "hpo", "create"],
+    },
+    "create_experiment_from_spec": {
+        "title": "Create Experiment from Spec",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+        "tags": ["optimization", "advanced", "create"],
+    },
+    "delete_experiment": {
+        "title": "Delete Experiment",
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["lifecycle", "cleanup"],
+    },
+    "update_experiment": {
+        "title": "Update Experiment",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+        "tags": ["lifecycle", "suspend", "resume"],
+    },
+}
 
-__all__ = ["MODULE_INFO", "TOOLS", "TOOL_CATEGORIES"]
+# ─── Resources (owned by this client module) ───────────────────────────────
+
+CLIENT_RESOURCES: dict[str, tuple[str, str]] = {
+    "optimizer://guides/hpo-patterns": (
+        "resources/hpo-patterns.md",
+        "HPO workflow patterns and algorithm selection guide.",
+    ),
+    "optimizer://guides/troubleshooting": (
+        "resources/troubleshooting.md",
+        "Common Katib errors and fixes.",
+    ),
+}
+
+# ─── Instruction sections (full tier; compact/minimal auto-derived) ────────
+
+PHASE_TO_SECTION: dict[str, str | None] = {
+    "optimizer_planning": "optimizer_planning",
+    "optimizer_discovery": None,
+    "optimizer_optimization": "optimizer_optimization",
+    "optimizer_monitoring": "optimizer_monitoring",
+    "optimizer_lifecycle": "optimizer_monitoring",
+}
+
+# Canonical ordering of this client's instruction sections.  server.py
+# concatenates SECTION_ORDER from every loaded client to build a stable
+# global preferred order, with no hardcoded list in the core. Names are
+# namespaced so they cannot collide with the trainer's sections.
+SECTION_ORDER: list[str] = [
+    "optimizer_planning",
+    "optimizer_optimization",
+    "optimizer_monitoring",
+]
+
+INSTRUCTION_SECTIONS: dict[str, dict[str, str]] = {
+    "optimizer_planning": {
+        "full": """\
+OPTIMIZER PLANNING (always do first):
+- katib_pre_flight() → One call: Katib CRD + controller health + trainer availability
+- If blockers returned, STOP and inform user
+- If trainer_available=false → cross-client workflows require --clients trainer,optimizer
+OPTIMIZER DISCOVERY (before creating experiments):
+- list_experiments() → find existing experiments in namespace
+- get_experiment(name) → inspect spec, status, trials, best trial
+- get_experiment_status(name) → lightweight status poll
+- get_successful_trials(name) → compare all successful trial hyperparameters""",
+    },
+    "optimizer_monitoring": {
+        "full": """\
+OPTIMIZER MONITORING AND LIFECYCLE:
+- get_experiment_trials(name) → list all trials with status and parameters
+- get_best_trial(name) → optimal hyperparameters and metrics from best trial
+- get_experiment_trial_logs(name) → pod logs with failure pattern detection
+- get_experiment_events(name) → K8s events for debugging scheduling/image issues
+- wait_for_experiment(name) → block until Complete/Failed (timeout capped at 3600s)
+- get_suggestion(name) → algorithm status and request/reply counts
+- delete_experiment(name, confirmed=True) → remove permanently (preview first)
+- update_experiment(name, action="suspend"|"resume") → pause/resume experiment""",
+    },
+    "optimizer_optimization": {
+        "full": """\
+OPTIMIZER TOOL SELECTION:
+- HPO with flat params → create_hpo_experiment() — specify objective, search space, algorithm
+  - Search types: uniform (continuous), loguniform (log-scale), choice (categorical)
+  - Algorithms: random (default), grid, bayesianoptimization, tpe, multivariate-tpe,
+    cmaes, sobol, hyperband
+  - trial_template is the Katib trialSpec; reference params as ${trialParameters.<name>}
+  - ALWAYS preview first (confirmed=False), then show preview and wait for approval
+- Raw V1beta1Experiment spec → create_experiment_from_spec() — escape hatch for
+  early stopping, custom metrics collectors, resume policies and NAS
+
+OPTIMIZATION RULES:
+- ALWAYS call katib_pre_flight() before creating experiments
+- ALWAYS preview before submitting (confirmed=False first)
+- max_trial_count is capped at 1000 and parallel_trial_count at 100
+- Use get_experiment_events() to debug stuck/failed experiments
+- Read optimizer://guides/hpo-patterns for algorithm selection guide""",
+    },
+}
+
+
+__all__ = [
+    "MODULE_INFO",
+    "TOOLS",
+    "CLIENT_TOOL_DESCRIPTIONS",
+    "CLIENT_TOOL_ANNOTATIONS",
+    "CLIENT_RESOURCES",
+    "INSTRUCTION_SECTIONS",
+    "PHASE_TO_SECTION",
+    "SECTION_ORDER",
+    *[t.__name__ for t in TOOLS],
+]

--- a/kubeflow_mcp/optimizer/__init__.py
+++ b/kubeflow_mcp/optimizer/__init__.py
@@ -98,7 +98,10 @@ CLIENT_TOOL_DESCRIPTIONS: dict[str, str] = {
         "Lightweight status check — status string + trial counts only. "
         "Faster than get_experiment() for polling."
     ),
-    "get_trial": "Get trial details: parameters, metrics, and status by name.",
+    "get_trial": (
+        "Get one trial's parameters, metrics and status. "
+        "Pass the experiment as `name` and the trial as `trial`."
+    ),
     "get_successful_trials": (
         "Successful trials with hyperparameters and metrics for comparison. "
         "Returns up to `limit` (default 50); `total` reports the full count."
@@ -117,7 +120,7 @@ CLIENT_TOOL_DESCRIPTIONS: dict[str, str] = {
     "get_experiment_events": ("K8s events for experiment. Debug scheduling/image pull issues."),
     "create_hpo_experiment": (
         "Create HPO experiment from flat params. Search types: uniform, "
-        "loguniform, choice. Algorithms: random, grid, bayesianoptimization, "
+        "loguniform, int, choice. Algorithms: random, grid, bayesianoptimization, "
         "tpe, multivariate-tpe, cmaes, sobol, hyperband. "
         "Set confirmed=True to submit."
     ),
@@ -332,10 +335,15 @@ OPTIMIZER MONITORING AND LIFECYCLE:
         "full": """\
 OPTIMIZER TOOL SELECTION:
 - HPO with flat params → create_hpo_experiment() — specify objective, search space, algorithm
-  - Search types: uniform (continuous), loguniform (log-scale), choice (categorical)
+  - Search types: uniform (continuous), loguniform (log-scale), int (discrete range),
+    choice (categorical)
+  - Prefer int over choice for ordered whole numbers: categorical values carry no
+    ordering, so the algorithm cannot tell that 4 lies between 2 and 8
   - Algorithms: random (default), grid, bayesianoptimization, tpe, multivariate-tpe,
     cmaes, sobol, hyperband
   - trial_template is the Katib trialSpec; reference params as ${trialParameters.<name>}
+  - primary_container_name is derived from trial_template; set it only when the
+    container Katib should collect metrics from is not the one it picks
   - ALWAYS preview first (confirmed=False), then show preview and wait for approval
 - Raw V1beta1Experiment spec → create_experiment_from_spec() — escape hatch for
   early stopping, custom metrics collectors, resume policies and NAS

--- a/kubeflow_mcp/optimizer/api/__init__.py
+++ b/kubeflow_mcp/optimizer/api/__init__.py
@@ -1,4 +1,4 @@
-# Copyright The Kubeflow Authors
+# Copyright The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,50 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Optimizer API tools - Ready for contributors.
+"""Optimizer API tools."""
 
-This package will contain MCP tools for Katib hyperparameter optimization.
+from kubeflow_mcp.optimizer.api.discovery import (
+    get_experiment,
+    get_experiment_status,
+    get_successful_trials,
+    get_trial,
+    list_experiments,
+    list_suggestions,
+)
+from kubeflow_mcp.optimizer.api.lifecycle import (
+    delete_experiment,
+    update_experiment,
+)
+from kubeflow_mcp.optimizer.api.monitoring import (
+    get_best_trial,
+    get_experiment_events,
+    get_experiment_trial_logs,
+    get_experiment_trials,
+    get_suggestion,
+    wait_for_experiment,
+)
+from kubeflow_mcp.optimizer.api.optimization import (
+    create_experiment_from_spec,
+    create_hpo_experiment,
+)
+from kubeflow_mcp.optimizer.api.planning import (
+    katib_pre_flight,
+)
 
-Suggested file structure:
-    api/
-    ├── __init__.py         # This file - exports all tools
-    ├── optimization.py     # create_optimization_job
-    ├── discovery.py        # list_optimization_jobs, get_optimization_job
-    ├── monitoring.py       # get_optimization_logs, get_optimization_events, wait_for_optimization
-    └── lifecycle.py        # delete_optimization_job
-
-Example tool implementation:
-
-    def create_optimization_job(
-        objective: str,
-        search_space: dict,
-        algorithm: str = "random",
-        max_trials: int = 10,
-        parallel_trials: int = 2,
-        confirmed: bool = False,
-    ) -> dict:
-        '''Create a hyperparameter optimization experiment.
-
-        Args:
-            objective: Metric to optimize (e.g., "accuracy", "loss")
-            search_space: Parameter ranges to explore
-            algorithm: Search algorithm (random, grid, bayesian, hyperband)
-            max_trials: Maximum number of trials
-            parallel_trials: Trials to run in parallel
-            confirmed: Set True to submit (preview mode by default)
-
-        Returns:
-            Preview config or job creation result
-        '''
-        if not confirmed:
-            return PreviewResponse(
-                status="preview",
-                config={...},
-            ).model_dump()
-
-        client = get_optimizer_client()
-        job_name = client.optimize(...)
-        return ToolResponse(data={"job_id": job_name}).model_dump()
-"""
-
-__all__: list[str] = []
+__all__ = [
+    "katib_pre_flight",
+    "list_experiments",
+    "get_experiment",
+    "get_experiment_status",
+    "get_trial",
+    "get_successful_trials",
+    "list_suggestions",
+    "get_experiment_trials",
+    "get_best_trial",
+    "get_suggestion",
+    "wait_for_experiment",
+    "get_experiment_trial_logs",
+    "get_experiment_events",
+    "create_hpo_experiment",
+    "create_experiment_from_spec",
+    "delete_experiment",
+    "update_experiment",
+]

--- a/kubeflow_mcp/optimizer/api/_common.py
+++ b/kubeflow_mcp/optimizer/api/_common.py
@@ -24,8 +24,14 @@ from kubeflow_mcp.common.constants import ErrorCode
 from kubeflow_mcp.common.types import ToolError, exception_details, is_k8s_not_found
 from kubeflow_mcp.core.policy import get_effective_persona
 from kubeflow_mcp.core.security import check_namespace_allowed
+from kubeflow_mcp.optimizer.constants import KATIB_API_GROUP
 
 _FIND_HINT = "Use list_experiments() to find available experiments"
+_WEBHOOK_HINT = (
+    "The Katib control plane is not serving its admission webhooks. Run "
+    "katib_pre_flight() to confirm, then check the katib-controller deployment "
+    "and its RBAC. No experiment can be created until it reports ready."
+)
 
 # Collection responses are truncated so a large experiment cannot exhaust the
 # agent's context window. Matches the trainer client's list bounds.
@@ -85,6 +91,20 @@ def _api_status(exc: Exception) -> int | None:
     return None
 
 
+def _is_webhook_unavailable(exc: Exception) -> bool:
+    """True when the API server could not reach Katib's admission webhooks.
+
+    A Katib control plane that is installed but not Ready leaves its webhook
+    Service with no endpoints, and every write is rejected with a 500 whose
+    message names the webhook. The raw error is a wall of HTTP headers that
+    says nothing about what to do, so it is worth detecting.
+    """
+    if _api_status(exc) != 500:
+        return False
+    message = str(exc)
+    return "failed calling webhook" in message and KATIB_API_GROUP in message
+
+
 def resource_error(exc: Exception, name: str, kind: str = "Experiment") -> ToolError:
     """Map an exception raised by the SDK or K8s API onto a ``ToolError``.
 
@@ -123,6 +143,9 @@ def resource_error(exc: Exception, name: str, kind: str = "Experiment") -> ToolE
         error=str(exc),
         error_code=ErrorCode.SDK_ERROR,
         details=exception_details(exc),
+        # Stays SDK_ERROR: an unreachable webhook is a genuine infrastructure
+        # failure and should trip the circuit breaker. Only the hint is added.
+        hint=_WEBHOOK_HINT if _is_webhook_unavailable(exc) else None,
     )
 
 
@@ -161,14 +184,22 @@ def require_mcp_ownership(name: str, namespace: str, action: str) -> ToolError |
     if get_effective_persona() == "platform-admin":
         return None
 
-    managed = mcp_utils.is_optimizer_mcp_managed(name, namespace)
-    if managed is None:
+    ownership = mcp_utils.get_optimizer_ownership(name, namespace)
+    if ownership is None:
         return ToolError(
             error=f"Cannot verify ownership of experiment '{name}' (API error)",
             error_code=ErrorCode.SDK_ERROR,
             hint="Retry, or use the platform-admin persona to bypass the check.",
         )
-    if not managed:
+    if ownership == mcp_utils.OWNERSHIP_MISSING:
+        # Report the real problem. Falling through to the ownership message
+        # would blame permissions for what is usually a mistyped name.
+        return ToolError(
+            error=f"Experiment '{name}' not found",
+            error_code=ErrorCode.RESOURCE_NOT_FOUND,
+            hint=_FIND_HINT,
+        )
+    if ownership == mcp_utils.OWNERSHIP_UNMANAGED:
         return ToolError(
             error=f"Experiment '{name}' was not created by MCP",
             error_code=ErrorCode.VALIDATION_ERROR,

--- a/kubeflow_mcp/optimizer/api/_common.py
+++ b/kubeflow_mcp/optimizer/api/_common.py
@@ -1,0 +1,136 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for optimizer tools.
+
+Holds the two blocks that would otherwise be copy-pasted across every tool in
+``optimizer/api``: mapping SDK exceptions onto the right ``ToolError``, and
+enforcing MCP ownership before a mutating operation.
+"""
+
+from kubeflow_mcp.common import utils as mcp_utils
+from kubeflow_mcp.common.constants import ErrorCode
+from kubeflow_mcp.common.types import ToolError, exception_details, is_k8s_not_found
+from kubeflow_mcp.core.policy import get_effective_persona
+from kubeflow_mcp.core.security import check_namespace_allowed
+
+_FIND_HINT = "Use list_experiments() to find available experiments"
+
+# Collection responses are truncated so a large experiment cannot exhaust the
+# agent's context window. Matches the trainer client's list bounds.
+DEFAULT_LIST_LIMIT = 50
+MAX_LIST_LIMIT = 500
+
+
+def clamp_limit(limit: int) -> tuple[int, ToolError | None]:
+    """Validate and cap a caller-supplied result limit.
+
+    Returns the effective limit and, when the input is invalid, the
+    ``ToolError`` the tool should return instead of calling the cluster.
+    """
+    if limit < 1:
+        return 0, ToolError(
+            error=f"limit must be >= 1, got {limit}",
+            error_code=ErrorCode.VALIDATION_ERROR,
+        )
+    return min(limit, MAX_LIST_LIMIT), None
+
+
+def check_optimizer_namespace(namespace: str | None) -> ToolError | None:
+    """Namespace policy check for optimizer tools.
+
+    Every optimizer tool must go through this rather than calling
+    :func:`check_namespace_allowed` directly. The generic helper defaults to
+    resolving an omitted namespace through the *trainer* client, which is a
+    different backend than the one these tools act on — checking one namespace
+    while operating on another would let the allowlist be bypassed.
+    """
+    return check_namespace_allowed(namespace, resolver=mcp_utils.get_optimizer_effective_namespace)
+
+
+def _api_status(exc: Exception) -> int | None:
+    """HTTP status of the underlying Kubernetes API error, if there is one.
+
+    Mirrors :func:`is_k8s_not_found` by walking the cause chain, because the
+    optimizer SDK re-raises API failures as ``RuntimeError(...) from ApiException``.
+    """
+    try:
+        from kubernetes.client.exceptions import ApiException
+    except ImportError:  # pragma: no cover - kubernetes is a hard dependency
+        return None
+    for candidate in (exc, exc.__cause__, exc.__context__):
+        if isinstance(candidate, ApiException):
+            return candidate.status
+    return None
+
+
+def experiment_error(exc: Exception, name: str) -> ToolError:
+    """Map an exception raised by the SDK or K8s API onto a ``ToolError``.
+
+    The optimizer SDK wraps API failures as ``RuntimeError(...) from
+    ApiException``, so a missing resource is only visible through the cause
+    chain — :func:`is_k8s_not_found` handles that.
+    """
+    if is_k8s_not_found(exc):
+        return ToolError(
+            error=f"Experiment '{name}' not found",
+            error_code=ErrorCode.RESOURCE_NOT_FOUND,
+            hint=_FIND_HINT,
+        )
+    if _api_status(exc) == 409:
+        # A name collision is caller-fixable, so report it as a validation
+        # error: SDK_ERROR would also count as an infrastructure failure and
+        # needlessly trip the circuit breaker for this tool.
+        return ToolError(
+            error=f"Experiment '{name}' already exists",
+            error_code=ErrorCode.VALIDATION_ERROR,
+            hint=(
+                "Choose a different name, or delete the existing experiment "
+                f"with delete_experiment('{name}', confirmed=True)."
+            ),
+        )
+    return ToolError(
+        error=str(exc),
+        error_code=ErrorCode.SDK_ERROR,
+        details=exception_details(exc),
+    )
+
+
+def require_mcp_ownership(name: str, namespace: str, action: str) -> ToolError | None:
+    """Block non-admin personas from mutating experiments MCP did not create.
+
+    Returns ``None`` when the operation is allowed (admin persona, or the
+    experiment carries the MCP ownership label), otherwise the ``ToolError``
+    to return to the caller.
+    """
+    if get_effective_persona() == "platform-admin":
+        return None
+
+    managed = mcp_utils.is_optimizer_mcp_managed(name, namespace)
+    if managed is None:
+        return ToolError(
+            error=f"Cannot verify ownership of experiment '{name}' (API error)",
+            error_code=ErrorCode.SDK_ERROR,
+            hint="Retry, or use the platform-admin persona to bypass the check.",
+        )
+    if not managed:
+        return ToolError(
+            error=f"Experiment '{name}' was not created by MCP",
+            error_code=ErrorCode.VALIDATION_ERROR,
+            hint=(
+                f"Non-admin personas can only {action} experiments created through "
+                "MCP tools. Use the platform-admin persona for external experiments."
+            ),
+        )
+    return None

--- a/kubeflow_mcp/optimizer/api/_common.py
+++ b/kubeflow_mcp/optimizer/api/_common.py
@@ -32,6 +32,16 @@ _FIND_HINT = "Use list_experiments() to find available experiments"
 DEFAULT_LIST_LIMIT = 50
 MAX_LIST_LIMIT = 500
 
+# Katib's CRD vocabulary calls a finished resource "Succeeded"; the SDK reports
+# "Complete". Accept both wherever a caller filters by status, so the same value
+# works against experiments and trials alike.
+STATUS_FILTER_ALIASES: dict[str, str] = {"Succeeded": "Complete"}
+
+
+def resolve_status_filter(status: str) -> str:
+    """Map a caller-supplied status onto the value the SDK actually reports."""
+    return STATUS_FILTER_ALIASES.get(status, status)
+
 
 def clamp_limit(limit: int) -> tuple[int, ToolError | None]:
     """Validate and cap a caller-supplied result limit.
@@ -75,30 +85,64 @@ def _api_status(exc: Exception) -> int | None:
     return None
 
 
-def experiment_error(exc: Exception, name: str) -> ToolError:
+def resource_error(exc: Exception, name: str, kind: str = "Experiment") -> ToolError:
     """Map an exception raised by the SDK or K8s API onto a ``ToolError``.
 
     The optimizer SDK wraps API failures as ``RuntimeError(...) from
     ApiException``, so a missing resource is only visible through the cause
     chain — :func:`is_k8s_not_found` handles that.
+
+    Args:
+        exc: The exception raised by the SDK or Kubernetes client.
+        name: Name of the resource the operation targeted.
+        kind: Resource kind, used in the message. Defaults to ``"Experiment"``.
     """
     if is_k8s_not_found(exc):
         return ToolError(
-            error=f"Experiment '{name}' not found",
+            error=f"{kind} '{name}' not found",
             error_code=ErrorCode.RESOURCE_NOT_FOUND,
-            hint=_FIND_HINT,
+            hint=(
+                _FIND_HINT
+                if kind == "Experiment"
+                else "A Suggestion is created once an experiment starts running."
+            ),
         )
     if _api_status(exc) == 409:
         # A name collision is caller-fixable, so report it as a validation
         # error: SDK_ERROR would also count as an infrastructure failure and
         # needlessly trip the circuit breaker for this tool.
         return ToolError(
-            error=f"Experiment '{name}' already exists",
+            error=f"{kind} '{name}' already exists",
             error_code=ErrorCode.VALIDATION_ERROR,
             hint=(
                 "Choose a different name, or delete the existing experiment "
                 f"with delete_experiment('{name}', confirmed=True)."
             ),
+        )
+    return ToolError(
+        error=str(exc),
+        error_code=ErrorCode.SDK_ERROR,
+        details=exception_details(exc),
+    )
+
+
+def experiment_error(exc: Exception, name: str) -> ToolError:
+    """:func:`resource_error` for the Experiment kind, which most tools target."""
+    return resource_error(exc, name)
+
+
+def collection_error(exc: Exception) -> ToolError:
+    """Map an exception from a list operation onto a ``ToolError``.
+
+    List tools have no single resource name to report, so they cannot use
+    :func:`resource_error`. A 403 is still surfaced distinctly because a
+    namespace the caller cannot read is caller-fixable, not an outage.
+    """
+    if _api_status(exc) == 403:
+        return ToolError(
+            error=f"Not authorized to list this resource: {exc}",
+            error_code=ErrorCode.PERMISSION_DENIED,
+            hint="Check the service account's RBAC for the target namespace.",
         )
     return ToolError(
         error=str(exc),

--- a/kubeflow_mcp/optimizer/api/_common.py
+++ b/kubeflow_mcp/optimizer/api/_common.py
@@ -19,6 +19,8 @@ Holds the two blocks that would otherwise be copy-pasted across every tool in
 enforcing MCP ownership before a mutating operation.
 """
 
+import json
+
 from kubeflow_mcp.common import utils as mcp_utils
 from kubeflow_mcp.common.constants import ErrorCode
 from kubeflow_mcp.common.types import ToolError, exception_details, is_k8s_not_found
@@ -31,6 +33,12 @@ _WEBHOOK_HINT = (
     "The Katib control plane is not serving its admission webhooks. Run "
     "katib_pre_flight() to confirm, then check the katib-controller deployment "
     "and its RBAC. No experiment can be created until it reports ready."
+)
+_TIMEOUT_HINT = (
+    "The API server did not answer in time. A write is admitted by Katib's "
+    "webhooks, so this usually means the katib-controller cannot be reached by "
+    "the API server (a network path or endpoint problem) rather than a slow "
+    "cluster. Run katib_pre_flight(), which probes the webhook directly."
 )
 
 # Collection responses are truncated so a large experiment cannot exhaust the
@@ -91,6 +99,45 @@ def _api_status(exc: Exception) -> int | None:
     return None
 
 
+def api_message(exc: Exception) -> str:
+    """The Kubernetes ``status.message`` from an API error, if there is one.
+
+    ``str(ApiException)`` renders the whole response including every HTTP
+    header, which buries the one sentence a reader needs. Tool errors are read
+    by an agent, so they carry the message alone; the full text is still
+    available under ``details``.
+    """
+    for candidate in (exc, exc.__cause__, exc.__context__):
+        body = getattr(candidate, "body", None)
+        if not body:
+            continue
+        try:
+            message = json.loads(body).get("message")
+        except (ValueError, TypeError, AttributeError):
+            continue
+        if message:
+            return str(message)
+    return str(exc).split("\n")[0]
+
+
+def is_request_timeout(exc: Exception) -> bool:
+    """True when the client gave up waiting rather than the server refusing.
+
+    urllib3 surfaces these as ``ReadTimeoutError``/``ConnectTimeoutError``,
+    sometimes wrapped by the SDK, so the cause chain is walked as elsewhere in
+    this module. A timeout carries no HTTP status, so it would otherwise fall
+    through to a bare ``SDK_ERROR`` holding a connection-pool repr.
+    """
+    try:
+        from urllib3.exceptions import TimeoutError as Urllib3Timeout
+    except ImportError:  # pragma: no cover - urllib3 ships with kubernetes
+        return False
+    for candidate in (exc, exc.__cause__, exc.__context__):
+        if isinstance(candidate, (Urllib3Timeout, TimeoutError)):
+            return True
+    return False
+
+
 def _is_webhook_unavailable(exc: Exception) -> bool:
     """True when the API server could not reach Katib's admission webhooks.
 
@@ -139,8 +186,18 @@ def resource_error(exc: Exception, name: str, kind: str = "Experiment") -> ToolE
                 f"with delete_experiment('{name}', confirmed=True)."
             ),
         )
+    if is_request_timeout(exc):
+        # TIMEOUT still counts as an infrastructure failure for the circuit
+        # breaker, but it names what happened instead of surfacing a raw
+        # connection-pool repr with no hint.
+        return ToolError(
+            error=f"Timed out waiting for the API server while operating on {kind} '{name}'",
+            error_code=ErrorCode.TIMEOUT,
+            details=exception_details(exc),
+            hint=_TIMEOUT_HINT,
+        )
     return ToolError(
-        error=str(exc),
+        error=api_message(exc),
         error_code=ErrorCode.SDK_ERROR,
         details=exception_details(exc),
         # Stays SDK_ERROR: an unreachable webhook is a genuine infrastructure

--- a/kubeflow_mcp/optimizer/api/architecture_test.py
+++ b/kubeflow_mcp/optimizer/api/architecture_test.py
@@ -1,0 +1,283 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Architecture tests for the optimizer module.
+
+Validates that the module structure, exports, and metadata match the
+conventions established by the trainer module (KEP-34 compliance).
+"""
+
+import inspect
+from typing import Any
+
+from kubeflow_mcp.common.constants import TOOL_NEXT_HINTS, TOOL_PHASES, TOOL_TO_PHASE
+from kubeflow_mcp.core.policy import DESTRUCTIVE_TOOLS, PERSONAS
+
+
+class TestModuleExports:
+    """Verify optimizer module exports match trainer conventions."""
+
+    def test_module_info_fields(self):
+        from kubeflow_mcp.optimizer import MODULE_INFO
+
+        assert MODULE_INFO["name"] == "optimizer"
+        assert MODULE_INFO["status"] == "implemented"
+        assert MODULE_INFO["sdk_client"] == "kubeflow.optimizer.OptimizerClient"
+        assert MODULE_INFO["sdk_version"] == ">=0.4.0"
+
+    def test_tools_list_not_empty(self):
+        from kubeflow_mcp.optimizer import TOOLS
+
+        assert len(TOOLS) == 17, f"Expected 17 tools, got {len(TOOLS)}"
+
+    def test_all_tools_are_callables(self):
+        from kubeflow_mcp.optimizer import TOOLS
+
+        for tool in TOOLS:
+            assert callable(tool), f"{tool} is not callable"
+            assert hasattr(tool, "__name__"), f"{tool} has no __name__"
+
+    def test_tool_names_are_unique(self):
+        from kubeflow_mcp.optimizer import TOOLS
+
+        names = [t.__name__ for t in TOOLS]
+        assert len(names) == len(set(names)), f"Duplicate tool names: {names}"
+
+    def test_all_tools_have_descriptions(self):
+        from kubeflow_mcp.optimizer import CLIENT_TOOL_DESCRIPTIONS, TOOLS
+
+        tool_names = {t.__name__ for t in TOOLS}
+        desc_names = set(CLIENT_TOOL_DESCRIPTIONS.keys())
+        missing = tool_names - desc_names
+        assert not missing, f"Tools missing descriptions: {missing}"
+
+    def test_all_tools_have_annotations(self):
+        from kubeflow_mcp.optimizer import CLIENT_TOOL_ANNOTATIONS, TOOLS
+
+        tool_names = {t.__name__ for t in TOOLS}
+        ann_names = set(CLIENT_TOOL_ANNOTATIONS.keys())
+        missing = tool_names - ann_names
+        assert not missing, f"Tools missing annotations: {missing}"
+
+    def test_annotations_have_required_fields(self):
+        from kubeflow_mcp.optimizer import CLIENT_TOOL_ANNOTATIONS
+
+        required = {"title", "readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint"}
+        for name, ann in CLIENT_TOOL_ANNOTATIONS.items():
+            missing = required - set(ann.keys())
+            assert not missing, f"{name} annotation missing: {missing}"
+
+    def test_all_tools_return_dict(self):
+        """All tool functions must have return type dict[str, Any]."""
+        from kubeflow_mcp.optimizer import TOOLS
+
+        for tool in TOOLS:
+            hints = inspect.get_annotations(tool)
+            assert "return" in hints, f"{tool.__name__} missing return annotation"
+            assert hints["return"] == dict[str, Any], (
+                f"{tool.__name__} return type should be dict[str, Any], got {hints['return']}"
+            )
+
+    def test_client_resources_exist(self):
+        from kubeflow_mcp.optimizer import CLIENT_RESOURCES
+
+        assert len(CLIENT_RESOURCES) >= 2
+        for uri, (path, _desc) in CLIENT_RESOURCES.items():
+            assert uri.startswith("optimizer://"), (
+                f"Resource URI should start with optimizer://: {uri}"
+            )
+            assert path.endswith(".md"), f"Resource path should end with .md: {path}"
+
+    def test_instruction_sections_exist(self):
+        from kubeflow_mcp.optimizer import INSTRUCTION_SECTIONS
+
+        assert "optimizer_planning" in INSTRUCTION_SECTIONS
+        assert "optimizer_optimization" in INSTRUCTION_SECTIONS
+        assert "optimizer_monitoring" in INSTRUCTION_SECTIONS
+
+    def test_phase_to_section_mapping(self):
+        from kubeflow_mcp.optimizer import PHASE_TO_SECTION
+
+        assert PHASE_TO_SECTION["optimizer_planning"] == "optimizer_planning"
+        assert PHASE_TO_SECTION["optimizer_discovery"] is None
+        assert PHASE_TO_SECTION["optimizer_optimization"] == "optimizer_optimization"
+        assert PHASE_TO_SECTION["optimizer_monitoring"] == "optimizer_monitoring"
+        assert PHASE_TO_SECTION["optimizer_lifecycle"] == "optimizer_monitoring"
+
+
+class TestToolPhaseRegistration:
+    """Verify all optimizer tools are registered in TOOL_PHASES."""
+
+    def test_all_tools_in_phases(self):
+        from kubeflow_mcp.optimizer import TOOLS
+
+        tool_names = {t.__name__ for t in TOOLS}
+        phase_tools = set()
+        for phase, tools in TOOL_PHASES.items():
+            if phase.startswith("optimizer_"):
+                phase_tools.update(tools)
+
+        missing = tool_names - phase_tools
+        assert not missing, f"Tools not in any optimizer phase: {missing}"
+
+        extra = phase_tools - tool_names
+        assert not extra, f"Phases reference non-existent tools: {extra}"
+
+    def test_all_tools_in_next_hints(self):
+        from kubeflow_mcp.optimizer import TOOLS
+
+        tool_names = {t.__name__ for t in TOOLS}
+        hint_names = set(TOOL_NEXT_HINTS.keys())
+        missing = tool_names - hint_names
+        assert not missing, f"Tools missing TOOL_NEXT_HINTS: {missing}"
+
+    def test_tool_to_phase_reverse_mapping(self):
+        from kubeflow_mcp.optimizer import TOOLS
+
+        tool_names = {t.__name__ for t in TOOLS}
+        for name in tool_names:
+            assert name in TOOL_TO_PHASE, f"{name} not in TOOL_TO_PHASE reverse mapping"
+            assert TOOL_TO_PHASE[name].startswith("optimizer_"), (
+                f"{name} mapped to non-optimizer phase: {TOOL_TO_PHASE[name]}"
+            )
+
+
+class TestPersonaIntegration:
+    """Verify optimizer tools are in the correct persona allowlists (KEP-34)."""
+
+    def _resolve_persona_tools(self, persona: str) -> set[str]:
+        """Resolve full tool set including inherited tools."""
+        config = PERSONAS[persona]
+        if config["tools"] == "*":
+            return {"*"}
+        tools = set(config["tools"])
+        if "inherit" in config:
+            tools |= self._resolve_persona_tools(config["inherit"])
+        return tools
+
+    def test_readonly_has_13_optimizer_tools(self):
+        """KEP-34: readonly gets all 13 read-only optimizer tools."""
+        readonly_tools = self._resolve_persona_tools("readonly")
+        optimizer_readonly = {
+            "katib_pre_flight",
+            "list_experiments",
+            "get_experiment",
+            "get_experiment_status",
+            "get_trial",
+            "get_successful_trials",
+            "list_suggestions",
+            "get_experiment_trials",
+            "get_best_trial",
+            "get_suggestion",
+            "wait_for_experiment",
+            "get_experiment_trial_logs",
+            "get_experiment_events",
+        }
+        assert optimizer_readonly <= readonly_tools, (
+            f"Missing from readonly: {optimizer_readonly - readonly_tools}"
+        )
+
+    def test_data_scientist_has_create_and_delete(self):
+        """KEP-34: data-scientist adds create_hpo_experiment + delete_experiment."""
+        ds_tools = self._resolve_persona_tools("data-scientist")
+        assert "create_hpo_experiment" in ds_tools
+        assert "delete_experiment" in ds_tools
+
+    def test_data_scientist_lacks_advanced_tools(self):
+        """KEP-34: data-scientist should NOT have create_experiment_from_spec."""
+        ds_tools = self._resolve_persona_tools("data-scientist")
+        assert "create_experiment_from_spec" not in ds_tools
+        assert "update_experiment" not in ds_tools
+
+    def test_ml_engineer_has_advanced_tools(self):
+        """KEP-34: ml-engineer adds create_experiment_from_spec + update_experiment."""
+        mle_tools = self._resolve_persona_tools("ml-engineer")
+        assert "create_experiment_from_spec" in mle_tools
+        assert "update_experiment" in mle_tools
+
+    def test_platform_admin_unrestricted(self):
+        assert PERSONAS["platform-admin"]["tools"] == "*"
+
+    def test_delete_experiment_is_destructive(self):
+        assert "delete_experiment" in DESTRUCTIVE_TOOLS
+
+
+class TestAnnotationSemantics:
+    """Verify annotation hints match tool behavior (KEP-34 MCP Tools tables)."""
+
+    def test_read_only_tools_marked_correctly(self):
+        from kubeflow_mcp.optimizer import CLIENT_TOOL_ANNOTATIONS
+
+        read_only_tools = {
+            "katib_pre_flight",
+            "list_experiments",
+            "get_experiment",
+            "get_experiment_status",
+            "get_trial",
+            "get_successful_trials",
+            "list_suggestions",
+            "get_experiment_trials",
+            "get_best_trial",
+            "get_suggestion",
+            "wait_for_experiment",
+            "get_experiment_trial_logs",
+            "get_experiment_events",
+        }
+        for name in read_only_tools:
+            ann = CLIENT_TOOL_ANNOTATIONS[name]
+            assert ann["readOnlyHint"] is True, f"{name} should be readOnlyHint=True"
+            assert ann["destructiveHint"] is False, f"{name} should be destructiveHint=False"
+
+    def test_mutating_tools_marked_correctly(self):
+        from kubeflow_mcp.optimizer import CLIENT_TOOL_ANNOTATIONS
+
+        for name in ("create_hpo_experiment", "create_experiment_from_spec"):
+            ann = CLIENT_TOOL_ANNOTATIONS[name]
+            assert ann["readOnlyHint"] is False
+            assert ann["idempotentHint"] is False  # create is not idempotent
+
+    def test_delete_experiment_is_destructive(self):
+        from kubeflow_mcp.optimizer import CLIENT_TOOL_ANNOTATIONS
+
+        ann = CLIENT_TOOL_ANNOTATIONS["delete_experiment"]
+        assert ann["destructiveHint"] is True
+        assert ann["idempotentHint"] is True
+
+    def test_update_experiment_not_destructive(self):
+        from kubeflow_mcp.optimizer import CLIENT_TOOL_ANNOTATIONS
+
+        ann = CLIENT_TOOL_ANNOTATIONS["update_experiment"]
+        assert ann["readOnlyHint"] is False
+        assert ann["destructiveHint"] is False
+        assert ann["idempotentHint"] is True
+
+
+class TestCrossClientHints:
+    """Verify cross-client TOOL_NEXT_HINTS bridge trainer ↔ optimizer (KEP-34)."""
+
+    def test_wait_for_training_hints_hpo(self):
+        hint = TOOL_NEXT_HINTS["wait_for_training"]
+        assert "create_hpo_experiment" in hint
+
+    def test_get_best_trial_hints_fine_tune(self):
+        hint = TOOL_NEXT_HINTS["get_best_trial"]
+        assert "fine_tune" in hint
+
+    def test_create_hpo_hints_monitoring(self):
+        hint = TOOL_NEXT_HINTS["create_hpo_experiment"]
+        assert "get_experiment_status" in hint or "wait_for_experiment" in hint
+
+    def test_wait_for_experiment_hints_best_trial(self):
+        hint = TOOL_NEXT_HINTS["wait_for_experiment"]
+        assert "get_best_trial" in hint

--- a/kubeflow_mcp/optimizer/api/architecture_test.py
+++ b/kubeflow_mcp/optimizer/api/architecture_test.py
@@ -62,6 +62,47 @@ class TestModuleExports:
         missing = tool_names - desc_names
         assert not missing, f"Tools missing descriptions: {missing}"
 
+    def test_advertised_algorithms_match_the_implementation(self):
+        """Every accepted algorithm must appear in the agent-facing surfaces.
+
+        A description is the tool's API: an agent only ever sees these strings,
+        so a capability the implementation accepts but the prose omits is
+        unreachable in practice. Binding the two makes drift a test failure
+        rather than a silently unusable feature.
+        """
+        from kubeflow_mcp.optimizer import CLIENT_TOOL_DESCRIPTIONS, INSTRUCTION_SECTIONS
+        from kubeflow_mcp.optimizer.api.optimization import ALGORITHMS
+
+        surfaces = {
+            "description": CLIENT_TOOL_DESCRIPTIONS["create_hpo_experiment"],
+            "instructions": INSTRUCTION_SECTIONS["optimizer_optimization"]["full"],
+        }
+        for surface, text in surfaces.items():
+            missing = {a for a in ALGORITHMS if a not in text}
+            assert not missing, f"algorithms absent from {surface}: {sorted(missing)}"
+
+    def test_advertised_search_types_match_the_implementation(self):
+        """Same binding for search-space types, which live in a different file.
+
+        ``int`` shipped in the builder while all three surfaces still listed
+        only three types, so agents had no way to discover it.
+        """
+        from pathlib import Path
+
+        from kubeflow_mcp.optimizer import CLIENT_TOOL_DESCRIPTIONS, INSTRUCTION_SECTIONS
+
+        guide = Path(__file__).resolve().parents[1] / "resources" / "hpo-patterns.md"
+        surfaces = {
+            "description": CLIENT_TOOL_DESCRIPTIONS["create_hpo_experiment"],
+            "instructions": INSTRUCTION_SECTIONS["optimizer_optimization"]["full"],
+            "hpo-patterns.md": guide.read_text(),
+        }
+        # Mirrors the branches in optimization._build_parameter.
+        search_types = {"uniform", "loguniform", "int", "choice"}
+        for surface, text in surfaces.items():
+            missing = {t for t in search_types if t not in text}
+            assert not missing, f"search types absent from {surface}: {sorted(missing)}"
+
     def test_all_tools_have_annotations(self):
         from kubeflow_mcp.optimizer import CLIENT_TOOL_ANNOTATIONS, TOOLS
 

--- a/kubeflow_mcp/optimizer/api/discovery.py
+++ b/kubeflow_mcp/optimizer/api/discovery.py
@@ -15,10 +15,15 @@
 """Discovery tools for Katib experiments, trials, and suggestions.
 
 SDK methods used:
-    - OptimizerClient.list_jobs()    → list_experiments
-    - OptimizerClient.get_job()      → get_experiment, get_experiment_status,
-                                       get_trial, get_successful_trials
-    - CustomObjectsApi               → list_suggestions (no SDK method)
+    - OptimizerClient.get_job()      → get_experiment, get_trial,
+                                       get_successful_trials
+    - CustomObjectsApi               → list_experiments, get_experiment_status,
+                                       list_suggestions
+
+``list_experiments`` reads the Experiment list directly rather than through
+``OptimizerClient.list_jobs()``: the SDK resolves every trial's TrainJob
+individually, so listing a namespace costs one call per trial while a summary
+needs only fields the Experiment CR already carries.
 """
 
 import logging
@@ -51,10 +56,11 @@ from kubeflow_mcp.optimizer.types import (
     conditions_to_list,
     early_stopping_to_dict,
     experiment_phase,
-    experiment_summary,
+    experiment_summary_from_cr,
     experiment_to_dict,
     is_success_status,
     optimal_trial_to_dict,
+    suggestion_to_dict,
     trial_counts_from_cr,
     trial_to_dict,
 )
@@ -89,10 +95,16 @@ def list_experiments(
         return limit_err.model_dump()
 
     try:
-        client = get_optimizer_client_for_namespace(namespace)
-        jobs = client.list_jobs()
+        ns = get_optimizer_effective_namespace(namespace)
+        resp = get_custom_objects_api().list_namespaced_custom_object(
+            group=KATIB_API_GROUP,
+            version=KATIB_API_VERSION,
+            namespace=ns,
+            plural=EXPERIMENT_PLURAL,
+            _request_timeout=K8S_TIMEOUT,
+        )
 
-        experiments = [experiment_summary(job) for job in jobs]
+        experiments = [experiment_summary_from_cr(item) for item in resp.get("items", [])]
         if status:
             want = resolve_status_filter(status)
             experiments = [e for e in experiments if e.get("status") == want]
@@ -344,7 +356,7 @@ def list_suggestions(
             _request_timeout=K8S_TIMEOUT,
         )
 
-        suggestions = [_suggestion_to_dict(item) for item in resp.get("items", [])]
+        suggestions = [suggestion_to_dict(item) for item in resp.get("items", [])]
         return ToolResponse(
             data={
                 "suggestions": suggestions[:limit],
@@ -404,20 +416,3 @@ def _experiment_cr_detail(name: str, namespace: str | None) -> dict[str, Any]:
     # CR counters are authoritative; they supersede the SDK-derived ones.
     detail.update(trial_counts_from_cr(status))
     return detail
-
-
-def _suggestion_to_dict(item: dict[str, Any]) -> dict[str, Any]:
-    """Serialize a raw Suggestion CRD dict from CustomObjectsApi."""
-    metadata = item.get("metadata", {})
-    spec = item.get("spec", {})
-    status = item.get("status", {})
-    algorithm = spec.get("algorithm", {})
-    conditions = status.get("conditions", []) or []
-    latest_condition = conditions[-1].get("type") if conditions else None
-    return {
-        "name": metadata.get("name"),
-        "algorithm": algorithm.get("algorithmName"),
-        "requests": spec.get("requests"),
-        "suggestion_count": status.get("suggestionCount"),
-        "condition": latest_condition,
-    }

--- a/kubeflow_mcp/optimizer/api/discovery.py
+++ b/kubeflow_mcp/optimizer/api/discovery.py
@@ -25,7 +25,7 @@ import logging
 from typing import Any
 
 from kubeflow_mcp.common.constants import ErrorCode
-from kubeflow_mcp.common.types import ToolError, ToolResponse, exception_details
+from kubeflow_mcp.common.types import ToolError, ToolResponse
 from kubeflow_mcp.common.utils import (
     K8S_TIMEOUT,
     get_custom_objects_api,
@@ -37,7 +37,9 @@ from kubeflow_mcp.optimizer.api._common import (
     DEFAULT_LIST_LIMIT,
     check_optimizer_namespace,
     clamp_limit,
+    collection_error,
     experiment_error,
+    resolve_status_filter,
 )
 from kubeflow_mcp.optimizer.constants import (
     EXPERIMENT_PLURAL,
@@ -46,22 +48,18 @@ from kubeflow_mcp.optimizer.constants import (
     SUGGESTION_PLURAL,
 )
 from kubeflow_mcp.optimizer.types import (
-    cr_conditions,
-    cr_early_stopping,
-    cr_optimal_trial,
-    cr_trial_counts,
+    conditions_to_list,
+    early_stopping_to_dict,
+    experiment_phase,
     experiment_summary,
     experiment_to_dict,
     is_success_status,
-    trial_counts,
+    optimal_trial_to_dict,
+    trial_counts_from_cr,
     trial_to_dict,
 )
 
 logger = logging.getLogger(__name__)
-
-# Legacy/CRD status "Succeeded" maps to the SDK's terminal status "Complete".
-# Mirrors the trainer's list_training_jobs alias for consistent filtering.
-_STATUS_FILTER_ALIASES: dict[str, str] = {"Succeeded": "Complete"}
 
 
 def list_experiments(
@@ -96,7 +94,7 @@ def list_experiments(
 
         experiments = [experiment_summary(job) for job in jobs]
         if status:
-            want = _STATUS_FILTER_ALIASES.get(status, status)
+            want = resolve_status_filter(status)
             experiments = [e for e in experiments if e.get("status") == want]
 
         return ToolResponse(
@@ -104,11 +102,7 @@ def list_experiments(
         ).model_dump()
 
     except Exception as e:
-        return ToolError(
-            error=str(e),
-            error_code=ErrorCode.SDK_ERROR,
-            details=exception_details(e),
-        ).model_dump()
+        return collection_error(e).model_dump()
 
 
 def get_experiment(
@@ -118,8 +112,9 @@ def get_experiment(
 ) -> dict[str, Any]:
     """Get full details of a Katib optimization experiment.
 
-    Returns the complete experiment: status, trials, search space, algorithm,
-    objectives, and trial configuration.
+    Combines the SDK's view (search space, algorithm, objectives, trial config,
+    embedded trials) with fields only the Experiment CR carries: ``conditions``,
+    ``best_trial``, ``early_stopping``, the phase, and the trial counters.
 
     Args:
         name: Experiment name.
@@ -129,7 +124,12 @@ def get_experiment(
             ``get_experiment_trials()`` to page through them.
 
     Returns:
-        dict: Response containing full experiment details.
+        dict: Response containing ``name``, ``status``, ``creation_timestamp``,
+        ``objectives``, ``algorithm``, ``search_space``, ``trial_config``,
+        ``trials`` (up to ``limit``), ``trials_truncated``, ``conditions``,
+        ``best_trial``, ``early_stopping`` and the CR trial counters. When the
+        CR read fails, the CR-sourced keys are replaced by
+        ``detail_unavailable: True`` and the SDK-derived values remain.
 
     Raises:
         ToolError: If experiment not found (``RESOURCE_NOT_FOUND``).
@@ -167,16 +167,21 @@ def get_experiment_status(
 ) -> dict[str, Any]:
     """Lightweight status-only check for an experiment.
 
-    Returns only the status string and trial counts — faster to consume than
-    ``get_experiment()`` for polling.
+    Reads the Experiment CR directly rather than going through
+    ``OptimizerClient.get_job()``, which additionally resolves every trial's
+    TrainJob. That makes this both cheaper than ``get_experiment()`` and
+    consistent with it: both report the CR's own counters, including
+    ``early_stopped_trials``, which the SDK's trial view cannot express.
 
     Args:
         name: Experiment name.
         namespace: K8s namespace. Uses default from kubeconfig when omitted.
 
     Returns:
-        dict: Response containing ``status``, ``total_trials``,
-              ``running_trials``, ``succeeded_trials``, ``failed_trials``.
+        dict: Response containing ``name``, ``status`` and the CR trial
+        counters (``total_trials``, ``running_trials``, ``succeeded_trials``,
+        ``failed_trials``, ``pending_trials``, ``killed_trials``,
+        ``early_stopped_trials``), omitting any the CR does not report.
     """
     name_err = validate_k8s_name(name)
     if name_err is not None:
@@ -187,14 +192,14 @@ def get_experiment_status(
         return ns_err.model_dump()
 
     try:
-        client = get_optimizer_client_for_namespace(namespace)
-        job = client.get_job(name=name)
+        obj = _read_experiment_cr(name, namespace)
+        status = obj.get("status") or {}
 
         data: dict[str, Any] = {
             "name": name,
-            "status": getattr(job, "status", None) or "Unknown",
+            "status": experiment_phase(status),
         }
-        data.update(trial_counts(job))
+        data.update(trial_counts_from_cr(status))
         return ToolResponse(data=data).model_dump()
 
     except Exception as e:
@@ -348,11 +353,25 @@ def list_suggestions(
         ).model_dump()
 
     except Exception as e:
-        return ToolError(
-            error=str(e),
-            error_code=ErrorCode.SDK_ERROR,
-            details=exception_details(e),
-        ).model_dump()
+        return collection_error(e).model_dump()
+
+
+def _read_experiment_cr(name: str, namespace: str | None) -> dict[str, Any]:
+    """Fetch the raw Experiment custom resource.
+
+    Raises whatever the Kubernetes client raises; callers decide whether that is
+    fatal (``get_experiment_status``) or merely degrades the response
+    (``get_experiment``).
+    """
+    ns = get_optimizer_effective_namespace(namespace)
+    return get_custom_objects_api().get_namespaced_custom_object(
+        group=KATIB_API_GROUP,
+        version=KATIB_API_VERSION,
+        namespace=ns,
+        plural=EXPERIMENT_PLURAL,
+        name=name,
+        _request_timeout=K8S_TIMEOUT,
+    )
 
 
 def _experiment_cr_detail(name: str, namespace: str | None) -> dict[str, Any]:
@@ -367,28 +386,22 @@ def _experiment_cr_detail(name: str, namespace: str | None) -> dict[str, Any]:
     response rather than failing the whole call.
     """
     try:
-        ns = get_optimizer_effective_namespace(namespace)
-        obj = get_custom_objects_api().get_namespaced_custom_object(
-            group=KATIB_API_GROUP,
-            version=KATIB_API_VERSION,
-            namespace=ns,
-            plural=EXPERIMENT_PLURAL,
-            name=name,
-            _request_timeout=K8S_TIMEOUT,
-        )
+        obj = _read_experiment_cr(name, namespace)
     except Exception as e:
         logger.debug("get_experiment(%s): CR detail unavailable: %s", name, e)
         return {"detail_unavailable": True}
 
     status = obj.get("status") or {}
-    spec = obj.get("spec") or {}
     detail: dict[str, Any] = {
-        "conditions": cr_conditions(status),
-        "best_trial": cr_optimal_trial(status),
-        "early_stopping": cr_early_stopping(spec),
+        "conditions": conditions_to_list(status),
+        "best_trial": optimal_trial_to_dict(status),
+        "early_stopping": early_stopping_to_dict(obj.get("spec") or {}),
+        # Derive the phase from the same source get_experiment_status uses, so
+        # the two tools cannot disagree about a single experiment.
+        "status": experiment_phase(status),
     }
     # CR counters are authoritative; they supersede the SDK-derived ones.
-    detail.update(cr_trial_counts(status))
+    detail.update(trial_counts_from_cr(status))
     return detail
 
 

--- a/kubeflow_mcp/optimizer/api/discovery.py
+++ b/kubeflow_mcp/optimizer/api/discovery.py
@@ -208,7 +208,7 @@ def get_experiment_status(
 
 def get_trial(
     name: str,
-    experiment: str,
+    trial: str,
     namespace: str | None = None,
 ) -> dict[str, Any]:
     """Get details of a specific trial within an experiment.
@@ -217,8 +217,9 @@ def get_trial(
     located within ``OptimizerClient.get_job().trials``.
 
     Args:
-        name: Trial name.
-        experiment: Parent experiment name.
+        name: Experiment name. Every optimizer tool takes the experiment as
+            ``name``; the trial is selected with ``trial``.
+        trial: Trial name within that experiment.
         namespace: K8s namespace. Uses default from kubeconfig when omitted.
 
     Returns:
@@ -227,12 +228,12 @@ def get_trial(
     Raises:
         ToolError: If experiment or trial not found (``RESOURCE_NOT_FOUND``).
     """
-    name_err = validate_k8s_name(name, "name")
+    name_err = validate_k8s_name(name)
     if name_err is not None:
         return name_err.model_dump()
-    exp_err = validate_k8s_name(experiment, "experiment")
-    if exp_err is not None:
-        return exp_err.model_dump()
+    trial_err = validate_k8s_name(trial, "trial")
+    if trial_err is not None:
+        return trial_err.model_dump()
 
     ns_err = check_optimizer_namespace(namespace)
     if ns_err is not None:
@@ -240,22 +241,22 @@ def get_trial(
 
     try:
         client = get_optimizer_client_for_namespace(namespace)
-        job = client.get_job(name=experiment)
+        job = client.get_job(name=name)
 
-        for trial in getattr(job, "trials", None) or []:
-            if getattr(trial, "name", None) == name:
-                data = trial_to_dict(trial)
-                data["experiment"] = experiment
+        for candidate in getattr(job, "trials", None) or []:
+            if getattr(candidate, "name", None) == trial:
+                data = trial_to_dict(candidate)
+                data["experiment"] = name
                 return ToolResponse(data=data).model_dump()
 
         return ToolError(
-            error=f"Trial '{name}' not found in experiment '{experiment}'",
+            error=f"Trial '{trial}' not found in experiment '{name}'",
             error_code=ErrorCode.RESOURCE_NOT_FOUND,
-            hint=f"Use get_experiment_trials('{experiment}') to list trials",
+            hint=f"Use get_experiment_trials('{name}') to list trials",
         ).model_dump()
 
     except Exception as e:
-        return experiment_error(e, experiment).model_dump()
+        return experiment_error(e, name).model_dump()
 
 
 def get_successful_trials(

--- a/kubeflow_mcp/optimizer/api/discovery.py
+++ b/kubeflow_mcp/optimizer/api/discovery.py
@@ -1,0 +1,409 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Discovery tools for Katib experiments, trials, and suggestions.
+
+SDK methods used:
+    - OptimizerClient.list_jobs()    → list_experiments
+    - OptimizerClient.get_job()      → get_experiment, get_experiment_status,
+                                       get_trial, get_successful_trials
+    - CustomObjectsApi               → list_suggestions (no SDK method)
+"""
+
+import logging
+from typing import Any
+
+from kubeflow_mcp.common.constants import ErrorCode
+from kubeflow_mcp.common.types import ToolError, ToolResponse, exception_details
+from kubeflow_mcp.common.utils import (
+    K8S_TIMEOUT,
+    get_custom_objects_api,
+    get_optimizer_client_for_namespace,
+    get_optimizer_effective_namespace,
+)
+from kubeflow_mcp.core.security import validate_k8s_name
+from kubeflow_mcp.optimizer.api._common import (
+    DEFAULT_LIST_LIMIT,
+    check_optimizer_namespace,
+    clamp_limit,
+    experiment_error,
+)
+from kubeflow_mcp.optimizer.constants import (
+    EXPERIMENT_PLURAL,
+    KATIB_API_GROUP,
+    KATIB_API_VERSION,
+    SUGGESTION_PLURAL,
+)
+from kubeflow_mcp.optimizer.types import (
+    cr_conditions,
+    cr_early_stopping,
+    cr_optimal_trial,
+    cr_trial_counts,
+    experiment_summary,
+    experiment_to_dict,
+    is_success_status,
+    trial_counts,
+    trial_to_dict,
+)
+
+logger = logging.getLogger(__name__)
+
+# Legacy/CRD status "Succeeded" maps to the SDK's terminal status "Complete".
+# Mirrors the trainer's list_training_jobs alias for consistent filtering.
+_STATUS_FILTER_ALIASES: dict[str, str] = {"Succeeded": "Complete"}
+
+
+def list_experiments(
+    namespace: str | None = None,
+    status: str | None = None,
+    limit: int = DEFAULT_LIST_LIMIT,
+) -> dict[str, Any]:
+    """List Katib optimization experiments.
+
+    Returns experiments in the target namespace with optional status filtering.
+
+    Args:
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+        status: Optional status filter (Created, Running, Complete, Failed).
+        limit: Maximum experiments to return. Defaults to 50, capped at 500.
+
+    Returns:
+        dict: Response containing ``experiments`` (up to ``limit``) and
+        ``total`` (all matches, so truncation is visible).
+    """
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    limit, limit_err = clamp_limit(limit)
+    if limit_err is not None:
+        return limit_err.model_dump()
+
+    try:
+        client = get_optimizer_client_for_namespace(namespace)
+        jobs = client.list_jobs()
+
+        experiments = [experiment_summary(job) for job in jobs]
+        if status:
+            want = _STATUS_FILTER_ALIASES.get(status, status)
+            experiments = [e for e in experiments if e.get("status") == want]
+
+        return ToolResponse(
+            data={"experiments": experiments[:limit], "total": len(experiments)}
+        ).model_dump()
+
+    except Exception as e:
+        return ToolError(
+            error=str(e),
+            error_code=ErrorCode.SDK_ERROR,
+            details=exception_details(e),
+        ).model_dump()
+
+
+def get_experiment(
+    name: str,
+    namespace: str | None = None,
+    limit: int = DEFAULT_LIST_LIMIT,
+) -> dict[str, Any]:
+    """Get full details of a Katib optimization experiment.
+
+    Returns the complete experiment: status, trials, search space, algorithm,
+    objectives, and trial configuration.
+
+    Args:
+        name: Experiment name.
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+        limit: Maximum embedded trials to return. Defaults to 50, capped at 500.
+            ``total_trials`` always reports the true count; use
+            ``get_experiment_trials()`` to page through them.
+
+    Returns:
+        dict: Response containing full experiment details.
+
+    Raises:
+        ToolError: If experiment not found (``RESOURCE_NOT_FOUND``).
+    """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    limit, limit_err = clamp_limit(limit)
+    if limit_err is not None:
+        return limit_err.model_dump()
+
+    try:
+        client = get_optimizer_client_for_namespace(namespace)
+        job = client.get_job(name=name)
+
+        data = experiment_to_dict(job)
+        trials = getattr(job, "trials", None) or []
+        data["trials"] = [trial_to_dict(t) for t in trials[:limit]]
+        data["trials_truncated"] = len(trials) > limit
+        data.update(_experiment_cr_detail(name, namespace))
+        return ToolResponse(data=data).model_dump()
+
+    except Exception as e:
+        return experiment_error(e, name).model_dump()
+
+
+def get_experiment_status(
+    name: str,
+    namespace: str | None = None,
+) -> dict[str, Any]:
+    """Lightweight status-only check for an experiment.
+
+    Returns only the status string and trial counts — faster to consume than
+    ``get_experiment()`` for polling.
+
+    Args:
+        name: Experiment name.
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+
+    Returns:
+        dict: Response containing ``status``, ``total_trials``,
+              ``running_trials``, ``succeeded_trials``, ``failed_trials``.
+    """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    try:
+        client = get_optimizer_client_for_namespace(namespace)
+        job = client.get_job(name=name)
+
+        data: dict[str, Any] = {
+            "name": name,
+            "status": getattr(job, "status", None) or "Unknown",
+        }
+        data.update(trial_counts(job))
+        return ToolResponse(data=data).model_dump()
+
+    except Exception as e:
+        return experiment_error(e, name).model_dump()
+
+
+def get_trial(
+    name: str,
+    experiment: str,
+    namespace: str | None = None,
+) -> dict[str, Any]:
+    """Get details of a specific trial within an experiment.
+
+    Returns trial parameters, metrics, and status for debugging. The trial is
+    located within ``OptimizerClient.get_job().trials``.
+
+    Args:
+        name: Trial name.
+        experiment: Parent experiment name.
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+
+    Returns:
+        dict: Response containing trial parameters, metrics, and status.
+
+    Raises:
+        ToolError: If experiment or trial not found (``RESOURCE_NOT_FOUND``).
+    """
+    name_err = validate_k8s_name(name, "name")
+    if name_err is not None:
+        return name_err.model_dump()
+    exp_err = validate_k8s_name(experiment, "experiment")
+    if exp_err is not None:
+        return exp_err.model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    try:
+        client = get_optimizer_client_for_namespace(namespace)
+        job = client.get_job(name=experiment)
+
+        for trial in getattr(job, "trials", None) or []:
+            if getattr(trial, "name", None) == name:
+                data = trial_to_dict(trial)
+                data["experiment"] = experiment
+                return ToolResponse(data=data).model_dump()
+
+        return ToolError(
+            error=f"Trial '{name}' not found in experiment '{experiment}'",
+            error_code=ErrorCode.RESOURCE_NOT_FOUND,
+            hint=f"Use get_experiment_trials('{experiment}') to list trials",
+        ).model_dump()
+
+    except Exception as e:
+        return experiment_error(e, experiment).model_dump()
+
+
+def get_successful_trials(
+    name: str,
+    namespace: str | None = None,
+    limit: int = DEFAULT_LIST_LIMIT,
+) -> dict[str, Any]:
+    """Get successful trials with hyperparameters and metrics.
+
+    Returns only trials whose status denotes success, for comparison. Useful
+    for finding the best hyperparameter combinations.
+
+    Args:
+        name: Experiment name.
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+        limit: Maximum trials to return. Defaults to 50, capped at 500.
+
+    Returns:
+        dict: Response containing ``trials`` (up to ``limit``) with parameters
+        and metrics, and ``total`` successful trials.
+    """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    limit, limit_err = clamp_limit(limit)
+    if limit_err is not None:
+        return limit_err.model_dump()
+
+    try:
+        client = get_optimizer_client_for_namespace(namespace)
+        job = client.get_job(name=name)
+
+        successful = [
+            trial_to_dict(t)
+            for t in (getattr(job, "trials", None) or [])
+            if is_success_status(getattr(getattr(t, "trainjob", None), "status", None))
+        ]
+        return ToolResponse(
+            data={"experiment": name, "trials": successful[:limit], "total": len(successful)}
+        ).model_dump()
+
+    except Exception as e:
+        return experiment_error(e, name).model_dump()
+
+
+def list_suggestions(
+    namespace: str | None = None,
+    limit: int = DEFAULT_LIST_LIMIT,
+) -> dict[str, Any]:
+    """List Katib suggestion resources in namespace.
+
+    Suggestions manage the optimization algorithm state. Useful for debugging
+    when experiments are stuck. Uses CustomObjectsApi directly (no SDK method
+    available).
+
+    Args:
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+        limit: Maximum suggestions to return. Defaults to 50, capped at 500.
+
+    Returns:
+        dict: Response containing ``suggestions`` (up to ``limit``) with
+        algorithm, status and request counts, plus the ``total`` found.
+    """
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    limit, limit_err = clamp_limit(limit)
+    if limit_err is not None:
+        return limit_err.model_dump()
+
+    try:
+        ns = get_optimizer_effective_namespace(namespace)
+        api = get_custom_objects_api()
+        resp = api.list_namespaced_custom_object(
+            group=KATIB_API_GROUP,
+            version=KATIB_API_VERSION,
+            namespace=ns,
+            plural=SUGGESTION_PLURAL,
+            _request_timeout=K8S_TIMEOUT,
+        )
+
+        suggestions = [_suggestion_to_dict(item) for item in resp.get("items", [])]
+        return ToolResponse(
+            data={
+                "suggestions": suggestions[:limit],
+                "total": len(suggestions),
+                "namespace": ns,
+            }
+        ).model_dump()
+
+    except Exception as e:
+        return ToolError(
+            error=str(e),
+            error_code=ErrorCode.SDK_ERROR,
+            details=exception_details(e),
+        ).model_dump()
+
+
+def _experiment_cr_detail(name: str, namespace: str | None) -> dict[str, Any]:
+    """Read the fields ``OptimizationJob`` omits straight from the Experiment CR.
+
+    Supplies ``conditions`` (why an experiment failed), ``best_trial`` and
+    ``early_stopping``, plus authoritative trial counts — Katib tracks
+    early-stopped trials here, and that state never reaches the TrainJob the
+    SDK derives its trial view from.
+
+    Best-effort: this is supplementary detail, so a failure here degrades the
+    response rather than failing the whole call.
+    """
+    try:
+        ns = get_optimizer_effective_namespace(namespace)
+        obj = get_custom_objects_api().get_namespaced_custom_object(
+            group=KATIB_API_GROUP,
+            version=KATIB_API_VERSION,
+            namespace=ns,
+            plural=EXPERIMENT_PLURAL,
+            name=name,
+            _request_timeout=K8S_TIMEOUT,
+        )
+    except Exception as e:
+        logger.debug("get_experiment(%s): CR detail unavailable: %s", name, e)
+        return {"detail_unavailable": True}
+
+    status = obj.get("status") or {}
+    spec = obj.get("spec") or {}
+    detail: dict[str, Any] = {
+        "conditions": cr_conditions(status),
+        "best_trial": cr_optimal_trial(status),
+        "early_stopping": cr_early_stopping(spec),
+    }
+    # CR counters are authoritative; they supersede the SDK-derived ones.
+    detail.update(cr_trial_counts(status))
+    return detail
+
+
+def _suggestion_to_dict(item: dict[str, Any]) -> dict[str, Any]:
+    """Serialize a raw Suggestion CRD dict from CustomObjectsApi."""
+    metadata = item.get("metadata", {})
+    spec = item.get("spec", {})
+    status = item.get("status", {})
+    algorithm = spec.get("algorithm", {})
+    conditions = status.get("conditions", []) or []
+    latest_condition = conditions[-1].get("type") if conditions else None
+    return {
+        "name": metadata.get("name"),
+        "algorithm": algorithm.get("algorithmName"),
+        "requests": spec.get("requests"),
+        "suggestion_count": status.get("suggestionCount"),
+        "condition": latest_condition,
+    }

--- a/kubeflow_mcp/optimizer/api/discovery_test.py
+++ b/kubeflow_mcp/optimizer/api/discovery_test.py
@@ -232,17 +232,30 @@ def test_get_trial_found():
     client = MagicMock()
     client.get_job.return_value = _job("exp-1", trials=[_trial("t1"), _trial("t2")])
     with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
-        result = discovery.get_trial("t2", experiment="exp-1")
+        result = discovery.get_trial("exp-1", trial="t2")
     assert result["success"] is True
     assert result["data"]["name"] == "t2"
     assert result["data"]["experiment"] == "exp-1"
+
+
+def test_get_trial_takes_the_experiment_as_name():
+    """``name`` is the experiment in every optimizer tool, this one included.
+
+    Guards the argument order: reading it as (trial, experiment) would look up
+    the wrong resource and report a not-found for a name that exists.
+    """
+    client = MagicMock()
+    client.get_job.return_value = _job("exp-1", trials=[_trial("t1")])
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        discovery.get_trial("exp-1", "t1")
+    assert client.get_job.call_args.kwargs["name"] == "exp-1"
 
 
 def test_get_trial_missing_trial():
     client = MagicMock()
     client.get_job.return_value = _job("exp-1", trials=[_trial("t1")])
     with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
-        result = discovery.get_trial("nope", experiment="exp-1")
+        result = discovery.get_trial("exp-1", trial="nope")
     assert result["success"] is False
     assert result["error_code"] == "RESOURCE_NOT_FOUND"
 
@@ -251,7 +264,7 @@ def test_get_trial_missing_experiment():
     client = MagicMock()
     client.get_job.side_effect = _not_found()
     with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
-        result = discovery.get_trial("t1", experiment="missing")
+        result = discovery.get_trial("missing", trial="t1")
     assert result["error_code"] == "RESOURCE_NOT_FOUND"
 
 

--- a/kubeflow_mcp/optimizer/api/discovery_test.py
+++ b/kubeflow_mcp/optimizer/api/discovery_test.py
@@ -215,9 +215,12 @@ def test_get_experiment_and_status_report_identical_counts():
 
 
 def test_get_experiment_status_not_found():
-    client = MagicMock()
-    client.get_job.side_effect = _not_found()
-    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+    api = MagicMock()
+    api.get_namespaced_custom_object.side_effect = _not_found()
+    with (
+        patch(f"{_DISC}.get_custom_objects_api", return_value=api),
+        patch(f"{_DISC}.get_optimizer_effective_namespace", return_value="kubeflow"),
+    ):
         result = discovery.get_experiment_status("missing")
     assert result["error_code"] == "RESOURCE_NOT_FOUND"
 

--- a/kubeflow_mcp/optimizer/api/discovery_test.py
+++ b/kubeflow_mcp/optimizer/api/discovery_test.py
@@ -18,9 +18,11 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 from kubernetes.client.exceptions import ApiException
 
 from kubeflow_mcp.optimizer.api import discovery
+from kubeflow_mcp.optimizer.types import trial_counts_from_cr
 
 _DISC = "kubeflow_mcp.optimizer.api.discovery"
 
@@ -134,25 +136,82 @@ def test_get_experiment_invalid_name():
 # ─── get_experiment_status ─────────────────────────────────────────────────
 
 
-def test_get_experiment_status_counts():
-    client = MagicMock()
-    client.get_job.return_value = _job(
-        "exp-1",
-        "Running",
-        trials=[
-            _trial("t1", "Complete"),
-            _trial("t2", "Running"),
-            _trial("t3", "Failed"),
-        ],
+def _status_cr(**status):
+    """Experiment CR carrying only status, as get_experiment_status reads it."""
+    return {"metadata": {"name": "exp-1"}, "spec": {}, "status": status}
+
+
+def _patch_cr(cr):
+    api = MagicMock()
+    api.get_namespaced_custom_object.return_value = cr
+    return (
+        patch(f"{_DISC}.get_custom_objects_api", return_value=api),
+        patch(f"{_DISC}.get_optimizer_effective_namespace", return_value="kubeflow"),
     )
-    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
-        result = discovery.get_experiment_status("exp-1")
-    data = result["data"]
+
+
+def test_get_experiment_status_counts():
+    cr = _status_cr(trials=3, trialsRunning=1, trialsSucceeded=1, trialsFailed=1)
+    api_p, ns_p = _patch_cr(cr)
+    with api_p, ns_p:
+        data = discovery.get_experiment_status("exp-1")["data"]
     assert data["status"] == "Running"
     assert data["total_trials"] == 3
     assert data["running_trials"] == 1
     assert data["succeeded_trials"] == 1
     assert data["failed_trials"] == 1
+
+
+def test_get_experiment_status_reads_the_cr_not_the_sdk():
+    """It must not call get_job(), which also resolves every trial's TrainJob."""
+    client = MagicMock()
+    api_p, ns_p = _patch_cr(_status_cr(trials=1))
+    with api_p, ns_p, patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        discovery.get_experiment_status("exp-1")
+    client.get_job.assert_not_called()
+
+
+def test_get_experiment_status_surfaces_early_stopped_trials():
+    """The SDK's trial view has no EarlyStopped state; the CR does."""
+    cr = _status_cr(trials=4, trialsSucceeded=2, trialsEarlyStopped=2)
+    api_p, ns_p = _patch_cr(cr)
+    with api_p, ns_p:
+        data = discovery.get_experiment_status("exp-1")["data"]
+    assert data["early_stopped_trials"] == 2
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ({"conditions": [{"type": "Succeeded", "status": "True"}]}, "Complete"),
+        ({"conditions": [{"type": "Failed", "status": "True"}]}, "Failed"),
+        ({"conditions": [{"type": "Succeeded", "status": "False"}]}, "Created"),
+        ({"trialsRunning": 2}, "Running"),
+        ({}, "Created"),
+    ],
+)
+def test_get_experiment_status_derives_phase_like_the_sdk(status, expected):
+    """Mirrors the SDK's own derivation from Experiment conditions."""
+    api_p, ns_p = _patch_cr(_status_cr(**status))
+    with api_p, ns_p:
+        data = discovery.get_experiment_status("exp-1")["data"]
+    assert data["status"] == expected
+
+
+def test_get_experiment_and_status_report_identical_counts():
+    """Regression: the two tools previously disagreed, because one derived
+    counts from TrainJob statuses and the other read the CR."""
+    cr = _experiment_cr()
+    client = MagicMock(get_job=MagicMock(return_value=_job("exp-1", trials=[_trial("t1")])))
+    api_p, ns_p = _patch_cr(cr)
+    with api_p, ns_p, patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        full = discovery.get_experiment("exp-1")["data"]
+        light = discovery.get_experiment_status("exp-1")["data"]
+
+    shared = set(trial_counts_from_cr(cr["status"]))
+    assert shared, "fixture should carry counters"
+    for key in shared:
+        assert full[key] == light[key], f"{key}: {full[key]} != {light[key]}"
 
 
 def test_get_experiment_status_not_found():

--- a/kubeflow_mcp/optimizer/api/discovery_test.py
+++ b/kubeflow_mcp/optimizer/api/discovery_test.py
@@ -14,6 +14,7 @@
 
 """Unit tests for optimizer discovery tools (mocked OptimizerClient)."""
 
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -69,10 +70,38 @@ def _not_found():
 # ─── list_experiments ──────────────────────────────────────────────────────
 
 
+def _listed_experiment(
+    name, *, running=0, succeeded=0, conditions=None, created="2026-01-01T00:00:00Z"
+):
+    """One item of a raw Experiment list, as CustomObjectsApi returns it."""
+    status = {"trials": running + succeeded, "trialsRunning": running}
+    if succeeded:
+        status["trialsSucceeded"] = succeeded
+    if conditions is not None:
+        status["conditions"] = conditions
+    return {"metadata": {"name": name, "creationTimestamp": created}, "status": status}
+
+
+_COMPLETE = [{"type": "Succeeded", "status": "True"}]
+
+
+@contextmanager
+def _experiment_list(items):
+    api = MagicMock()
+    api.list_namespaced_custom_object.return_value = {"items": items}
+    with (
+        patch(f"{_DISC}.get_custom_objects_api", return_value=api),
+        patch(f"{_DISC}.get_optimizer_effective_namespace", return_value="default"),
+    ):
+        yield api
+
+
 def test_list_experiments_happy_path():
-    client = MagicMock()
-    client.list_jobs.return_value = [_job("a", "Running"), _job("b", "Complete")]
-    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+    items = [
+        _listed_experiment("a", running=1),
+        _listed_experiment("b", succeeded=1, conditions=_COMPLETE),
+    ]
+    with _experiment_list(items):
         result = discovery.list_experiments()
     assert result["success"] is True
     assert result["data"]["total"] == 2
@@ -80,19 +109,62 @@ def test_list_experiments_happy_path():
     assert names == {"a", "b"}
 
 
+def test_list_experiments_reads_the_cr_in_one_call():
+    """The point of listing the CR: cost must not scale with trials.
+
+    ``OptimizerClient.list_jobs()`` resolves every trial's TrainJob one by one,
+    so a namespace of experiments cost one API call per trial. Listing the CR is
+    a single call no matter how many experiments or trials exist.
+    """
+    items = [_listed_experiment(f"exp-{i}", running=50) for i in range(30)]
+    with _experiment_list(items) as api:
+        with patch(f"{_DISC}.get_optimizer_client_for_namespace") as client_factory:
+            result = discovery.list_experiments()
+    assert result["data"]["total"] == 30
+    assert api.list_namespaced_custom_object.call_count == 1
+    client_factory.assert_not_called()
+
+
+def test_list_experiments_reports_counters_even_when_katib_omits_them():
+    """A fresh experiment has no counters on its CR, but the keys must persist."""
+    with _experiment_list([{"metadata": {"name": "fresh"}}]):
+        result = discovery.list_experiments()
+    exp = result["data"]["experiments"][0]
+    assert exp["status"] == "Created"
+    for key in ("total_trials", "running_trials", "succeeded_trials", "failed_trials"):
+        assert exp[key] == 0
+
+
 def test_list_experiments_status_filter():
-    client = MagicMock()
-    client.list_jobs.return_value = [_job("a", "Running"), _job("b", "Complete")]
-    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+    items = [
+        _listed_experiment("a", running=1),
+        _listed_experiment("b", succeeded=1, conditions=_COMPLETE),
+    ]
+    with _experiment_list(items):
         result = discovery.list_experiments(status="Complete")
     assert result["data"]["total"] == 1
     assert result["data"]["experiments"][0]["name"] == "b"
 
 
+def test_list_experiments_status_filter_accepts_succeeded_alias():
+    """troubleshooting.md documents Succeeded as an alias at the experiment level."""
+    items = [
+        _listed_experiment("a", running=1),
+        _listed_experiment("b", succeeded=1, conditions=_COMPLETE),
+    ]
+    with _experiment_list(items):
+        result = discovery.list_experiments(status="Succeeded")
+    assert result["data"]["total"] == 1
+    assert result["data"]["experiments"][0]["name"] == "b"
+
+
 def test_list_experiments_sdk_error():
-    client = MagicMock()
-    client.list_jobs.side_effect = RuntimeError("boom")
-    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+    api = MagicMock()
+    api.list_namespaced_custom_object.side_effect = RuntimeError("boom")
+    with (
+        patch(f"{_DISC}.get_custom_objects_api", return_value=api),
+        patch(f"{_DISC}.get_optimizer_effective_namespace", return_value="default"),
+    ):
         result = discovery.list_experiments()
     assert result["success"] is False
     assert result["error_code"] == "SDK_ERROR"
@@ -310,7 +382,7 @@ def test_list_suggestions_happy_path():
     assert result["data"]["total"] == 1
     sugg = result["data"]["suggestions"][0]
     assert sugg["algorithm"] == "random"
-    assert sugg["condition"] == "Succeeded"
+    assert [c["type"] for c in sugg["conditions"]] == ["Succeeded"]
 
 
 def test_list_suggestions_sdk_error():

--- a/kubeflow_mcp/optimizer/api/discovery_test.py
+++ b/kubeflow_mcp/optimizer/api/discovery_test.py
@@ -1,0 +1,374 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for optimizer discovery tools (mocked OptimizerClient)."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from kubernetes.client.exceptions import ApiException
+
+from kubeflow_mcp.optimizer.api import discovery
+
+_DISC = "kubeflow_mcp.optimizer.api.discovery"
+
+
+def _metric(name="accuracy", latest="0.95"):
+    return SimpleNamespace(name=name, min="0.5", max=latest, latest=latest)
+
+
+def _trial(name, status="Complete", params=None, metrics=None):
+    trainjob = SimpleNamespace(name=f"{name}-job", status=status)
+    return SimpleNamespace(
+        name=name,
+        parameters=params or {"lr": "0.01"},
+        trainjob=trainjob,
+        metrics=metrics if metrics is not None else [_metric()],
+    )
+
+
+def _job(name="exp-1", status="Running", trials=None):
+    return SimpleNamespace(
+        name=name,
+        status=status,
+        creation_timestamp=datetime(2026, 7, 21, tzinfo=timezone.utc),
+        trials=trials if trials is not None else [],
+        objectives=[SimpleNamespace(metric="accuracy", direction="maximize")],
+        algorithm=SimpleNamespace(random_state=42),
+        search_space={},
+        trial_config=SimpleNamespace(num_trials=10, parallel_trials=2, max_failed_trials=3),
+    )
+
+
+def _not_found():
+    """Build the exception shape the real SDK raises for a missing resource.
+
+    The kubernetes backend wraps a 404 as ``raise RuntimeError(...) from
+    ApiException(404)`` — is_k8s_not_found must detect it via ``__cause__``.
+    """
+    cause = ApiException(status=404, reason="Not Found")
+    err = RuntimeError("Failed to get OptimizationJob: default/missing")
+    err.__cause__ = cause
+    return err
+
+
+# ─── list_experiments ──────────────────────────────────────────────────────
+
+
+def test_list_experiments_happy_path():
+    client = MagicMock()
+    client.list_jobs.return_value = [_job("a", "Running"), _job("b", "Complete")]
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.list_experiments()
+    assert result["success"] is True
+    assert result["data"]["total"] == 2
+    names = {e["name"] for e in result["data"]["experiments"]}
+    assert names == {"a", "b"}
+
+
+def test_list_experiments_status_filter():
+    client = MagicMock()
+    client.list_jobs.return_value = [_job("a", "Running"), _job("b", "Complete")]
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.list_experiments(status="Complete")
+    assert result["data"]["total"] == 1
+    assert result["data"]["experiments"][0]["name"] == "b"
+
+
+def test_list_experiments_sdk_error():
+    client = MagicMock()
+    client.list_jobs.side_effect = RuntimeError("boom")
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.list_experiments()
+    assert result["success"] is False
+    assert result["error_code"] == "SDK_ERROR"
+
+
+# ─── get_experiment ────────────────────────────────────────────────────────
+
+
+def test_get_experiment_happy_path():
+    client = MagicMock()
+    client.get_job.return_value = _job(
+        "exp-1", "Running", trials=[_trial("t1"), _trial("t2", status="Failed")]
+    )
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.get_experiment("exp-1")
+    assert result["success"] is True
+    data = result["data"]
+    assert data["name"] == "exp-1"
+    assert data["total_trials"] == 2
+    assert data["succeeded_trials"] == 1
+    assert data["failed_trials"] == 1
+    assert len(data["trials"]) == 2
+    assert "trial_config" in data
+
+
+def test_get_experiment_not_found():
+    client = MagicMock()
+    client.get_job.side_effect = _not_found()
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.get_experiment("missing")
+    assert result["success"] is False
+    assert result["error_code"] == "RESOURCE_NOT_FOUND"
+
+
+def test_get_experiment_invalid_name():
+    result = discovery.get_experiment("Invalid_Name!")
+    assert result["success"] is False
+    assert result["error_code"] == "VALIDATION_ERROR"
+
+
+# ─── get_experiment_status ─────────────────────────────────────────────────
+
+
+def test_get_experiment_status_counts():
+    client = MagicMock()
+    client.get_job.return_value = _job(
+        "exp-1",
+        "Running",
+        trials=[
+            _trial("t1", "Complete"),
+            _trial("t2", "Running"),
+            _trial("t3", "Failed"),
+        ],
+    )
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.get_experiment_status("exp-1")
+    data = result["data"]
+    assert data["status"] == "Running"
+    assert data["total_trials"] == 3
+    assert data["running_trials"] == 1
+    assert data["succeeded_trials"] == 1
+    assert data["failed_trials"] == 1
+
+
+def test_get_experiment_status_not_found():
+    client = MagicMock()
+    client.get_job.side_effect = _not_found()
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.get_experiment_status("missing")
+    assert result["error_code"] == "RESOURCE_NOT_FOUND"
+
+
+# ─── get_trial ─────────────────────────────────────────────────────────────
+
+
+def test_get_trial_found():
+    client = MagicMock()
+    client.get_job.return_value = _job("exp-1", trials=[_trial("t1"), _trial("t2")])
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.get_trial("t2", experiment="exp-1")
+    assert result["success"] is True
+    assert result["data"]["name"] == "t2"
+    assert result["data"]["experiment"] == "exp-1"
+
+
+def test_get_trial_missing_trial():
+    client = MagicMock()
+    client.get_job.return_value = _job("exp-1", trials=[_trial("t1")])
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.get_trial("nope", experiment="exp-1")
+    assert result["success"] is False
+    assert result["error_code"] == "RESOURCE_NOT_FOUND"
+
+
+def test_get_trial_missing_experiment():
+    client = MagicMock()
+    client.get_job.side_effect = _not_found()
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.get_trial("t1", experiment="missing")
+    assert result["error_code"] == "RESOURCE_NOT_FOUND"
+
+
+# ─── get_successful_trials ─────────────────────────────────────────────────
+
+
+def test_get_successful_trials_filters():
+    client = MagicMock()
+    client.get_job.return_value = _job(
+        "exp-1",
+        trials=[
+            _trial("t1", "Complete"),
+            _trial("t2", "Failed"),
+            _trial("t3", "Complete"),
+        ],
+    )
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.get_successful_trials("exp-1")
+    assert result["data"]["total"] == 2
+    assert {t["name"] for t in result["data"]["trials"]} == {"t1", "t3"}
+
+
+# ─── list_suggestions ──────────────────────────────────────────────────────
+
+
+def test_list_suggestions_happy_path():
+    api = MagicMock()
+    api.list_namespaced_custom_object.return_value = {
+        "items": [
+            {
+                "metadata": {"name": "exp-1"},
+                "spec": {"algorithm": {"algorithmName": "random"}, "requests": 5},
+                "status": {"suggestionCount": 5, "conditions": [{"type": "Succeeded"}]},
+            }
+        ]
+    }
+    with (
+        patch(f"{_DISC}.get_custom_objects_api", return_value=api),
+        patch(f"{_DISC}.get_optimizer_effective_namespace", return_value="default"),
+    ):
+        result = discovery.list_suggestions()
+    assert result["success"] is True
+    assert result["data"]["total"] == 1
+    sugg = result["data"]["suggestions"][0]
+    assert sugg["algorithm"] == "random"
+    assert sugg["condition"] == "Succeeded"
+
+
+def test_list_suggestions_sdk_error():
+    api = MagicMock()
+    api.list_namespaced_custom_object.side_effect = RuntimeError("boom")
+    with (
+        patch(f"{_DISC}.get_custom_objects_api", return_value=api),
+        patch(f"{_DISC}.get_optimizer_effective_namespace", return_value="default"),
+    ):
+        result = discovery.list_suggestions()
+    assert result["success"] is False
+    assert result["error_code"] == "SDK_ERROR"
+
+
+# ─── get_experiment: Experiment CR enrichment ──────────────────────────────
+# OptimizationJob omits conditions, the current optimal trial and the
+# early-stopping spec, so get_experiment reads them from the CR. Field names
+# below follow kubeflow_katib_api v0.19.0 (camelCase wire format).
+
+
+def _experiment_cr(**status):
+    base = {
+        "trials": 6,
+        "trialsSucceeded": 3,
+        "trialsFailed": 1,
+        "trialsRunning": 1,
+        "trialsEarlyStopped": 1,
+        "conditions": [
+            {
+                "type": "Failed",
+                "status": "True",
+                "reason": "ExperimentFailed",
+                "message": "max failed trials exceeded",
+                "lastTransitionTime": "2026-08-10T00:00:00Z",
+            }
+        ],
+        "currentOptimalTrial": {
+            "bestTrialName": "exp-1-abc",
+            "parameterAssignments": [{"name": "lr", "value": "0.03"}],
+            "observation": {
+                "metrics": [{"name": "accuracy", "latest": "0.93", "max": "0.93", "min": "0.41"}]
+            },
+        },
+    }
+    base.update(status)
+    return {
+        "metadata": {"name": "exp-1"},
+        "spec": {
+            "earlyStopping": {
+                "algorithmName": "medianstop",
+                "algorithmSettings": [{"name": "min_trials_required", "value": "3"}],
+            }
+        },
+        "status": base,
+    }
+
+
+def _with_cr(cr):
+    api = MagicMock()
+    api.get_namespaced_custom_object.return_value = cr
+    return api
+
+
+def test_get_experiment_surfaces_conditions():
+    client = MagicMock(get_job=MagicMock(return_value=_job("exp-1", "Failed")))
+    with (
+        patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client),
+        patch(f"{_DISC}.get_custom_objects_api", return_value=_with_cr(_experiment_cr())),
+        patch(f"{_DISC}.get_optimizer_effective_namespace", return_value="kubeflow"),
+    ):
+        data = discovery.get_experiment("exp-1")["data"]
+
+    assert data["conditions"][0]["type"] == "Failed"
+    assert data["conditions"][0]["reason"] == "ExperimentFailed"
+    assert "max failed trials" in data["conditions"][0]["message"]
+
+
+def test_get_experiment_surfaces_best_trial_and_early_stopping():
+    client = MagicMock(get_job=MagicMock(return_value=_job("exp-1")))
+    with (
+        patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client),
+        patch(f"{_DISC}.get_custom_objects_api", return_value=_with_cr(_experiment_cr())),
+        patch(f"{_DISC}.get_optimizer_effective_namespace", return_value="kubeflow"),
+    ):
+        data = discovery.get_experiment("exp-1")["data"]
+
+    assert data["best_trial"]["name"] == "exp-1-abc"
+    assert data["best_trial"]["parameters"] == {"lr": "0.03"}
+    assert data["best_trial"]["metrics"][0]["name"] == "accuracy"
+    assert data["early_stopping"]["algorithm"] == "medianstop"
+    assert data["early_stopping"]["settings"]["min_trials_required"] == "3"
+
+
+def test_cr_counts_supersede_sdk_counts_and_include_early_stopped():
+    """The SDK derives counts from TrainJob status, which has no EarlyStopped
+    state — the CR is authoritative."""
+    client = MagicMock(get_job=MagicMock(return_value=_job("exp-1", trials=[_trial("t1")])))
+    with (
+        patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client),
+        patch(f"{_DISC}.get_custom_objects_api", return_value=_with_cr(_experiment_cr())),
+        patch(f"{_DISC}.get_optimizer_effective_namespace", return_value="kubeflow"),
+    ):
+        data = discovery.get_experiment("exp-1")["data"]
+
+    assert data["total_trials"] == 6  # CR value, not the 1 embedded trial
+    assert data["succeeded_trials"] == 3
+    assert data["early_stopped_trials"] == 1
+
+
+def test_get_experiment_reports_no_best_trial_before_metrics_exist():
+    cr = _experiment_cr(currentOptimalTrial={"parameterAssignments": []})
+    client = MagicMock(get_job=MagicMock(return_value=_job("exp-1")))
+    with (
+        patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client),
+        patch(f"{_DISC}.get_custom_objects_api", return_value=_with_cr(cr)),
+        patch(f"{_DISC}.get_optimizer_effective_namespace", return_value="kubeflow"),
+    ):
+        data = discovery.get_experiment("exp-1")["data"]
+    assert data["best_trial"] is None
+
+
+def test_get_experiment_degrades_when_cr_read_fails():
+    """The CR read is supplementary — losing it must not fail the whole call."""
+    client = MagicMock(get_job=MagicMock(return_value=_job("exp-1")))
+    api = MagicMock()
+    api.get_namespaced_custom_object.side_effect = RuntimeError("forbidden")
+    with (
+        patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client),
+        patch(f"{_DISC}.get_custom_objects_api", return_value=api),
+        patch(f"{_DISC}.get_optimizer_effective_namespace", return_value="kubeflow"),
+    ):
+        result = discovery.get_experiment("exp-1")
+
+    assert result["success"] is True
+    assert result["data"]["detail_unavailable"] is True
+    assert result["data"]["name"] == "exp-1"

--- a/kubeflow_mcp/optimizer/api/lifecycle.py
+++ b/kubeflow_mcp/optimizer/api/lifecycle.py
@@ -220,7 +220,9 @@ def update_experiment(
                 "metadata": {"annotations": annotation_patch},
                 "spec": {"parallelTrialCount": target},
             },
-            _request_timeout=mcp_utils.K8S_TIMEOUT,
+            # Patching an Experiment is admitted by the same webhooks as a
+            # create, so it gets the write budget rather than the read timeout.
+            _request_timeout=mcp_utils.K8S_WRITE_TIMEOUT,
         )
 
         past = "suspended" if action == "suspend" else "resumed"

--- a/kubeflow_mcp/optimizer/api/lifecycle.py
+++ b/kubeflow_mcp/optimizer/api/lifecycle.py
@@ -47,6 +47,41 @@ ACTIONS = ("suspend", "resume")
 PARALLELISM_ANNOTATION = "kubeflow-mcp/pre-suspend-parallel-trial-count"
 DEFAULT_PARALLELISM = 1
 
+# (parallelTrialCount to set, annotation patch to apply)
+ParallelismPatch = tuple[int, dict[str, str | None]]
+
+
+def _suspend_patch(current_parallelism: int | None) -> ParallelismPatch:
+    """Pause by zeroing concurrency, remembering what to restore later."""
+    remembered = str(current_parallelism or DEFAULT_PARALLELISM)
+    return 0, {PARALLELISM_ANNOTATION: remembered}
+
+
+def _resume_patch(annotations: dict[str, str]) -> ParallelismPatch:
+    """Restore the remembered concurrency, clearing the stash as we go.
+
+    Never restores 0: a missing or corrupt annotation would otherwise leave the
+    experiment paused while reporting that it resumed.
+    """
+    stashed = annotations.get(PARALLELISM_ANNOTATION)
+    target = int(stashed) if stashed and stashed.isdigit() else DEFAULT_PARALLELISM
+    return max(target, DEFAULT_PARALLELISM), {PARALLELISM_ANNOTATION: None}
+
+
+def _update_response(
+    name: str, namespace: str, action: str, parallelism: int, outcome: str
+) -> dict[str, Any]:
+    """Single response shape for every update_experiment outcome."""
+    return ToolResponse(
+        data={
+            "experiment": name,
+            "namespace": namespace,
+            "action": action,
+            "parallel_trial_count": parallelism,
+            "message": f"Experiment '{name}' {outcome}",
+        }
+    ).model_dump()
+
 
 def delete_experiment(
     name: str,
@@ -173,27 +208,12 @@ def update_experiment(
         annotations = (current.get("metadata") or {}).get("annotations") or {}
         parallelism = (current.get("spec") or {}).get("parallelTrialCount")
 
-        if action == "suspend":
-            if parallelism == 0:
-                return ToolResponse(
-                    data={
-                        "experiment": name,
-                        "namespace": ns,
-                        "action": action,
-                        "parallel_trial_count": 0,
-                        "message": f"Experiment '{name}' is already suspended",
-                    }
-                ).model_dump()
-            target = 0
-            # Remember the concurrency we are pausing so resume can restore it.
-            annotation_patch = {PARALLELISM_ANNOTATION: str(parallelism or DEFAULT_PARALLELISM)}
-        else:
-            stashed = annotations.get(PARALLELISM_ANNOTATION)
-            target = int(stashed) if stashed and stashed.isdigit() else DEFAULT_PARALLELISM
-            target = max(target, DEFAULT_PARALLELISM)
-            # Clear the stash so a later suspend records a fresh value.
-            annotation_patch = {PARALLELISM_ANNOTATION: None}
+        if action == "suspend" and parallelism == 0:
+            return _update_response(name, ns, action, 0, "is already suspended")
 
+        target, annotation_patch = (
+            _suspend_patch(parallelism) if action == "suspend" else _resume_patch(annotations)
+        )
         api.patch_namespaced_custom_object(
             **target_ref,
             body={
@@ -204,15 +224,7 @@ def update_experiment(
         )
 
         past = "suspended" if action == "suspend" else "resumed"
-        return ToolResponse(
-            data={
-                "experiment": name,
-                "namespace": ns,
-                "action": action,
-                "parallel_trial_count": target,
-                "message": f"Experiment '{name}' {past} (parallelTrialCount={target})",
-            }
-        ).model_dump()
+        return _update_response(name, ns, action, target, f"{past} (parallelTrialCount={target})")
 
     except Exception as e:
         logger.warning("update_experiment(%s, %s) failed: %s", name, action, e, exc_info=True)

--- a/kubeflow_mcp/optimizer/api/lifecycle.py
+++ b/kubeflow_mcp/optimizer/api/lifecycle.py
@@ -1,0 +1,219 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lifecycle tools for Katib experiment management.
+
+SDK methods used:
+    - OptimizerClient.delete_job()                       → delete_experiment
+    - CustomObjectsApi.patch_namespaced_custom_object()  → update_experiment
+"""
+
+import logging
+from typing import Any
+
+from kubeflow_mcp.common import utils as mcp_utils
+from kubeflow_mcp.common.constants import ErrorCode
+from kubeflow_mcp.common.types import PreviewResponse, ToolError, ToolResponse
+from kubeflow_mcp.core.security import validate_k8s_name
+from kubeflow_mcp.optimizer.api._common import (
+    check_optimizer_namespace,
+    experiment_error,
+    require_mcp_ownership,
+)
+from kubeflow_mcp.optimizer.constants import (
+    EXPERIMENT_PLURAL,
+    KATIB_API_GROUP,
+    KATIB_API_VERSION,
+)
+
+logger = logging.getLogger(__name__)
+
+ACTIONS = ("suspend", "resume")
+
+# Katib has no first-class suspend field, so pausing is done by setting
+# spec.parallelTrialCount to 0. The pre-suspend value is stashed in this
+# annotation so resume restores the original concurrency instead of guessing.
+PARALLELISM_ANNOTATION = "kubeflow-mcp/pre-suspend-parallel-trial-count"
+DEFAULT_PARALLELISM = 1
+
+
+def delete_experiment(
+    name: str,
+    namespace: str | None = None,
+    confirmed: bool = False,
+) -> dict[str, Any]:
+    """Delete a Katib experiment permanently.
+
+    Removes the experiment along with its trials and suggestion. Irreversible,
+    so it requires ``confirmed=True``; the first call returns a preview.
+
+    Non-admin personas may only delete experiments created through MCP.
+
+    Args:
+        name: Experiment name to delete.
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+        confirmed: Set ``True`` to delete. ``False`` returns a preview.
+
+    Returns:
+        dict: Preview, or deletion result with ``deleted`` (bool).
+
+    Raises:
+        ToolError: If experiment not found (``RESOURCE_NOT_FOUND``).
+    """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    try:
+        ns = mcp_utils.get_optimizer_effective_namespace(namespace)
+
+        owner_err = require_mcp_ownership(name, ns, "delete")
+        if owner_err is not None:
+            return owner_err.model_dump()
+
+        if not confirmed:
+            return PreviewResponse(
+                message=(
+                    f"Will permanently delete experiment '{name}' in '{ns}', "
+                    "including its trials and suggestion. Set confirmed=True to proceed."
+                ),
+                config={"experiment": name, "namespace": ns},
+            ).model_dump()
+
+        client = mcp_utils.get_optimizer_client_for_namespace(namespace)
+        client.delete_job(name=name)
+
+        return ToolResponse(
+            data={
+                "experiment": name,
+                "namespace": ns,
+                "deleted": True,
+                "message": f"Experiment '{name}' deleted",
+            }
+        ).model_dump()
+
+    except Exception as e:
+        logger.warning("delete_experiment(%s) failed: %s", name, e, exc_info=True)
+        return experiment_error(e, name).model_dump()
+
+
+def update_experiment(
+    name: str,
+    action: str,
+    namespace: str | None = None,
+) -> dict[str, Any]:
+    """Suspend or resume a Katib experiment.
+
+    Katib exposes no suspend field, so ``"suspend"`` sets
+    ``spec.parallelTrialCount`` to 0 — running trials finish but no new ones
+    start. The previous value is recorded in an annotation so ``"resume"``
+    restores the original concurrency.
+
+    Non-admin personas may only update experiments created through MCP.
+
+    Args:
+        name: Experiment name.
+        action: ``"suspend"`` to pause, ``"resume"`` to continue.
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+
+    Returns:
+        dict: Response with ``experiment``, ``namespace``, ``action`` and the
+        resulting ``parallel_trial_count``.
+
+    Raises:
+        ToolError: If experiment not found or the action is invalid.
+    """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
+    if action not in ACTIONS:
+        return ToolError(
+            error=f"Invalid action '{action}'. Must be one of: {ACTIONS}",
+            error_code=ErrorCode.VALIDATION_ERROR,
+        ).model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    try:
+        ns = mcp_utils.get_optimizer_effective_namespace(namespace)
+
+        owner_err = require_mcp_ownership(name, ns, action)
+        if owner_err is not None:
+            return owner_err.model_dump()
+
+        api = mcp_utils.get_custom_objects_api()
+        target_ref = {
+            "group": KATIB_API_GROUP,
+            "version": KATIB_API_VERSION,
+            "namespace": ns,
+            "plural": EXPERIMENT_PLURAL,
+            "name": name,
+        }
+        current = api.get_namespaced_custom_object(
+            **target_ref, _request_timeout=mcp_utils.K8S_TIMEOUT
+        )
+        annotations = (current.get("metadata") or {}).get("annotations") or {}
+        parallelism = (current.get("spec") or {}).get("parallelTrialCount")
+
+        if action == "suspend":
+            if parallelism == 0:
+                return ToolResponse(
+                    data={
+                        "experiment": name,
+                        "namespace": ns,
+                        "action": action,
+                        "parallel_trial_count": 0,
+                        "message": f"Experiment '{name}' is already suspended",
+                    }
+                ).model_dump()
+            target = 0
+            # Remember the concurrency we are pausing so resume can restore it.
+            annotation_patch = {PARALLELISM_ANNOTATION: str(parallelism or DEFAULT_PARALLELISM)}
+        else:
+            stashed = annotations.get(PARALLELISM_ANNOTATION)
+            target = int(stashed) if stashed and stashed.isdigit() else DEFAULT_PARALLELISM
+            target = max(target, DEFAULT_PARALLELISM)
+            # Clear the stash so a later suspend records a fresh value.
+            annotation_patch = {PARALLELISM_ANNOTATION: None}
+
+        api.patch_namespaced_custom_object(
+            **target_ref,
+            body={
+                "metadata": {"annotations": annotation_patch},
+                "spec": {"parallelTrialCount": target},
+            },
+            _request_timeout=mcp_utils.K8S_TIMEOUT,
+        )
+
+        past = "suspended" if action == "suspend" else "resumed"
+        return ToolResponse(
+            data={
+                "experiment": name,
+                "namespace": ns,
+                "action": action,
+                "parallel_trial_count": target,
+                "message": f"Experiment '{name}' {past} (parallelTrialCount={target})",
+            }
+        ).model_dump()
+
+    except Exception as e:
+        logger.warning("update_experiment(%s, %s) failed: %s", name, action, e, exc_info=True)
+        return experiment_error(e, name).model_dump()

--- a/kubeflow_mcp/optimizer/api/lifecycle_test.py
+++ b/kubeflow_mcp/optimizer/api/lifecycle_test.py
@@ -1,0 +1,213 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for optimizer lifecycle tools (confirmation, ownership, suspend/resume)."""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+from kubernetes.client.exceptions import ApiException
+
+from kubeflow_mcp.optimizer.api import lifecycle as lc
+
+_UTILS = "kubeflow_mcp.common.utils"
+_COMMON = "kubeflow_mcp.optimizer.api._common"
+
+
+def _not_found():
+    """The shape the SDK raises: RuntimeError chaining a 404 ApiException."""
+    err = RuntimeError("Failed to get OptimizationJob: kubeflow/missing")
+    err.__cause__ = ApiException(status=404, reason="Not Found")
+    return err
+
+
+@contextmanager
+def cluster(api: MagicMock | None = None, persona="platform-admin", managed=True, client=None):
+    api = api or MagicMock()
+    client = client or MagicMock()
+    with (
+        patch(f"{_UTILS}.get_optimizer_effective_namespace", return_value="kubeflow"),
+        patch(f"{_UTILS}.get_custom_objects_api", return_value=api),
+        patch(f"{_UTILS}.get_optimizer_client_for_namespace", return_value=client),
+        patch(f"{_UTILS}.is_optimizer_mcp_managed", return_value=managed),
+        patch(f"{_COMMON}.get_effective_persona", return_value=persona),
+    ):
+        yield api, client
+
+
+def _experiment(parallel=4, annotations=None):
+    return {
+        "metadata": {"annotations": annotations or {}},
+        "spec": {"parallelTrialCount": parallel},
+    }
+
+
+# ─── delete_experiment ─────────────────────────────────────────────────────
+
+
+def test_delete_preview_does_not_delete():
+    with cluster() as (_, client):
+        result = lc.delete_experiment("demo")
+    assert result["status"] == "preview"
+    assert result["config"] == {"experiment": "demo", "namespace": "kubeflow"}
+    client.delete_job.assert_not_called()
+
+
+def test_delete_confirmed_calls_sdk():
+    with cluster() as (_, client):
+        result = lc.delete_experiment("demo", confirmed=True)
+    assert result["data"]["deleted"] is True
+    client.delete_job.assert_called_once_with(name="demo")
+
+
+def test_delete_invalid_name():
+    result = lc.delete_experiment("Bad_Name!")
+    assert result["error_code"] == "VALIDATION_ERROR"
+
+
+def test_delete_not_found():
+    client = MagicMock()
+    client.delete_job.side_effect = _not_found()
+    with cluster(client=client):
+        result = lc.delete_experiment("missing", confirmed=True)
+    assert result["error_code"] == "RESOURCE_NOT_FOUND"
+
+
+# ─── MCP ownership enforcement ─────────────────────────────────────────────
+
+
+def test_non_admin_blocked_from_deleting_external_experiment():
+    with cluster(persona="data-scientist", managed=False) as (_, client):
+        result = lc.delete_experiment("external", confirmed=True)
+    assert result["success"] is False
+    assert result["error_code"] == "VALIDATION_ERROR"
+    client.delete_job.assert_not_called()
+
+
+def test_non_admin_allowed_for_mcp_created_experiment():
+    with cluster(persona="data-scientist", managed=True) as (_, client):
+        result = lc.delete_experiment("ours", confirmed=True)
+    assert result["success"] is True
+    client.delete_job.assert_called_once()
+
+
+def test_admin_bypasses_ownership_check():
+    with cluster(persona="platform-admin", managed=False) as (_, client):
+        result = lc.delete_experiment("external", confirmed=True)
+    assert result["success"] is True
+    client.delete_job.assert_called_once()
+
+
+def test_ownership_check_failure_is_reported():
+    """managed=None means the label lookup itself failed — must not delete."""
+    with cluster(persona="data-scientist", managed=None) as (_, client):
+        result = lc.delete_experiment("unknown", confirmed=True)
+    assert result["error_code"] == "SDK_ERROR"
+    client.delete_job.assert_not_called()
+
+
+# ─── update_experiment: suspend / resume ───────────────────────────────────
+
+
+def test_suspend_zeroes_parallelism_and_stashes_previous():
+    api = MagicMock()
+    api.get_namespaced_custom_object.return_value = _experiment(parallel=4)
+    with cluster(api):
+        result = lc.update_experiment("demo", "suspend")
+
+    assert result["data"]["parallel_trial_count"] == 0
+    body = api.patch_namespaced_custom_object.call_args.kwargs["body"]
+    assert body["spec"]["parallelTrialCount"] == 0
+    assert body["metadata"]["annotations"][lc.PARALLELISM_ANNOTATION] == "4"
+    # KEP text also mentions resumePolicy; we deliberately do not touch it.
+    assert "resumePolicy" not in body["spec"]
+
+
+def test_resume_restores_stashed_parallelism_and_clears_annotation():
+    api = MagicMock()
+    api.get_namespaced_custom_object.return_value = _experiment(
+        parallel=0, annotations={lc.PARALLELISM_ANNOTATION: "4"}
+    )
+    with cluster(api):
+        result = lc.update_experiment("demo", "resume")
+
+    assert result["data"]["parallel_trial_count"] == 4
+    body = api.patch_namespaced_custom_object.call_args.kwargs["body"]
+    assert body["spec"]["parallelTrialCount"] == 4
+    assert body["metadata"]["annotations"][lc.PARALLELISM_ANNOTATION] is None
+
+
+def test_resume_without_stash_falls_back_to_default():
+    api = MagicMock()
+    api.get_namespaced_custom_object.return_value = _experiment(parallel=0)
+    with cluster(api):
+        result = lc.update_experiment("demo", "resume")
+    assert result["data"]["parallel_trial_count"] == lc.DEFAULT_PARALLELISM
+
+
+def test_resume_never_restores_zero():
+    """A corrupt stash of '0' would silently leave the experiment paused."""
+    api = MagicMock()
+    api.get_namespaced_custom_object.return_value = _experiment(
+        parallel=0, annotations={lc.PARALLELISM_ANNOTATION: "0"}
+    )
+    with cluster(api):
+        result = lc.update_experiment("demo", "resume")
+    assert result["data"]["parallel_trial_count"] >= lc.DEFAULT_PARALLELISM
+
+
+def test_suspend_is_idempotent():
+    api = MagicMock()
+    api.get_namespaced_custom_object.return_value = _experiment(parallel=0)
+    with cluster(api):
+        result = lc.update_experiment("demo", "suspend")
+    assert result["success"] is True
+    assert "already suspended" in result["data"]["message"]
+    api.patch_namespaced_custom_object.assert_not_called()
+
+
+def test_suspend_resume_round_trip_preserves_concurrency():
+    api = MagicMock()
+    api.get_namespaced_custom_object.return_value = _experiment(parallel=7)
+    with cluster(api):
+        lc.update_experiment("demo", "suspend")
+        stashed = api.patch_namespaced_custom_object.call_args.kwargs["body"]["metadata"][
+            "annotations"
+        ]
+        api.get_namespaced_custom_object.return_value = _experiment(parallel=0, annotations=stashed)
+        result = lc.update_experiment("demo", "resume")
+    assert result["data"]["parallel_trial_count"] == 7
+
+
+@pytest.mark.parametrize("action", ["pause", "", "SUSPEND"])
+def test_invalid_action_rejected(action):
+    result = lc.update_experiment("demo", action)
+    assert result["error_code"] == "VALIDATION_ERROR"
+
+
+def test_update_not_found():
+    api = MagicMock()
+    api.get_namespaced_custom_object.side_effect = _not_found()
+    with cluster(api):
+        result = lc.update_experiment("missing", "suspend")
+    assert result["error_code"] == "RESOURCE_NOT_FOUND"
+
+
+def test_non_admin_blocked_from_updating_external_experiment():
+    api = MagicMock()
+    with cluster(api, persona="ml-engineer", managed=False):
+        result = lc.update_experiment("external", "suspend")
+    assert result["success"] is False
+    api.patch_namespaced_custom_object.assert_not_called()

--- a/kubeflow_mcp/optimizer/api/lifecycle_test.py
+++ b/kubeflow_mcp/optimizer/api/lifecycle_test.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from kubernetes.client.exceptions import ApiException
 
+from kubeflow_mcp.common import utils as mcp_utils
 from kubeflow_mcp.optimizer.api import lifecycle as lc
 
 _UTILS = "kubeflow_mcp.common.utils"
@@ -35,13 +36,19 @@ def _not_found():
 
 @contextmanager
 def cluster(api: MagicMock | None = None, persona="platform-admin", managed=True, client=None):
+    """``managed`` accepts True/False/None, or an ownership string directly."""
     api = api or MagicMock()
     client = client or MagicMock()
+    ownership = {
+        True: mcp_utils.OWNERSHIP_MANAGED,
+        False: mcp_utils.OWNERSHIP_UNMANAGED,
+        None: None,
+    }.get(managed, managed)
     with (
         patch(f"{_UTILS}.get_optimizer_effective_namespace", return_value="kubeflow"),
         patch(f"{_UTILS}.get_custom_objects_api", return_value=api),
         patch(f"{_UTILS}.get_optimizer_client_for_namespace", return_value=client),
-        patch(f"{_UTILS}.is_optimizer_mcp_managed", return_value=managed),
+        patch(f"{_UTILS}.get_optimizer_ownership", return_value=ownership),
         patch(f"{_COMMON}.get_effective_persona", return_value=persona),
     ):
         yield api, client
@@ -116,6 +123,24 @@ def test_ownership_check_failure_is_reported():
         result = lc.delete_experiment("unknown", confirmed=True)
     assert result["error_code"] == "SDK_ERROR"
     client.delete_job.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("call", "attr"),
+    [
+        (lambda: lc.delete_experiment("typo", confirmed=True), "delete_job"),
+        (lambda: lc.update_experiment("typo", "suspend"), "delete_job"),
+    ],
+)
+def test_missing_experiment_reports_not_found_not_ownership(call, attr):
+    """A name that does not exist must not be blamed on ownership: that sends
+    the caller after RBAC when the real problem is usually a typo."""
+    with cluster(persona="data-scientist", managed=mcp_utils.OWNERSHIP_MISSING) as (_, client):
+        result = call()
+    assert result["success"] is False
+    assert result["error_code"] == "RESOURCE_NOT_FOUND"
+    assert "not created by MCP" not in result["error"]
+    getattr(client, attr).assert_not_called()
 
 
 # ─── update_experiment: suspend / resume ───────────────────────────────────

--- a/kubeflow_mcp/optimizer/api/limits_test.py
+++ b/kubeflow_mcp/optimizer/api/limits_test.py
@@ -75,9 +75,13 @@ def test_clamp_limit_rejects_non_positive(bad):
 
 
 def test_list_experiments_truncates_but_reports_true_total():
-    jobs = [_job() for _ in range(120)]
-    client = MagicMock(list_jobs=MagicMock(return_value=jobs))
-    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+    items = [{"metadata": {"name": f"exp-{i}"}} for i in range(120)]
+    api = MagicMock()
+    api.list_namespaced_custom_object.return_value = {"items": items}
+    with (
+        patch(f"{_DISC}.get_custom_objects_api", return_value=api),
+        patch(f"{_DISC}.get_optimizer_effective_namespace", return_value="default"),
+    ):
         result = discovery.list_experiments(limit=5)
     assert len(result["data"]["experiments"]) == 5
     assert result["data"]["total"] == 120

--- a/kubeflow_mcp/optimizer/api/limits_test.py
+++ b/kubeflow_mcp/optimizer/api/limits_test.py
@@ -1,0 +1,185 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Result-limit enforcement on optimizer collection tools.
+
+Unbounded responses are an MCP hazard: a large experiment could otherwise emit
+every trial into the agent's context window. Every collection tool must bound
+what it returns while still reporting the true total.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kubeflow_mcp.optimizer.api import discovery, monitoring
+from kubeflow_mcp.optimizer.api._common import DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT, clamp_limit
+
+_DISC = "kubeflow_mcp.optimizer.api.discovery"
+_MON = "kubeflow_mcp.optimizer.api.monitoring"
+
+
+def _trial(i):
+    return SimpleNamespace(
+        name=f"t{i}",
+        parameters={"lr": "0.01"},
+        trainjob=SimpleNamespace(name=f"t{i}-job", status="Complete"),
+        metrics=[],
+    )
+
+
+def _job(trial_count=0):
+    return SimpleNamespace(
+        name="exp",
+        status="Running",
+        creation_timestamp=None,
+        trials=[_trial(i) for i in range(trial_count)],
+        objectives=[],
+        algorithm=SimpleNamespace(random_state=None),
+        search_space={},
+        trial_config=SimpleNamespace(num_trials=1, parallel_trials=1, max_failed_trials=None),
+    )
+
+
+# ─── clamp_limit ───────────────────────────────────────────────────────────
+
+
+def test_clamp_limit_caps_at_maximum():
+    assert clamp_limit(10_000) == (MAX_LIST_LIMIT, None)
+
+
+def test_clamp_limit_passes_through_valid_values():
+    assert clamp_limit(7) == (7, None)
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_clamp_limit_rejects_non_positive(bad):
+    value, err = clamp_limit(bad)
+    assert err is not None
+    assert err.error_code == "VALIDATION_ERROR"
+
+
+# ─── every collection tool bounds its response ─────────────────────────────
+
+
+def test_list_experiments_truncates_but_reports_true_total():
+    jobs = [_job() for _ in range(120)]
+    client = MagicMock(list_jobs=MagicMock(return_value=jobs))
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.list_experiments(limit=5)
+    assert len(result["data"]["experiments"]) == 5
+    assert result["data"]["total"] == 120
+
+
+def test_get_experiment_truncates_trials_and_flags_it():
+    client = MagicMock(get_job=MagicMock(return_value=_job(trial_count=120)))
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.get_experiment("exp", limit=5)
+    data = result["data"]
+    assert len(data["trials"]) == 5
+    assert data["trials_truncated"] is True
+    # Counts are derived from the full set, not the truncated slice.
+    assert data["total_trials"] == 120
+
+
+def test_get_experiment_does_not_flag_truncation_when_all_fit():
+    client = MagicMock(get_job=MagicMock(return_value=_job(trial_count=3)))
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.get_experiment("exp", limit=50)
+    assert result["data"]["trials_truncated"] is False
+
+
+def test_get_successful_trials_truncates():
+    client = MagicMock(get_job=MagicMock(return_value=_job(trial_count=80)))
+    with patch(f"{_DISC}.get_optimizer_client_for_namespace", return_value=client):
+        result = discovery.get_successful_trials("exp", limit=10)
+    assert len(result["data"]["trials"]) == 10
+    assert result["data"]["total"] == 80
+
+
+def test_list_suggestions_truncates():
+    api = MagicMock()
+    api.list_namespaced_custom_object.return_value = {
+        "items": [{"metadata": {"name": f"s{i}"}, "spec": {}, "status": {}} for i in range(70)]
+    }
+    with (
+        patch(f"{_DISC}.get_custom_objects_api", return_value=api),
+        patch(f"{_DISC}.get_optimizer_effective_namespace", return_value="default"),
+    ):
+        result = discovery.list_suggestions(limit=4)
+    assert len(result["data"]["suggestions"]) == 4
+    assert result["data"]["total"] == 70
+
+
+def test_get_experiment_trials_truncates():
+    client = MagicMock(get_job=MagicMock(return_value=_job(trial_count=90)))
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.get_experiment_trials("exp", limit=6)
+    assert len(result["data"]["trials"]) == 6
+    assert result["data"]["total"] == 90
+    # Summary counts still reflect every trial.
+    assert result["data"]["summary"]["total_trials"] == 90
+
+
+def test_get_experiment_events_truncates():
+    events = [
+        SimpleNamespace(
+            involved_object_kind="Pod",
+            involved_object_name=f"p{i}",
+            reason="Scheduled",
+            message="m",
+            event_time=None,
+        )
+        for i in range(75)
+    ]
+    client = MagicMock(get_job_events=MagicMock(return_value=events))
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.get_experiment_events("exp", limit=3)
+    assert len(result["data"]["events"]) == 3
+    assert result["data"]["total"] == 75
+
+
+@pytest.mark.parametrize(
+    ("tool", "kwargs"),
+    [
+        (discovery.list_experiments, {}),
+        (discovery.get_experiment, {"name": "exp"}),
+        (discovery.get_successful_trials, {"name": "exp"}),
+        (discovery.list_suggestions, {}),
+        (monitoring.get_experiment_trials, {"name": "exp"}),
+        (monitoring.get_experiment_events, {"name": "exp"}),
+    ],
+)
+def test_every_collection_tool_rejects_invalid_limit(tool, kwargs):
+    result = tool(limit=0, **kwargs)
+    assert result["success"] is False
+    assert result["error_code"] == "VALIDATION_ERROR"
+
+
+@pytest.mark.parametrize(
+    ("tool", "kwargs"),
+    [
+        (discovery.list_experiments, {}),
+        (discovery.get_experiment, {"name": "exp"}),
+        (discovery.get_successful_trials, {"name": "exp"}),
+        (discovery.list_suggestions, {}),
+        (monitoring.get_experiment_trials, {"name": "exp"}),
+        (monitoring.get_experiment_events, {"name": "exp"}),
+    ],
+)
+def test_default_limit_is_consistent(tool, kwargs):
+    import inspect
+
+    assert inspect.signature(tool).parameters["limit"].default == DEFAULT_LIST_LIMIT

--- a/kubeflow_mcp/optimizer/api/monitoring.py
+++ b/kubeflow_mcp/optimizer/api/monitoring.py
@@ -1,0 +1,414 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Monitoring tools for Katib experiment tracking and debugging.
+
+SDK methods used:
+    - OptimizerClient.get_job()                → get_experiment_trials
+    - OptimizerClient.get_best_results()       → get_best_trial
+    - OptimizerClient.wait_for_job_status()    → wait_for_experiment
+    - OptimizerClient.get_job_logs()           → get_experiment_trial_logs
+    - OptimizerClient.get_job_events()         → get_experiment_events
+    - CustomObjectsApi                         → get_suggestion (no SDK method)
+"""
+
+import logging
+from typing import Any
+
+from kubeflow_mcp.common.constants import ErrorCode
+from kubeflow_mcp.common.failures import extract_failure_hint
+from kubeflow_mcp.common.types import ToolError, ToolResponse, exception_details, is_k8s_not_found
+from kubeflow_mcp.common.utils import (
+    K8S_TIMEOUT,
+    get_custom_objects_api,
+    get_optimizer_client_for_namespace,
+    get_optimizer_effective_namespace,
+)
+from kubeflow_mcp.core.security import (
+    truncate_log_output,
+    validate_k8s_name,
+)
+from kubeflow_mcp.optimizer.api._common import (
+    DEFAULT_LIST_LIMIT,
+    check_optimizer_namespace,
+    clamp_limit,
+    experiment_error,
+)
+from kubeflow_mcp.optimizer.constants import (
+    KATIB_API_GROUP,
+    KATIB_API_VERSION,
+    OPTIMIZATION_JOB_COMPLETE,
+    OPTIMIZATION_JOB_FAILED,
+    SUGGESTION_PLURAL,
+)
+from kubeflow_mcp.optimizer.types import (
+    event_to_dict,
+    result_to_dict,
+    trial_counts,
+    trial_to_dict,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_LOG_LINES = 1000
+MAX_WAIT_TIMEOUT = 3600
+MIN_POLLING_INTERVAL = 5
+
+
+def get_experiment_trials(
+    name: str,
+    namespace: str | None = None,
+    status: str | None = None,
+    limit: int = DEFAULT_LIST_LIMIT,
+) -> dict[str, Any]:
+    """List trials for a Katib experiment with optional status filter.
+
+    Trials are read from ``OptimizerClient.get_job().trials``.
+
+    Args:
+        name: Experiment name.
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+        status: Optional status filter (e.g. Running, Complete, Failed).
+        limit: Maximum trials to return. Defaults to 50, capped at 500.
+
+    Returns:
+        dict: Response containing ``trials`` (up to ``limit``), ``total``
+        matching trials, and a ``summary`` of counts by status.
+    """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    limit, limit_err = clamp_limit(limit)
+    if limit_err is not None:
+        return limit_err.model_dump()
+
+    try:
+        client = get_optimizer_client_for_namespace(namespace)
+        job = client.get_job(name=name)
+
+        trials = [trial_to_dict(t) for t in (getattr(job, "trials", None) or [])]
+        if status:
+            trials = [t for t in trials if t.get("status") == status]
+
+        data: dict[str, Any] = {
+            "experiment": name,
+            "trials": trials[:limit],
+            "total": len(trials),
+        }
+        data["summary"] = trial_counts(job)
+        return ToolResponse(data=data).model_dump()
+
+    except Exception as e:
+        return experiment_error(e, name).model_dump()
+
+
+def get_best_trial(
+    name: str,
+    namespace: str | None = None,
+) -> dict[str, Any]:
+    """Get the best trial with optimal hyperparameters and metrics.
+
+    Uses ``OptimizerClient.get_best_results()``.
+
+    Args:
+        name: Experiment name.
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+
+    Returns:
+        dict: Response containing best hyperparameters and metrics, or a note
+              when no successful trial exists yet.
+    """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    try:
+        client = get_optimizer_client_for_namespace(namespace)
+        result = client.get_best_results(name=name)
+
+        best = result_to_dict(result)
+        if best is None:
+            return ToolResponse(
+                data={
+                    "experiment": name,
+                    "best_trial": None,
+                    "message": "No optimal result available yet — no successful trials.",
+                }
+            ).model_dump()
+
+        return ToolResponse(
+            data={
+                "experiment": name,
+                "parameters": best["parameters"],
+                "metrics": best["metrics"],
+                "next_steps": [
+                    f"fine_tune(...) — retrain with these hyperparameters from '{name}'",
+                ],
+            }
+        ).model_dump()
+
+    except Exception as e:
+        return experiment_error(e, name).model_dump()
+
+
+def get_suggestion(
+    name: str,
+    namespace: str | None = None,
+) -> dict[str, Any]:
+    """Get suggestion algorithm status for an experiment.
+
+    The Suggestion resource shares the experiment's name. Uses CustomObjectsApi
+    directly (no SDK method available).
+
+    Args:
+        name: Experiment name (suggestion shares the same name).
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+
+    Returns:
+        dict: Response containing algorithm name, status, and request counts.
+    """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    try:
+        ns = get_optimizer_effective_namespace(namespace)
+        api = get_custom_objects_api()
+        obj = api.get_namespaced_custom_object(
+            group=KATIB_API_GROUP,
+            version=KATIB_API_VERSION,
+            namespace=ns,
+            plural=SUGGESTION_PLURAL,
+            name=name,
+            _request_timeout=K8S_TIMEOUT,
+        )
+
+        spec = obj.get("spec", {})
+        status = obj.get("status", {})
+        algorithm = spec.get("algorithm", {})
+        conditions = status.get("conditions", []) or []
+        data = {
+            "name": name,
+            "namespace": ns,
+            "algorithm": algorithm.get("algorithmName"),
+            "requests": spec.get("requests"),
+            "suggestion_count": status.get("suggestionCount"),
+            "conditions": [
+                {"type": c.get("type"), "status": c.get("status"), "reason": c.get("reason")}
+                for c in conditions
+            ],
+        }
+        return ToolResponse(data=data).model_dump()
+
+    except Exception as e:
+        if is_k8s_not_found(e):
+            return ToolError(
+                error=f"Suggestion '{name}' not found",
+                error_code=ErrorCode.RESOURCE_NOT_FOUND,
+                hint="A Suggestion is created once an experiment starts running.",
+            ).model_dump()
+        return ToolError(
+            error=str(e),
+            error_code=ErrorCode.SDK_ERROR,
+            details=exception_details(e),
+        ).model_dump()
+
+
+def wait_for_experiment(
+    name: str,
+    namespace: str | None = None,
+    timeout_seconds: int = 600,
+    polling_interval: int = 15,
+) -> dict[str, Any]:
+    """Block until experiment reaches terminal status (Complete/Failed).
+
+    Uses ``OptimizerClient.wait_for_job_status()``. Timeout is capped at 3600
+    seconds and the polling interval has a minimum of 5 seconds.
+
+    Args:
+        name: Experiment name.
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+        timeout_seconds: Maximum seconds to wait. Capped at 3600.
+        polling_interval: Seconds between status polls. Minimum 5.
+
+    Returns:
+        dict: Response containing final experiment status and trial summary.
+    """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    if timeout_seconds < 1:
+        return ToolError(
+            error=f"timeout_seconds must be >= 1, got {timeout_seconds}",
+            error_code=ErrorCode.VALIDATION_ERROR,
+        ).model_dump()
+
+    timeout_seconds = min(timeout_seconds, MAX_WAIT_TIMEOUT)
+    polling_interval = max(polling_interval, MIN_POLLING_INTERVAL)
+
+    try:
+        client = get_optimizer_client_for_namespace(namespace)
+        job = client.wait_for_job_status(
+            name=name,
+            status={OPTIMIZATION_JOB_COMPLETE, OPTIMIZATION_JOB_FAILED},
+            timeout=timeout_seconds,
+            polling_interval=polling_interval,
+        )
+
+        final_status = getattr(job, "status", None) or "Unknown"
+        data: dict[str, Any] = {
+            "experiment": name,
+            "status": final_status,
+            "reached": True,
+            "message": f"Experiment reached '{final_status}'",
+        }
+        data.update(trial_counts(job))
+        return ToolResponse(data=data).model_dump()
+
+    except TimeoutError:
+        return ToolResponse(
+            data={
+                "experiment": name,
+                "status": "Unknown",
+                "reached": False,
+                "message": f"Timeout after {timeout_seconds}s",
+                "hint": "Use get_experiment_events() to check for scheduling issues",
+            }
+        ).model_dump()
+    except Exception as e:
+        return experiment_error(e, name).model_dump()
+
+
+def get_experiment_trial_logs(
+    name: str,
+    trial: str | None = None,
+    namespace: str | None = None,
+) -> dict[str, Any]:
+    """Get pod logs from an experiment trial.
+
+    Uses ``OptimizerClient.get_job_logs()``. If no trial is specified, the SDK
+    returns logs from the current best trial.
+
+    Args:
+        name: Experiment name.
+        trial: Optional trial name. If omitted, uses the best trial.
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+
+    Returns:
+        dict: Response containing ``logs``, ``trial`` name, and ``failure_hint``.
+
+    Raises:
+        ToolError: If experiment not found (``RESOURCE_NOT_FOUND``).
+    """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+    if trial is not None:
+        trial_err = validate_k8s_name(trial, "trial")
+        if trial_err is not None:
+            return trial_err.model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    try:
+        client = get_optimizer_client_for_namespace(namespace)
+        log_lines = list(client.get_job_logs(name=name, trial_name=trial, follow=False))
+        if len(log_lines) > MAX_LOG_LINES:
+            log_lines = log_lines[-MAX_LOG_LINES:]
+
+        logs = "\n".join(log_lines)
+        sanitized = truncate_log_output(logs)
+
+        data: dict[str, Any] = {
+            "experiment": name,
+            "trial": trial,
+            "logs": sanitized,
+            "lines": len(sanitized.split("\n")) if sanitized else 0,
+        }
+
+        hint = extract_failure_hint(logs)
+        if hint:
+            data["failure_hint"] = hint
+            data["next_steps"] = [
+                f"Detected {hint['category']}: {hint['suggestion']}",
+                f"Check get_experiment_events('{name}') for K8s-level issues",
+            ]
+
+        return ToolResponse(data=data).model_dump()
+
+    except Exception as e:
+        return experiment_error(e, name).model_dump()
+
+
+def get_experiment_events(
+    name: str,
+    namespace: str | None = None,
+    limit: int = DEFAULT_LIST_LIMIT,
+) -> dict[str, Any]:
+    """Get K8s events for a Katib experiment.
+
+    Uses ``OptimizerClient.get_job_events()``.
+
+    Args:
+        name: Experiment name.
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+        limit: Maximum events to return. Defaults to 50, capped at 500.
+
+    Returns:
+        dict: Response containing ``events`` (up to ``limit``) with type,
+        reason, message and timestamp, plus the ``total`` found.
+    """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    limit, limit_err = clamp_limit(limit)
+    if limit_err is not None:
+        return limit_err.model_dump()
+
+    try:
+        client = get_optimizer_client_for_namespace(namespace)
+        events = client.get_job_events(name=name)
+
+        event_list = [event_to_dict(e) for e in events[:limit]]
+        return ToolResponse(
+            data={"experiment": name, "events": event_list, "total": len(events)}
+        ).model_dump()
+
+    except Exception as e:
+        return experiment_error(e, name).model_dump()

--- a/kubeflow_mcp/optimizer/api/monitoring.py
+++ b/kubeflow_mcp/optimizer/api/monitoring.py
@@ -28,7 +28,7 @@ from typing import Any
 
 from kubeflow_mcp.common.constants import ErrorCode
 from kubeflow_mcp.common.failures import extract_failure_hint
-from kubeflow_mcp.common.types import ToolError, ToolResponse, exception_details, is_k8s_not_found
+from kubeflow_mcp.common.types import ToolError, ToolResponse
 from kubeflow_mcp.common.utils import (
     K8S_TIMEOUT,
     get_custom_objects_api,
@@ -44,6 +44,8 @@ from kubeflow_mcp.optimizer.api._common import (
     check_optimizer_namespace,
     clamp_limit,
     experiment_error,
+    resolve_status_filter,
+    resource_error,
 )
 from kubeflow_mcp.optimizer.constants import (
     KATIB_API_GROUP,
@@ -55,7 +57,7 @@ from kubeflow_mcp.optimizer.constants import (
 from kubeflow_mcp.optimizer.types import (
     event_to_dict,
     result_to_dict,
-    trial_counts,
+    trial_counts_from_job,
     trial_to_dict,
 )
 
@@ -104,14 +106,15 @@ def get_experiment_trials(
 
         trials = [trial_to_dict(t) for t in (getattr(job, "trials", None) or [])]
         if status:
-            trials = [t for t in trials if t.get("status") == status]
+            want = resolve_status_filter(status)
+            trials = [t for t in trials if t.get("status") == want]
 
         data: dict[str, Any] = {
             "experiment": name,
             "trials": trials[:limit],
             "total": len(trials),
         }
-        data["summary"] = trial_counts(job)
+        data["summary"] = trial_counts_from_job(job)
         return ToolResponse(data=data).model_dump()
 
     except Exception as e:
@@ -225,17 +228,7 @@ def get_suggestion(
         return ToolResponse(data=data).model_dump()
 
     except Exception as e:
-        if is_k8s_not_found(e):
-            return ToolError(
-                error=f"Suggestion '{name}' not found",
-                error_code=ErrorCode.RESOURCE_NOT_FOUND,
-                hint="A Suggestion is created once an experiment starts running.",
-            ).model_dump()
-        return ToolError(
-            error=str(e),
-            error_code=ErrorCode.SDK_ERROR,
-            details=exception_details(e),
-        ).model_dump()
+        return resource_error(e, name, kind="Suggestion").model_dump()
 
 
 def wait_for_experiment(
@@ -291,7 +284,7 @@ def wait_for_experiment(
             "reached": True,
             "message": f"Experiment reached '{final_status}'",
         }
-        data.update(trial_counts(job))
+        data.update(trial_counts_from_job(job))
         return ToolResponse(data=data).model_dump()
 
     except TimeoutError:

--- a/kubeflow_mcp/optimizer/api/monitoring.py
+++ b/kubeflow_mcp/optimizer/api/monitoring.py
@@ -264,9 +264,15 @@ def wait_for_experiment(
             error=f"timeout_seconds must be >= 1, got {timeout_seconds}",
             error_code=ErrorCode.VALIDATION_ERROR,
         ).model_dump()
+    # Rejected rather than clamped upward, matching wait_for_training: silently
+    # polling slower than asked looks like the tool ignoring its own arguments.
+    if polling_interval < MIN_POLLING_INTERVAL:
+        return ToolError(
+            error=f"polling_interval must be >= {MIN_POLLING_INTERVAL}, got {polling_interval}",
+            error_code=ErrorCode.VALIDATION_ERROR,
+        ).model_dump()
 
     timeout_seconds = min(timeout_seconds, MAX_WAIT_TIMEOUT)
-    polling_interval = max(polling_interval, MIN_POLLING_INTERVAL)
 
     try:
         client = get_optimizer_client_for_namespace(namespace)

--- a/kubeflow_mcp/optimizer/api/monitoring.py
+++ b/kubeflow_mcp/optimizer/api/monitoring.py
@@ -57,6 +57,7 @@ from kubeflow_mcp.optimizer.constants import (
 from kubeflow_mcp.optimizer.types import (
     event_to_dict,
     result_to_dict,
+    suggestion_to_dict,
     trial_counts_from_job,
     trial_to_dict,
 )
@@ -210,21 +211,10 @@ def get_suggestion(
             _request_timeout=K8S_TIMEOUT,
         )
 
-        spec = obj.get("spec", {})
-        status = obj.get("status", {})
-        algorithm = spec.get("algorithm", {})
-        conditions = status.get("conditions", []) or []
-        data = {
-            "name": name,
-            "namespace": ns,
-            "algorithm": algorithm.get("algorithmName"),
-            "requests": spec.get("requests"),
-            "suggestion_count": status.get("suggestionCount"),
-            "conditions": [
-                {"type": c.get("type"), "status": c.get("status"), "reason": c.get("reason")}
-                for c in conditions
-            ],
-        }
+        # Same serializer as list_suggestions, so both views of a Suggestion
+        # describe it with the same field names. Only the namespace is extra.
+        data = suggestion_to_dict(obj)
+        data["namespace"] = ns
         return ToolResponse(data=data).model_dump()
 
     except Exception as e:

--- a/kubeflow_mcp/optimizer/api/monitoring_test.py
+++ b/kubeflow_mcp/optimizer/api/monitoring_test.py
@@ -261,3 +261,32 @@ def test_get_experiment_events_not_found():
     with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
         result = monitoring.get_experiment_events("missing")
     assert result["error_code"] == "RESOURCE_NOT_FOUND"
+
+
+def test_get_experiment_trials_accepts_the_succeeded_alias():
+    """Katib's CRD vocabulary says "Succeeded"; the SDK reports "Complete".
+    Both must select the same trials, as they do for list_experiments."""
+    client = MagicMock()
+    client.get_job.return_value = _job(trials=[_trial("t1", "Complete"), _trial("t2", "Failed")])
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        aliased = monitoring.get_experiment_trials("exp-1", status="Succeeded")
+        native = monitoring.get_experiment_trials("exp-1", status="Complete")
+
+    assert aliased["data"]["total"] == 1
+    assert aliased["data"]["trials"][0]["name"] == "t1"
+    assert aliased["data"]["trials"] == native["data"]["trials"]
+
+
+def test_get_suggestion_not_found_names_the_right_kind():
+    """It must not report a missing Suggestion as a missing Experiment."""
+    api = MagicMock()
+    api.get_namespaced_custom_object.side_effect = _not_found()
+    with (
+        patch(f"{_MON}.get_custom_objects_api", return_value=api),
+        patch(f"{_MON}.get_optimizer_effective_namespace", return_value="kubeflow"),
+    ):
+        result = monitoring.get_suggestion("exp-1")
+
+    assert result["error_code"] == "RESOURCE_NOT_FOUND"
+    assert "Suggestion 'exp-1' not found" in result["error"]
+    assert "experiment starts running" in result["hint"]

--- a/kubeflow_mcp/optimizer/api/monitoring_test.py
+++ b/kubeflow_mcp/optimizer/api/monitoring_test.py
@@ -1,0 +1,263 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for optimizer monitoring tools (mocked OptimizerClient)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from kubernetes.client.exceptions import ApiException
+
+from kubeflow_mcp.optimizer.api import monitoring
+
+_MON = "kubeflow_mcp.optimizer.api.monitoring"
+
+
+def _metric(name="accuracy", latest="0.95"):
+    return SimpleNamespace(name=name, min="0.5", max=latest, latest=latest)
+
+
+def _trial(name, status="Complete"):
+    return SimpleNamespace(
+        name=name,
+        parameters={"lr": "0.01"},
+        trainjob=SimpleNamespace(name=f"{name}-job", status=status),
+        metrics=[_metric()],
+    )
+
+
+def _job(name="exp-1", status="Running", trials=None):
+    return SimpleNamespace(
+        name=name,
+        status=status,
+        creation_timestamp=None,
+        trials=trials if trials is not None else [],
+        objectives=[],
+        algorithm=SimpleNamespace(random_state=None),
+        search_space={},
+        trial_config=SimpleNamespace(num_trials=10, parallel_trials=2, max_failed_trials=None),
+    )
+
+
+def _not_found():
+    """Build the exception shape the real SDK raises for a missing resource.
+
+    The kubernetes backend wraps a 404 as ``raise RuntimeError(...) from
+    ApiException(404)`` — is_k8s_not_found must detect it via ``__cause__``.
+    """
+    cause = ApiException(status=404, reason="Not Found")
+    err = RuntimeError("Failed to get OptimizationJob: default/missing")
+    err.__cause__ = cause
+    return err
+
+
+# ─── get_experiment_trials ─────────────────────────────────────────────────
+
+
+def test_get_experiment_trials_happy_path():
+    client = MagicMock()
+    client.get_job.return_value = _job(trials=[_trial("t1"), _trial("t2", "Failed")])
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.get_experiment_trials("exp-1")
+    assert result["success"] is True
+    assert result["data"]["total"] == 2
+    assert result["data"]["summary"]["failed_trials"] == 1
+
+
+def test_get_experiment_trials_status_filter():
+    client = MagicMock()
+    client.get_job.return_value = _job(trials=[_trial("t1", "Complete"), _trial("t2", "Failed")])
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.get_experiment_trials("exp-1", status="Failed")
+    assert result["data"]["total"] == 1
+    assert result["data"]["trials"][0]["name"] == "t2"
+
+
+def test_get_experiment_trials_not_found():
+    client = MagicMock()
+    client.get_job.side_effect = _not_found()
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.get_experiment_trials("missing")
+    assert result["error_code"] == "RESOURCE_NOT_FOUND"
+
+
+# ─── get_best_trial ────────────────────────────────────────────────────────
+
+
+def test_get_best_trial_happy_path():
+    client = MagicMock()
+    client.get_best_results.return_value = SimpleNamespace(
+        parameters={"lr": "0.01"}, metrics=[_metric()]
+    )
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.get_best_trial("exp-1")
+    assert result["success"] is True
+    assert result["data"]["parameters"] == {"lr": "0.01"}
+    assert result["data"]["metrics"][0]["name"] == "accuracy"
+
+
+def test_get_best_trial_no_result():
+    client = MagicMock()
+    client.get_best_results.return_value = None
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.get_best_trial("exp-1")
+    assert result["success"] is True
+    assert result["data"]["best_trial"] is None
+
+
+def test_get_best_trial_not_found():
+    client = MagicMock()
+    client.get_best_results.side_effect = _not_found()
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.get_best_trial("missing")
+    assert result["error_code"] == "RESOURCE_NOT_FOUND"
+
+
+# ─── get_suggestion ────────────────────────────────────────────────────────
+
+
+def test_get_suggestion_happy_path():
+    api = MagicMock()
+    api.get_namespaced_custom_object.return_value = {
+        "spec": {"algorithm": {"algorithmName": "random"}, "requests": 3},
+        "status": {
+            "suggestionCount": 3,
+            "conditions": [{"type": "Running", "status": "True", "reason": "Ready"}],
+        },
+    }
+    with (
+        patch(f"{_MON}.get_custom_objects_api", return_value=api),
+        patch(f"{_MON}.get_optimizer_effective_namespace", return_value="default"),
+    ):
+        result = monitoring.get_suggestion("exp-1")
+    assert result["success"] is True
+    assert result["data"]["algorithm"] == "random"
+    assert result["data"]["conditions"][0]["type"] == "Running"
+
+
+def test_get_suggestion_not_found():
+    api = MagicMock()
+    api.get_namespaced_custom_object.side_effect = _not_found()
+    with (
+        patch(f"{_MON}.get_custom_objects_api", return_value=api),
+        patch(f"{_MON}.get_optimizer_effective_namespace", return_value="default"),
+    ):
+        result = monitoring.get_suggestion("missing")
+    assert result["error_code"] == "RESOURCE_NOT_FOUND"
+
+
+# ─── wait_for_experiment ───────────────────────────────────────────────────
+
+
+def test_wait_for_experiment_reaches_terminal():
+    client = MagicMock()
+    client.wait_for_job_status.return_value = _job(status="Complete", trials=[_trial("t1")])
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.wait_for_experiment("exp-1", timeout_seconds=30)
+    assert result["data"]["reached"] is True
+    assert result["data"]["status"] == "Complete"
+    # status set passed to SDK is the terminal set
+    _, kwargs = client.wait_for_job_status.call_args
+    assert kwargs["status"] == {"Complete", "Failed"}
+
+
+def test_wait_for_experiment_caps_timeout_and_interval():
+    client = MagicMock()
+    client.wait_for_job_status.return_value = _job(status="Complete")
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        monitoring.wait_for_experiment("exp-1", timeout_seconds=99999, polling_interval=1)
+    _, kwargs = client.wait_for_job_status.call_args
+    assert kwargs["timeout"] == monitoring.MAX_WAIT_TIMEOUT
+    assert kwargs["polling_interval"] == monitoring.MIN_POLLING_INTERVAL
+
+
+def test_wait_for_experiment_timeout():
+    client = MagicMock()
+    client.wait_for_job_status.side_effect = TimeoutError()
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.wait_for_experiment("exp-1", timeout_seconds=5)
+    assert result["success"] is True
+    assert result["data"]["reached"] is False
+
+
+def test_wait_for_experiment_invalid_timeout():
+    result = monitoring.wait_for_experiment("exp-1", timeout_seconds=0)
+    assert result["error_code"] == "VALIDATION_ERROR"
+
+
+# ─── get_experiment_trial_logs ─────────────────────────────────────────────
+
+
+def test_get_experiment_trial_logs_happy_path():
+    client = MagicMock()
+    client.get_job_logs.return_value = iter(["epoch 1", "epoch 2", "done"])
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.get_experiment_trial_logs("exp-1", trial="t1")
+    assert result["success"] is True
+    assert "epoch 1" in result["data"]["logs"]
+    _, kwargs = client.get_job_logs.call_args
+    assert kwargs["trial_name"] == "t1"
+    assert kwargs["follow"] is False
+
+
+def test_get_experiment_trial_logs_failure_hint():
+    client = MagicMock()
+    client.get_job_logs.return_value = iter(
+        ["Traceback (most recent call last):", "RuntimeError: CUDA out of memory"]
+    )
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.get_experiment_trial_logs("exp-1")
+    assert result["data"]["failure_hint"]["category"] == "OOM"
+
+
+def test_get_experiment_trial_logs_not_found():
+    client = MagicMock()
+    client.get_job_logs.side_effect = _not_found()
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.get_experiment_trial_logs("missing")
+    assert result["error_code"] == "RESOURCE_NOT_FOUND"
+
+
+# ─── get_experiment_events ─────────────────────────────────────────────────
+
+
+def test_get_experiment_events_happy_path():
+    client = MagicMock()
+    client.get_job_events.return_value = [
+        SimpleNamespace(
+            involved_object_kind="Pod",
+            involved_object_name="exp-1-trial-0",
+            reason="Scheduled",
+            message="assigned to node",
+            event_time=None,
+        )
+    ]
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.get_experiment_events("exp-1")
+    assert result["success"] is True
+    assert result["data"]["total"] == 1
+    assert result["data"]["events"][0]["reason"] == "Scheduled"
+
+
+def test_get_experiment_events_invalid_limit():
+    result = monitoring.get_experiment_events("exp-1", limit=0)
+    assert result["error_code"] == "VALIDATION_ERROR"
+
+
+def test_get_experiment_events_not_found():
+    client = MagicMock()
+    client.get_job_events.side_effect = _not_found()
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.get_experiment_events("missing")
+    assert result["error_code"] == "RESOURCE_NOT_FOUND"

--- a/kubeflow_mcp/optimizer/api/monitoring_test.py
+++ b/kubeflow_mcp/optimizer/api/monitoring_test.py
@@ -172,14 +172,27 @@ def test_wait_for_experiment_reaches_terminal():
     assert kwargs["status"] == {"Complete", "Failed"}
 
 
-def test_wait_for_experiment_caps_timeout_and_interval():
+def test_wait_for_experiment_caps_timeout():
     client = MagicMock()
     client.wait_for_job_status.return_value = _job(status="Complete")
     with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
-        monitoring.wait_for_experiment("exp-1", timeout_seconds=99999, polling_interval=1)
+        monitoring.wait_for_experiment("exp-1", timeout_seconds=99999, polling_interval=15)
     _, kwargs = client.wait_for_job_status.call_args
     assert kwargs["timeout"] == monitoring.MAX_WAIT_TIMEOUT
-    assert kwargs["polling_interval"] == monitoring.MIN_POLLING_INTERVAL
+    assert kwargs["polling_interval"] == 15
+
+
+def test_wait_for_experiment_rejects_too_frequent_polling():
+    """Matches wait_for_training: too low is an error, not a silent adjustment.
+
+    Clamping upward would poll slower than the caller asked without saying so.
+    """
+    client = MagicMock()
+    with patch(f"{_MON}.get_optimizer_client_for_namespace", return_value=client):
+        result = monitoring.wait_for_experiment("exp-1", polling_interval=1)
+    assert result["success"] is False
+    assert result["error_code"] == "VALIDATION_ERROR"
+    client.wait_for_job_status.assert_not_called()
 
 
 def test_wait_for_experiment_timeout():

--- a/kubeflow_mcp/optimizer/api/namespace_policy_test.py
+++ b/kubeflow_mcp/optimizer/api/namespace_policy_test.py
@@ -97,37 +97,62 @@ def test_generic_helper_still_defaults_to_trainer():
         assert check_namespace_allowed(None) is None
 
 
+# Minimal valid arguments per tool. Keyed by name so the sweep below can be
+# driven from the module's own TOOLS list rather than a parallel copy of it.
+_TOOL_KWARGS: dict[str, dict] = {
+    "list_experiments": {},
+    "get_experiment": {"name": "exp"},
+    "get_experiment_status": {"name": "exp"},
+    "get_trial": {"name": "exp", "trial": "t1"},
+    "get_successful_trials": {"name": "exp"},
+    "list_suggestions": {},
+    "get_experiment_trials": {"name": "exp"},
+    "get_best_trial": {"name": "exp"},
+    "get_suggestion": {"name": "exp"},
+    "wait_for_experiment": {"name": "exp"},
+    "get_experiment_trial_logs": {"name": "exp"},
+    "get_experiment_events": {"name": "exp"},
+    "delete_experiment": {"name": "exp", "confirmed": True},
+    "update_experiment": {"name": "exp", "action": "suspend"},
+    "create_hpo_experiment": {
+        "name": "exp",
+        "objective_metric": "acc",
+        "search_space": {"lr": {"min": 0.1, "max": 1}},
+        "trial_template": {"kind": "TrainJob"},
+        "confirmed": True,
+    },
+    "create_experiment_from_spec": {
+        "spec": {"metadata": {"name": "exp"}},
+        "confirmed": True,
+    },
+}
+
+# katib_pre_flight inspects cluster-scoped resources and takes no namespace,
+# so it is the one tool with nothing to enforce.
+_NO_NAMESPACE = {"katib_pre_flight"}
+
+
+def test_every_tool_is_covered_by_the_sweep():
+    """Fail when a new tool is added without namespace coverage.
+
+    The sweep below used to be a hand-written list, which silently stayed green
+    as tools were added. This binds it to the module's own TOOLS export so a new
+    tool must either be exercised or explicitly exempted.
+    """
+    from kubeflow_mcp.optimizer import TOOLS
+
+    covered = set(_TOOL_KWARGS) | _NO_NAMESPACE
+    missing = {t.__name__ for t in TOOLS} - covered
+    assert not missing, f"tools missing namespace-policy coverage: {sorted(missing)}"
+
+
 @pytest.mark.parametrize(
     ("tool", "kwargs"),
     [
-        (discovery.list_experiments, {}),
-        (discovery.get_experiment, {"name": "exp"}),
-        (discovery.get_experiment_status, {"name": "exp"}),
-        (discovery.get_trial, {"name": "t1", "experiment": "exp"}),
-        (discovery.get_successful_trials, {"name": "exp"}),
-        (discovery.list_suggestions, {}),
-        (monitoring.get_experiment_trials, {"name": "exp"}),
-        (monitoring.get_best_trial, {"name": "exp"}),
-        (monitoring.get_suggestion, {"name": "exp"}),
-        (monitoring.wait_for_experiment, {"name": "exp"}),
-        (monitoring.get_experiment_trial_logs, {"name": "exp"}),
-        (monitoring.get_experiment_events, {"name": "exp"}),
-        (lifecycle.delete_experiment, {"name": "exp", "confirmed": True}),
-        (lifecycle.update_experiment, {"name": "exp", "action": "suspend"}),
-        (
-            optimization.create_hpo_experiment,
-            {
-                "name": "exp",
-                "objective_metric": "acc",
-                "search_space": {"lr": {"min": 0.1, "max": 1}},
-                "trial_template": {"kind": "TrainJob"},
-                "confirmed": True,
-            },
-        ),
-        (
-            optimization.create_experiment_from_spec,
-            {"spec": {"metadata": {"name": "exp"}}, "confirmed": True},
-        ),
+        pytest.param(tool, _TOOL_KWARGS[tool.__name__], id=tool.__name__)
+        for module in (discovery, monitoring, lifecycle, optimization)
+        for tool in vars(module).values()
+        if callable(tool) and getattr(tool, "__name__", None) in _TOOL_KWARGS
     ],
 )
 def test_every_tool_enforces_the_allowlist(tool, kwargs):

--- a/kubeflow_mcp/optimizer/api/namespace_policy_test.py
+++ b/kubeflow_mcp/optimizer/api/namespace_policy_test.py
@@ -1,0 +1,160 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Namespace-allowlist enforcement for optimizer tools.
+
+Regression guard: the policy check must resolve an omitted namespace through the
+*optimizer* client. Resolving it through the trainer client validates a
+different namespace than the one the operation targets, which both let the
+allowlist be bypassed and broke optimizer-only deployments.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kubeflow_mcp.core.security import check_namespace_allowed
+from kubeflow_mcp.optimizer.api import discovery, lifecycle, monitoring, optimization
+from kubeflow_mcp.optimizer.api._common import check_optimizer_namespace
+
+_POLICY = "kubeflow_mcp.core.policy.get_allowed_namespaces"
+_TRAINER_NS = "kubeflow_mcp.common.utils.get_trainer_effective_namespace"
+_OPTIMIZER_NS = "kubeflow_mcp.common.utils.get_optimizer_effective_namespace"
+
+
+def test_bypass_is_closed_when_clients_disagree():
+    """Trainer default is allowed, optimizer default is not — must deny."""
+    with (
+        patch(_POLICY, return_value=["team-a"]),
+        patch(_TRAINER_NS, return_value="team-a"),
+        patch(_OPTIMIZER_NS, return_value="team-b"),
+    ):
+        err = check_optimizer_namespace(None)
+    assert err is not None
+    assert err.error_code == "PERMISSION_DENIED"
+    assert "team-b" in err.error
+
+
+def test_allows_when_optimizer_default_is_permitted():
+    with (
+        patch(_POLICY, return_value=["team-a"]),
+        patch(_TRAINER_NS, return_value="team-b"),
+        patch(_OPTIMIZER_NS, return_value="team-a"),
+    ):
+        assert check_optimizer_namespace(None) is None
+
+
+def test_works_without_a_trainer_client():
+    """Optimizer-only servers must not be denied just because TrainerClient
+    cannot be constructed."""
+    with (
+        patch(_POLICY, return_value=["team-a"]),
+        patch(_TRAINER_NS, side_effect=RuntimeError("trainer not available")),
+        patch(_OPTIMIZER_NS, return_value="team-a"),
+    ):
+        assert check_optimizer_namespace(None) is None
+
+
+def test_fails_closed_when_namespace_cannot_be_resolved():
+    with (
+        patch(_POLICY, return_value=["team-a"]),
+        patch(_OPTIMIZER_NS, side_effect=RuntimeError("no cluster")),
+    ):
+        err = check_optimizer_namespace(None)
+    assert err is not None
+    assert err.error_code == "PERMISSION_DENIED"
+
+
+def test_explicit_namespace_is_checked_directly():
+    with patch(_POLICY, return_value=["team-a"]):
+        assert check_optimizer_namespace("team-a") is None
+        assert check_optimizer_namespace("team-b").error_code == "PERMISSION_DENIED"
+
+
+def test_no_allowlist_permits_everything():
+    with patch(_POLICY, return_value=None):
+        assert check_optimizer_namespace(None) is None
+        assert check_optimizer_namespace("anything") is None
+
+
+def test_generic_helper_still_defaults_to_trainer():
+    """Trainer callers must keep their existing behaviour."""
+    with (
+        patch(_POLICY, return_value=["team-a"]),
+        patch(_TRAINER_NS, return_value="team-a"),
+    ):
+        assert check_namespace_allowed(None) is None
+
+
+@pytest.mark.parametrize(
+    ("tool", "kwargs"),
+    [
+        (discovery.list_experiments, {}),
+        (discovery.get_experiment, {"name": "exp"}),
+        (discovery.get_experiment_status, {"name": "exp"}),
+        (discovery.get_trial, {"name": "t1", "experiment": "exp"}),
+        (discovery.get_successful_trials, {"name": "exp"}),
+        (discovery.list_suggestions, {}),
+        (monitoring.get_experiment_trials, {"name": "exp"}),
+        (monitoring.get_best_trial, {"name": "exp"}),
+        (monitoring.get_suggestion, {"name": "exp"}),
+        (monitoring.wait_for_experiment, {"name": "exp"}),
+        (monitoring.get_experiment_trial_logs, {"name": "exp"}),
+        (monitoring.get_experiment_events, {"name": "exp"}),
+        (lifecycle.delete_experiment, {"name": "exp", "confirmed": True}),
+        (lifecycle.update_experiment, {"name": "exp", "action": "suspend"}),
+        (
+            optimization.create_hpo_experiment,
+            {
+                "name": "exp",
+                "objective_metric": "acc",
+                "search_space": {"lr": {"min": 0.1, "max": 1}},
+                "trial_template": {"kind": "TrainJob"},
+                "confirmed": True,
+            },
+        ),
+        (
+            optimization.create_experiment_from_spec,
+            {"spec": {"metadata": {"name": "exp"}}, "confirmed": True},
+        ),
+    ],
+)
+def test_every_tool_enforces_the_allowlist(tool, kwargs):
+    """No optimizer tool may reach the cluster when the resolved namespace is
+    outside the allowlist."""
+    client = MagicMock()
+    api = MagicMock()
+    with (
+        patch(_POLICY, return_value=["team-a"]),
+        patch(_TRAINER_NS, return_value="team-a"),  # would pass the old check
+        patch(_OPTIMIZER_NS, return_value="team-b"),  # but this is the real target
+        patch("kubeflow_mcp.common.utils.get_optimizer_client_for_namespace", return_value=client),
+        patch("kubeflow_mcp.common.utils.get_custom_objects_api", return_value=api),
+        patch(
+            "kubeflow_mcp.optimizer.api.discovery.get_optimizer_client_for_namespace",
+            return_value=client,
+        ),
+        patch("kubeflow_mcp.optimizer.api.discovery.get_custom_objects_api", return_value=api),
+        patch(
+            "kubeflow_mcp.optimizer.api.monitoring.get_optimizer_client_for_namespace",
+            return_value=client,
+        ),
+        patch("kubeflow_mcp.optimizer.api.monitoring.get_custom_objects_api", return_value=api),
+    ):
+        result = tool(**kwargs)
+
+    assert result["success"] is False, f"{tool.__name__} did not deny"
+    assert result["error_code"] == "PERMISSION_DENIED", f"{tool.__name__} wrong error"
+    client.assert_not_called()
+    api.assert_not_called()

--- a/kubeflow_mcp/optimizer/api/optimization.py
+++ b/kubeflow_mcp/optimizer/api/optimization.py
@@ -76,10 +76,13 @@ def _build_parameter(name: str, spec: dict[str, Any]) -> models.V1beta1Parameter
     names, string coercion of numbers) stays identical to the SDK's own output.
 
     Raises:
-        ValueError: The entry is malformed; the message is surfaced to the caller.
+        TypeError: The entry is not an object.
+        ValueError: The entry is an object but malformed.
+
+    Either message is surfaced to the caller as a validation error.
     """
     if not isinstance(spec, dict):
-        raise ValueError(f"search_space['{name}'] must be an object, got {type(spec).__name__}")
+        raise TypeError(f"search_space['{name}'] must be an object, got {type(spec).__name__}")
 
     if "choices" in spec:
         choices = spec["choices"]
@@ -237,42 +240,32 @@ def create_hpo_experiment(
     if ns_err is not None:
         return ns_err.model_dump()
 
-    if objective_type not in OBJECTIVE_TYPES:
-        return ToolError(
-            error=f"objective_type must be one of {sorted(OBJECTIVE_TYPES)}, got '{objective_type}'",
-            error_code=ErrorCode.VALIDATION_ERROR,
-        ).model_dump()
-    if algorithm not in ALGORITHMS:
-        return ToolError(
-            error=f"algorithm must be one of {sorted(ALGORITHMS)}, got '{algorithm}'",
-            error_code=ErrorCode.VALIDATION_ERROR,
-        ).model_dump()
-    if not search_space:
-        return ToolError(
-            error="search_space must define at least one parameter",
-            error_code=ErrorCode.VALIDATION_ERROR,
-        ).model_dump()
-    if not trial_template:
-        return ToolError(
-            error="trial_template must define the workload to run per trial",
-            error_code=ErrorCode.VALIDATION_ERROR,
-        ).model_dump()
-    if not 1 <= max_trial_count <= MAX_TRIAL_COUNT_LIMIT:
-        return ToolError(
-            error=(
-                f"max_trial_count must be between 1 and {MAX_TRIAL_COUNT_LIMIT}, "
-                f"got {max_trial_count}"
-            ),
-            error_code=ErrorCode.VALIDATION_ERROR,
-        ).model_dump()
-    if not 1 <= parallel_trial_count <= MAX_PARALLEL_TRIAL_LIMIT:
-        return ToolError(
-            error=(
-                f"parallel_trial_count must be between 1 and {MAX_PARALLEL_TRIAL_LIMIT}, "
-                f"got {parallel_trial_count}"
-            ),
-            error_code=ErrorCode.VALIDATION_ERROR,
-        ).model_dump()
+    # (is_invalid, message) pairs, evaluated in order; the first failure wins.
+    # Kept as a table so adding a rule does not add another return path.
+    problems: list[tuple[bool, str]] = [
+        (
+            objective_type not in OBJECTIVE_TYPES,
+            f"objective_type must be one of {sorted(OBJECTIVE_TYPES)}, got '{objective_type}'",
+        ),
+        (
+            algorithm not in ALGORITHMS,
+            f"algorithm must be one of {sorted(ALGORITHMS)}, got '{algorithm}'",
+        ),
+        (not search_space, "search_space must define at least one parameter"),
+        (not trial_template, "trial_template must define the workload to run per trial"),
+        (
+            not 1 <= max_trial_count <= MAX_TRIAL_COUNT_LIMIT,
+            f"max_trial_count must be between 1 and {MAX_TRIAL_COUNT_LIMIT}, got {max_trial_count}",
+        ),
+        (
+            not 1 <= parallel_trial_count <= MAX_PARALLEL_TRIAL_LIMIT,
+            f"parallel_trial_count must be between 1 and {MAX_PARALLEL_TRIAL_LIMIT}, "
+            f"got {parallel_trial_count}",
+        ),
+    ]
+    for is_invalid, message in problems:
+        if is_invalid:
+            return ToolError(error=message, error_code=ErrorCode.VALIDATION_ERROR).model_dump()
 
     try:
         ns = mcp_utils.get_optimizer_effective_namespace(namespace)
@@ -288,7 +281,7 @@ def create_hpo_experiment(
             parallel_trial_count=parallel_trial_count,
             max_failed_trials=max_failed_trials,
         ).to_dict()
-    except ValueError as e:
+    except (TypeError, ValueError) as e:
         return ToolError(error=str(e), error_code=ErrorCode.VALIDATION_ERROR).model_dump()
 
     if not confirmed:

--- a/kubeflow_mcp/optimizer/api/optimization.py
+++ b/kubeflow_mcp/optimizer/api/optimization.py
@@ -42,6 +42,7 @@ from kubeflow_mcp.optimizer.api._common import check_optimizer_namespace, experi
 from kubeflow_mcp.optimizer.constants import (
     EXPERIMENT_KIND,
     EXPERIMENT_PLURAL,
+    INT_PARAMETER,
     KATIB_API_GROUP,
     KATIB_API_VERSION,
 )
@@ -101,14 +102,81 @@ def _build_parameter(name: str, spec: dict[str, Any]) -> models.V1beta1Parameter
             param = Search.uniform(spec["min"], spec["max"])
         elif distribution == "loguniform":
             param = Search.loguniform(spec["min"], spec["max"])
+        elif distribution == "int":
+            param = _build_int_parameter(name, spec)
         else:
             raise ValueError(
-                f"search_space['{name}'].type must be 'uniform' or 'loguniform', "
+                f"search_space['{name}'].type must be 'uniform', 'loguniform' or 'int', "
                 f"got '{distribution}'"
             )
 
     param.name = name
     return param
+
+
+def _build_int_parameter(name: str, spec: dict[str, Any]) -> models.V1beta1ParameterSpec:
+    """Build an integer parameter, which the SDK's ``Search`` cannot express.
+
+    ``Search`` only emits ``double`` and ``categorical``, so an ordered discrete
+    range could otherwise only be written as ``choices``, which every algorithm
+    then treats as unordered categories. Reuses ``Search.uniform`` for the
+    feasible-space encoding and retypes it, so the string coercion still matches
+    the SDK's own output exactly.
+    """
+    for bound in ("min", "max"):
+        value = spec[bound]
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(
+                f"search_space['{name}'].{bound} must be an integer when type is "
+                f"'int', got {value!r}"
+            )
+
+    param = Search.uniform(spec["min"], spec["max"])
+    param.parameter_type = INT_PARAMETER
+
+    if "step" in spec:
+        step = spec["step"]
+        if isinstance(step, bool) or not isinstance(step, int) or step < 1:
+            raise ValueError(
+                f"search_space['{name}'].step must be a positive integer, got {step!r}"
+            )
+        param.feasible_space.step = str(step)
+
+    return param
+
+
+def _resolve_primary_container(trial_template: dict[str, Any], override: str | None) -> str:
+    """Name the container Katib should collect metrics from.
+
+    Katib injects its metrics collector into the container named by
+    ``primaryContainerName``; if that name matches nothing in the trial's pod,
+    no metrics are ever collected and the experiment stalls with no error.
+    Defaulting to Trainer's ``node`` is only right for TrainJob templates, so
+    the name is read off the template when it carries an inline pod spec.
+    """
+    if override:
+        return override
+
+    spec = trial_template.get("spec")
+    if not isinstance(spec, dict):
+        return trainer_constants.NODE
+
+    # batch/v1 Job and friends nest the pod under spec.template; a bare Pod
+    # trialSpec carries containers directly.
+    pod_spec = (
+        spec.get("template", {}).get("spec") if isinstance(spec.get("template"), dict) else None
+    )
+    containers = (pod_spec or spec).get("containers")
+    if not isinstance(containers, list):
+        return trainer_constants.NODE
+
+    names = [c["name"] for c in containers if isinstance(c, dict) and c.get("name")]
+    if not names:
+        # TrainJob and other runtime-backed templates have no inline containers;
+        # Trainer names the workload container "node".
+        return trainer_constants.NODE
+    # A sidecar can sort first, so prefer the conventional name when present.
+    return trainer_constants.NODE if trainer_constants.NODE in names else names[0]
 
 
 def _build_experiment(
@@ -123,6 +191,7 @@ def _build_experiment(
     max_trial_count: int,
     parallel_trial_count: int,
     max_failed_trials: int | None,
+    primary_container_name: str | None = None,
 ) -> models.V1beta1Experiment:
     """Assemble the Experiment CR, stamped with the MCP ownership label."""
     return models.V1beta1Experiment(
@@ -145,7 +214,9 @@ def _build_experiment(
             algorithm=models.V1beta1AlgorithmSpec(algorithmName=algorithm),
             trialTemplate=models.V1beta1TrialTemplate(
                 retain=True,
-                primaryContainerName=trainer_constants.NODE,
+                primaryContainerName=_resolve_primary_container(
+                    trial_template, primary_container_name
+                ),
                 trialParameters=[
                     models.V1beta1TrialParameterSpec(name=key, reference=key)
                     for key in search_space
@@ -187,19 +258,25 @@ def create_hpo_experiment(
     max_trial_count: int = 10,
     parallel_trial_count: int = 2,
     max_failed_trials: int | None = None,
+    primary_container_name: str | None = None,
     namespace: str | None = None,
     confirmed: bool = False,
 ) -> dict[str, Any]:
     """Create a hyperparameter optimization experiment from flat parameters.
 
-    ``search_space`` maps each parameter name to a continuous range or a
-    categorical list::
+    ``search_space`` maps each parameter name to a continuous range, an integer
+    range, or a categorical list::
 
         {
             "lr": {"min": 0.001, "max": 0.1, "type": "loguniform"},
             "momentum": {"min": 0.5, "max": 0.99},
+            "num_layers": {"min": 2, "max": 8, "type": "int"},
             "batch_size": {"choices": [16, 32, 64]},
         }
+
+    Prefer ``type: "int"`` over ``choices`` for an ordered discrete range:
+    categorical values carry no ordering, so the algorithm cannot tell that 4
+    lies between 2 and 8.
 
     ``trial_template`` is the Katib ``trialSpec`` — the workload cloned per
     trial. Reference tuned parameters with ``${trialParameters.<name>}``::
@@ -226,6 +303,9 @@ def create_hpo_experiment(
         max_trial_count: Total trials to run. Default 10.
         parallel_trial_count: Trials to run concurrently. Default 2.
         max_failed_trials: Failed trials tolerated before the experiment fails.
+        primary_container_name: Container Katib collects metrics from. Defaults
+            to the container named in ``trial_template``, or Trainer's ``node``
+            when the template carries no inline pod spec (a TrainJob).
         namespace: K8s namespace. Uses default from kubeconfig when omitted.
         confirmed: Set ``True`` to submit. ``False`` returns a preview.
 
@@ -280,6 +360,7 @@ def create_hpo_experiment(
             max_trial_count=max_trial_count,
             parallel_trial_count=parallel_trial_count,
             max_failed_trials=max_failed_trials,
+            primary_container_name=primary_container_name,
         ).to_dict()
     except (TypeError, ValueError) as e:
         return ToolError(error=str(e), error_code=ErrorCode.VALIDATION_ERROR).model_dump()

--- a/kubeflow_mcp/optimizer/api/optimization.py
+++ b/kubeflow_mcp/optimizer/api/optimization.py
@@ -1,0 +1,385 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optimization tools for creating Katib experiments.
+
+Both tools build a ``V1beta1Experiment`` and create it through
+``CustomObjectsApi``.
+
+``OptimizerClient.optimize()`` is deliberately **not** used: it requires
+``TrainJobTemplate.trainer`` to be a ``CustomTrainer`` holding a live Python
+callable (``func``), which cannot cross the MCP/JSON boundary. It also
+generates its own Experiment name and sets no metadata labels, so MCP could
+neither honour a caller-supplied name nor stamp the ownership label that
+``delete_experiment``/``update_experiment`` rely on. Building the CR directly
+avoids all three limits, and additionally reaches Katib algorithms the SDK's
+typed classes cannot express (tpe, cmaes, hyperband, ...).
+"""
+
+import logging
+from typing import Any
+
+from kubeflow.optimizer import Search
+from kubeflow.trainer.constants import constants as trainer_constants
+from kubeflow_katib_api import models
+
+from kubeflow_mcp.common import utils as mcp_utils
+from kubeflow_mcp.common.constants import ErrorCode
+from kubeflow_mcp.common.types import PreviewResponse, ToolError, ToolResponse
+from kubeflow_mcp.core.security import validate_k8s_name
+from kubeflow_mcp.optimizer.api._common import check_optimizer_namespace, experiment_error
+from kubeflow_mcp.optimizer.constants import (
+    EXPERIMENT_KIND,
+    EXPERIMENT_PLURAL,
+    KATIB_API_GROUP,
+    KATIB_API_VERSION,
+)
+
+logger = logging.getLogger(__name__)
+
+# Katib suggestion algorithms. Superset of what the SDK's typed algorithm
+# classes expose (RandomSearch/GridSearch), reachable because we build the CR.
+ALGORITHMS = frozenset(
+    {
+        "random",
+        "grid",
+        "bayesianoptimization",
+        "tpe",
+        "multivariate-tpe",
+        "cmaes",
+        "sobol",
+        "hyperband",
+    }
+)
+OBJECTIVE_TYPES = frozenset({"maximize", "minimize"})
+
+# Guard rails against an agent requesting a runaway experiment.
+MAX_TRIAL_COUNT_LIMIT = 1000
+MAX_PARALLEL_TRIAL_LIMIT = 100
+
+
+def _build_parameter(name: str, spec: dict[str, Any]) -> models.V1beta1ParameterSpec:
+    """Convert one search-space entry into a Katib parameter spec.
+
+    Uses the SDK's ``Search`` helpers so feasible-space encoding (distribution
+    names, string coercion of numbers) stays identical to the SDK's own output.
+
+    Raises:
+        ValueError: The entry is malformed; the message is surfaced to the caller.
+    """
+    if not isinstance(spec, dict):
+        raise ValueError(f"search_space['{name}'] must be an object, got {type(spec).__name__}")
+
+    if "choices" in spec:
+        choices = spec["choices"]
+        if not isinstance(choices, list) or not choices:
+            raise ValueError(f"search_space['{name}'].choices must be a non-empty list")
+        param = Search.choice(choices)
+    else:
+        missing = {"min", "max"} - spec.keys()
+        if missing:
+            raise ValueError(
+                f"search_space['{name}'] needs 'min' and 'max' (or 'choices'); "
+                f"missing {sorted(missing)}"
+            )
+        distribution = spec.get("type", "uniform")
+        if distribution == "uniform":
+            param = Search.uniform(spec["min"], spec["max"])
+        elif distribution == "loguniform":
+            param = Search.loguniform(spec["min"], spec["max"])
+        else:
+            raise ValueError(
+                f"search_space['{name}'].type must be 'uniform' or 'loguniform', "
+                f"got '{distribution}'"
+            )
+
+    param.name = name
+    return param
+
+
+def _build_experiment(
+    *,
+    name: str,
+    namespace: str,
+    objective_metric: str,
+    objective_type: str,
+    search_space: dict[str, Any],
+    trial_template: dict[str, Any],
+    algorithm: str,
+    max_trial_count: int,
+    parallel_trial_count: int,
+    max_failed_trials: int | None,
+) -> models.V1beta1Experiment:
+    """Assemble the Experiment CR, stamped with the MCP ownership label."""
+    return models.V1beta1Experiment(
+        apiVersion=f"{KATIB_API_GROUP}/{KATIB_API_VERSION}",
+        kind=EXPERIMENT_KIND,
+        metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+            name=name,
+            namespace=namespace,
+            labels={mcp_utils.MCP_MANAGED_LABEL: mcp_utils.MCP_MANAGED_VALUE},
+        ),
+        spec=models.V1beta1ExperimentSpec(
+            parameters=[_build_parameter(key, spec) for key, spec in search_space.items()],
+            maxTrialCount=max_trial_count,
+            parallelTrialCount=parallel_trial_count,
+            maxFailedTrialCount=max_failed_trials,
+            objective=models.V1beta1ObjectiveSpec(
+                objectiveMetricName=objective_metric,
+                type=objective_type,
+            ),
+            algorithm=models.V1beta1AlgorithmSpec(algorithmName=algorithm),
+            trialTemplate=models.V1beta1TrialTemplate(
+                retain=True,
+                primaryContainerName=trainer_constants.NODE,
+                trialParameters=[
+                    models.V1beta1TrialParameterSpec(name=key, reference=key)
+                    for key in search_space
+                ],
+                trialSpec=trial_template,
+            ),
+        ),
+    )
+
+
+def _create(experiment: dict[str, Any], namespace: str, name: str) -> dict[str, Any]:
+    """Create the Experiment CR and build the success response."""
+    api = mcp_utils.get_custom_objects_api()
+    api.create_namespaced_custom_object(
+        group=KATIB_API_GROUP,
+        version=KATIB_API_VERSION,
+        namespace=namespace,
+        plural=EXPERIMENT_PLURAL,
+        body=experiment,
+        _request_timeout=mcp_utils.K8S_TIMEOUT,
+    )
+    return ToolResponse(
+        data={
+            "experiment": name,
+            "namespace": namespace,
+            "created": True,
+            "message": f"Experiment '{name}' created in namespace '{namespace}'",
+        }
+    ).model_dump()
+
+
+def create_hpo_experiment(
+    name: str,
+    objective_metric: str,
+    search_space: dict[str, Any],
+    trial_template: dict[str, Any],
+    objective_type: str = "maximize",
+    algorithm: str = "random",
+    max_trial_count: int = 10,
+    parallel_trial_count: int = 2,
+    max_failed_trials: int | None = None,
+    namespace: str | None = None,
+    confirmed: bool = False,
+) -> dict[str, Any]:
+    """Create a hyperparameter optimization experiment from flat parameters.
+
+    ``search_space`` maps each parameter name to a continuous range or a
+    categorical list::
+
+        {
+            "lr": {"min": 0.001, "max": 0.1, "type": "loguniform"},
+            "momentum": {"min": 0.5, "max": 0.99},
+            "batch_size": {"choices": [16, 32, 64]},
+        }
+
+    ``trial_template`` is the Katib ``trialSpec`` — the workload cloned per
+    trial. Reference tuned parameters with ``${trialParameters.<name>}``::
+
+        {
+            "apiVersion": "trainer.kubeflow.org/v1alpha1",
+            "kind": "TrainJob",
+            "spec": {
+                "runtimeRef": {"name": "torch-distributed"},
+                "trainer": {
+                    "image": "my/trainer:latest",
+                    "args": ["--lr=${trialParameters.lr}"],
+                },
+            },
+        }
+
+    Args:
+        name: Experiment name (also the Kubernetes resource name).
+        objective_metric: Metric to optimize (e.g. ``"accuracy"``).
+        search_space: Parameter ranges to explore (see format above).
+        trial_template: Katib ``trialSpec`` for the workload to run per trial.
+        objective_type: ``"maximize"`` or ``"minimize"``. Default ``"maximize"``.
+        algorithm: Suggestion algorithm; one of :data:`ALGORITHMS`.
+        max_trial_count: Total trials to run. Default 10.
+        parallel_trial_count: Trials to run concurrently. Default 2.
+        max_failed_trials: Failed trials tolerated before the experiment fails.
+        namespace: K8s namespace. Uses default from kubeconfig when omitted.
+        confirmed: Set ``True`` to submit. ``False`` returns a preview.
+
+    Returns:
+        dict: Preview of the Experiment CR, or the creation result.
+    """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    if objective_type not in OBJECTIVE_TYPES:
+        return ToolError(
+            error=f"objective_type must be one of {sorted(OBJECTIVE_TYPES)}, got '{objective_type}'",
+            error_code=ErrorCode.VALIDATION_ERROR,
+        ).model_dump()
+    if algorithm not in ALGORITHMS:
+        return ToolError(
+            error=f"algorithm must be one of {sorted(ALGORITHMS)}, got '{algorithm}'",
+            error_code=ErrorCode.VALIDATION_ERROR,
+        ).model_dump()
+    if not search_space:
+        return ToolError(
+            error="search_space must define at least one parameter",
+            error_code=ErrorCode.VALIDATION_ERROR,
+        ).model_dump()
+    if not trial_template:
+        return ToolError(
+            error="trial_template must define the workload to run per trial",
+            error_code=ErrorCode.VALIDATION_ERROR,
+        ).model_dump()
+    if not 1 <= max_trial_count <= MAX_TRIAL_COUNT_LIMIT:
+        return ToolError(
+            error=(
+                f"max_trial_count must be between 1 and {MAX_TRIAL_COUNT_LIMIT}, "
+                f"got {max_trial_count}"
+            ),
+            error_code=ErrorCode.VALIDATION_ERROR,
+        ).model_dump()
+    if not 1 <= parallel_trial_count <= MAX_PARALLEL_TRIAL_LIMIT:
+        return ToolError(
+            error=(
+                f"parallel_trial_count must be between 1 and {MAX_PARALLEL_TRIAL_LIMIT}, "
+                f"got {parallel_trial_count}"
+            ),
+            error_code=ErrorCode.VALIDATION_ERROR,
+        ).model_dump()
+
+    try:
+        ns = mcp_utils.get_optimizer_effective_namespace(namespace)
+        experiment = _build_experiment(
+            name=name,
+            namespace=ns,
+            objective_metric=objective_metric,
+            objective_type=objective_type,
+            search_space=search_space,
+            trial_template=trial_template,
+            algorithm=algorithm,
+            max_trial_count=max_trial_count,
+            parallel_trial_count=parallel_trial_count,
+            max_failed_trials=max_failed_trials,
+        ).to_dict()
+    except ValueError as e:
+        return ToolError(error=str(e), error_code=ErrorCode.VALIDATION_ERROR).model_dump()
+
+    if not confirmed:
+        return PreviewResponse(
+            message=(
+                f"Will create experiment '{name}' in '{ns}': {max_trial_count} trials "
+                f"({parallel_trial_count} in parallel) optimizing '{objective_metric}' "
+                f"via '{algorithm}'. Set confirmed=True to submit."
+            ),
+            config=experiment,
+        ).model_dump()
+
+    try:
+        return _create(experiment, ns, name)
+    except Exception as e:
+        logger.warning("create_hpo_experiment(%s) failed: %s", name, e, exc_info=True)
+        return experiment_error(e, name).model_dump()
+
+
+def create_experiment_from_spec(
+    spec: dict[str, Any],
+    namespace: str | None = None,
+    confirmed: bool = False,
+) -> dict[str, Any]:
+    """Create an experiment from a complete V1beta1Experiment manifest.
+
+    Escape hatch for configurations ``create_hpo_experiment()`` does not model —
+    early stopping, custom metrics collectors, resume policies or NAS. The
+    manifest is validated against the Katib schema before submission and is
+    stamped with the MCP ownership label.
+
+    Args:
+        spec: Full ``V1beta1Experiment`` manifest (``apiVersion``, ``kind``,
+            ``metadata.name``, ``spec``).
+        namespace: K8s namespace. Overrides ``metadata.namespace`` when given.
+        confirmed: Set ``True`` to submit. ``False`` returns a preview.
+
+    Returns:
+        dict: Preview of the Experiment CR, or the creation result.
+    """
+    if not isinstance(spec, dict) or not spec:
+        return ToolError(
+            error="spec must be a non-empty V1beta1Experiment manifest",
+            error_code=ErrorCode.VALIDATION_ERROR,
+        ).model_dump()
+
+    name = (spec.get("metadata") or {}).get("name")
+    if not name:
+        return ToolError(
+            error="spec.metadata.name is required",
+            error_code=ErrorCode.VALIDATION_ERROR,
+        ).model_dump()
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
+    ns_err = check_optimizer_namespace(namespace)
+    if ns_err is not None:
+        return ns_err.model_dump()
+
+    try:
+        experiment = models.V1beta1Experiment.from_dict(spec)
+    except Exception as e:
+        return ToolError(
+            error=f"Invalid V1beta1Experiment spec: {e}",
+            error_code=ErrorCode.VALIDATION_ERROR,
+            hint="Compare against the Katib v1beta1 Experiment schema.",
+        ).model_dump()
+    if experiment is None:
+        return ToolError(
+            error="Invalid V1beta1Experiment spec: parsed to nothing",
+            error_code=ErrorCode.VALIDATION_ERROR,
+        ).model_dump()
+
+    ns = mcp_utils.get_optimizer_effective_namespace(
+        namespace or (spec.get("metadata") or {}).get("namespace")
+    )
+
+    body = experiment.to_dict()
+    metadata = body.setdefault("metadata", {})
+    metadata["namespace"] = ns
+    metadata.setdefault("labels", {})[mcp_utils.MCP_MANAGED_LABEL] = mcp_utils.MCP_MANAGED_VALUE
+
+    if not confirmed:
+        return PreviewResponse(
+            message=f"Will create experiment '{name}' in '{ns}'. Set confirmed=True to submit.",
+            config=body,
+        ).model_dump()
+
+    try:
+        return _create(body, ns, name)
+    except Exception as e:
+        logger.warning("create_experiment_from_spec(%s) failed: %s", name, e, exc_info=True)
+        return experiment_error(e, name).model_dump()

--- a/kubeflow_mcp/optimizer/api/optimization.py
+++ b/kubeflow_mcp/optimizer/api/optimization.py
@@ -236,7 +236,9 @@ def _create(experiment: dict[str, Any], namespace: str, name: str) -> dict[str, 
         namespace=namespace,
         plural=EXPERIMENT_PLURAL,
         body=experiment,
-        _request_timeout=mcp_utils.K8S_TIMEOUT,
+        # Creating an Experiment goes through Katib's admission webhooks, so it
+        # needs the longer write budget rather than the read timeout.
+        _request_timeout=mcp_utils.K8S_WRITE_TIMEOUT,
     )
     return ToolResponse(
         data={

--- a/kubeflow_mcp/optimizer/api/optimization_test.py
+++ b/kubeflow_mcp/optimizer/api/optimization_test.py
@@ -279,6 +279,41 @@ def test_duplicate_name_is_actionable_and_does_not_trip_breaker():
     assert is_infrastructure_error(result) is False
 
 
+def test_create_uses_the_longer_write_timeout():
+    """A create is admitted by two webhooks, each with its own 10s budget.
+
+    Sending the 5s read timeout meant the client gave up before the API server
+    could report the admission failure, turning a diagnosable error into an
+    opaque "read timed out".
+    """
+    from kubeflow_mcp.common import utils as mcp_utils
+
+    with cluster() as api:
+        _create(confirmed=True)
+    timeout = api.create_namespaced_custom_object.call_args.kwargs["_request_timeout"]
+    assert timeout == mcp_utils.K8S_WRITE_TIMEOUT
+    assert timeout > mcp_utils.K8S_TIMEOUT
+
+
+def test_client_side_timeout_is_reported_as_timeout_not_opaque_sdk_error():
+    from urllib3.exceptions import ReadTimeoutError
+
+    from kubeflow_mcp.common.constants import is_infrastructure_error
+
+    api = MagicMock()
+    api.create_namespaced_custom_object.side_effect = ReadTimeoutError(
+        None, "/apis", "Read timed out."
+    )
+    with cluster(api):
+        result = _create(confirmed=True)
+
+    assert result["error_code"] == "TIMEOUT"
+    assert "Timed out waiting for the API server" in result["error"]
+    assert "katib_pre_flight()" in result["hint"]
+    # A timeout is still an infrastructure failure, so the breaker should trip.
+    assert is_infrastructure_error(result) is True
+
+
 def test_unreachable_katib_webhook_gets_an_actionable_hint():
     """Observed on a cluster whose katib-controller was Running but not Ready:
     the raw 500 is a wall of HTTP headers that never says what to do."""

--- a/kubeflow_mcp/optimizer/api/optimization_test.py
+++ b/kubeflow_mcp/optimizer/api/optimization_test.py
@@ -166,6 +166,92 @@ def test_all_advertised_algorithms_are_accepted():
         assert result["config"]["spec"]["algorithm"]["algorithmName"] == algorithm
 
 
+# ─── integer parameters ────────────────────────────────────────────────────
+
+
+def test_int_parameter_is_typed_int_not_double():
+    """Katib supports "int"; the SDK's Search helpers only emit double."""
+    with cluster():
+        params = _create(search_space={"layers": {"min": 2, "max": 8, "type": "int"}})["config"][
+            "spec"
+        ]["parameters"]
+
+    assert params[0]["parameterType"] == "int"
+    # Bounds keep the SDK's own string encoding.
+    assert params[0]["feasibleSpace"]["min"] == "2"
+    assert params[0]["feasibleSpace"]["max"] == "8"
+
+
+def test_int_parameter_accepts_step():
+    with cluster():
+        params = _create(search_space={"layers": {"min": 2, "max": 8, "type": "int", "step": 2}})[
+            "config"
+        ]["spec"]["parameters"]
+    assert params[0]["feasibleSpace"]["step"] == "2"
+
+
+@pytest.mark.parametrize(
+    "space",
+    [
+        {"layers": {"min": 2.5, "max": 8, "type": "int"}},
+        {"layers": {"min": 2, "max": "8", "type": "int"}},
+        {"layers": {"min": 2, "max": 8, "type": "int", "step": 0}},
+        {"layers": {"min": 2, "max": 8, "type": "int", "step": 1.5}},
+    ],
+)
+def test_int_parameter_rejects_non_integers(space):
+    with cluster() as api:
+        result = _create(search_space=space)
+    assert result["success"] is False
+    assert result["error_code"] == "VALIDATION_ERROR"
+    api.create_namespaced_custom_object.assert_not_called()
+
+
+# ─── primaryContainerName resolution ───────────────────────────────────────
+
+JOB_TEMPLATE = {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "spec": {
+        "template": {
+            "spec": {"containers": [{"name": "training-container", "image": "katib/random:1"}]}
+        }
+    },
+}
+
+
+def test_primary_container_follows_a_job_template():
+    """Katib collects metrics from this container; hardcoding Trainer's "node"
+    would silently collect nothing from a plain batch/v1 Job."""
+    with cluster():
+        spec = _create(trial_template=JOB_TEMPLATE)["config"]["spec"]
+    assert spec["trialTemplate"]["primaryContainerName"] == "training-container"
+
+
+def test_primary_container_defaults_to_node_for_a_trainjob():
+    """A TrainJob has no inline pod spec; Trainer names its container "node"."""
+    with cluster():
+        spec = _create()["config"]["spec"]
+    assert spec["trialTemplate"]["primaryContainerName"] == "node"
+
+
+def test_primary_container_prefers_node_over_a_sidecar():
+    template = {
+        "spec": {"template": {"spec": {"containers": [{"name": "istio-proxy"}, {"name": "node"}]}}}
+    }
+    with cluster():
+        spec = _create(trial_template=template)["config"]["spec"]
+    assert spec["trialTemplate"]["primaryContainerName"] == "node"
+
+
+def test_explicit_primary_container_wins():
+    with cluster():
+        spec = _create(trial_template=JOB_TEMPLATE, primary_container_name="sidecar")["config"][
+            "spec"
+        ]
+    assert spec["trialTemplate"]["primaryContainerName"] == "sidecar"
+
+
 def test_create_failure_maps_to_sdk_error():
     api = MagicMock()
     api.create_namespaced_custom_object.side_effect = RuntimeError("boom")
@@ -191,6 +277,37 @@ def test_duplicate_name_is_actionable_and_does_not_trip_breaker():
     assert "already exists" in result["error"]
     assert "delete_experiment" in result["hint"]
     assert is_infrastructure_error(result) is False
+
+
+def test_unreachable_katib_webhook_gets_an_actionable_hint():
+    """Observed on a cluster whose katib-controller was Running but not Ready:
+    the raw 500 is a wall of HTTP headers that never says what to do."""
+    from kubernetes.client.exceptions import ApiException
+
+    from kubeflow_mcp.common.constants import is_infrastructure_error
+
+    api = MagicMock()
+    api.create_namespaced_custom_object.side_effect = ApiException(
+        status=500,
+        reason="Internal Server Error",
+        http_resp=MagicMock(
+            status=500,
+            reason="Internal Server Error",
+            data=(
+                b'{"message":"Internal error occurred: failed calling webhook '
+                b'\\"defaulter.experiment.katib.kubeflow.org\\": no endpoints available '
+                b'for service \\"katib-controller\\""}'
+            ),
+            getheaders=lambda: {},
+        ),
+    )
+    with cluster(api):
+        result = _create(confirmed=True)
+
+    assert result["error_code"] == "SDK_ERROR"
+    assert "katib_pre_flight()" in result["hint"]
+    # A downed control plane is a real outage: the breaker should still trip.
+    assert is_infrastructure_error(result) is True
 
 
 # ─── create_experiment_from_spec ───────────────────────────────────────────

--- a/kubeflow_mcp/optimizer/api/optimization_test.py
+++ b/kubeflow_mcp/optimizer/api/optimization_test.py
@@ -1,0 +1,266 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for optimizer creation tools (CR construction + two-phase confirm)."""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kubeflow_mcp.common.utils import MCP_MANAGED_LABEL, MCP_MANAGED_VALUE
+from kubeflow_mcp.optimizer.api import optimization as opt
+
+_UTILS = "kubeflow_mcp.common.utils"
+
+TRIAL_TEMPLATE = {
+    "apiVersion": "trainer.kubeflow.org/v1alpha1",
+    "kind": "TrainJob",
+    "spec": {
+        "runtimeRef": {"name": "torch-distributed"},
+        "trainer": {"image": "my/trainer:1", "args": ["--lr=${trialParameters.lr}"]},
+    },
+}
+SEARCH_SPACE = {
+    "lr": {"min": 0.001, "max": 0.1, "type": "loguniform"},
+    "batch_size": {"choices": [16, 32, 64]},
+}
+
+
+@contextmanager
+def cluster(api: MagicMock | None = None):
+    """Patch namespace resolution and the CustomObjects API."""
+    api = api or MagicMock()
+    with (
+        patch(f"{_UTILS}.get_optimizer_effective_namespace", return_value="kubeflow"),
+        patch(f"{_UTILS}.get_custom_objects_api", return_value=api),
+    ):
+        yield api
+
+
+def _create(**overrides):
+    args = {
+        "name": "demo-hpo",
+        "objective_metric": "accuracy",
+        "search_space": SEARCH_SPACE,
+        "trial_template": TRIAL_TEMPLATE,
+    }
+    args.update(overrides)
+    return opt.create_hpo_experiment(**args)
+
+
+# ─── create_hpo_experiment: preview / CR construction ──────────────────────
+
+
+def test_preview_does_not_create():
+    with cluster() as api:
+        result = _create()
+    assert result["status"] == "preview"
+    api.create_namespaced_custom_object.assert_not_called()
+
+
+def test_preview_builds_expected_cr():
+    with cluster():
+        spec = _create(algorithm="tpe", max_trial_count=6, parallel_trial_count=3)["config"]["spec"]
+
+    assert spec["algorithm"] == {"algorithmName": "tpe"}
+    assert spec["objective"] == {"objectiveMetricName": "accuracy", "type": "maximize"}
+    assert spec["maxTrialCount"] == 6
+    assert spec["parallelTrialCount"] == 3
+    # Every search-space key must be referenced as a trial parameter.
+    assert [p["name"] for p in spec["trialTemplate"]["trialParameters"]] == ["lr", "batch_size"]
+    assert spec["trialTemplate"]["trialSpec"] == TRIAL_TEMPLATE
+
+
+def test_search_space_encoding_matches_sdk():
+    with cluster():
+        params = _create()["config"]["spec"]["parameters"]
+
+    by_name = {p["name"]: p for p in params}
+    assert by_name["lr"]["parameterType"] == "double"
+    assert by_name["lr"]["feasibleSpace"]["distribution"] == "logUniform"
+    assert by_name["batch_size"]["parameterType"] == "categorical"
+    # Katib requires categorical values as strings.
+    assert by_name["batch_size"]["feasibleSpace"]["list"] == ["16", "32", "64"]
+
+
+def test_uniform_is_the_default_distribution():
+    with cluster():
+        params = _create(search_space={"momentum": {"min": 0.5, "max": 0.99}})["config"]["spec"][
+            "parameters"
+        ]
+    assert params[0]["feasibleSpace"]["distribution"] == "uniform"
+
+
+def test_created_experiment_carries_mcp_ownership_label():
+    with cluster():
+        labels = _create()["config"]["metadata"]["labels"]
+    assert labels[MCP_MANAGED_LABEL] == MCP_MANAGED_VALUE
+
+
+def test_confirmed_creates_experiment():
+    with cluster() as api:
+        result = _create(confirmed=True)
+
+    assert result["success"] is True
+    assert result["data"]["created"] is True
+    kwargs = api.create_namespaced_custom_object.call_args.kwargs
+    assert kwargs["plural"] == "experiments"
+    assert kwargs["namespace"] == "kubeflow"
+    assert kwargs["body"]["metadata"]["name"] == "demo-hpo"
+
+
+def test_caller_supplied_name_is_honoured():
+    """optimize() would generate its own name; building the CR must not."""
+    with cluster():
+        config = _create(name="my-chosen-name")["config"]
+    assert config["metadata"]["name"] == "my-chosen-name"
+
+
+# ─── create_hpo_experiment: validation ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"name": "Invalid_Name!"},
+        {"algorithm": "not-an-algorithm"},
+        {"objective_type": "max"},
+        {"search_space": {}},
+        {"trial_template": {}},
+        {"max_trial_count": 0},
+        {"max_trial_count": opt.MAX_TRIAL_COUNT_LIMIT + 1},
+        {"parallel_trial_count": 0},
+        {"parallel_trial_count": opt.MAX_PARALLEL_TRIAL_LIMIT + 1},
+        {"search_space": {"lr": {"min": 0.1}}},
+        {"search_space": {"lr": {"choices": []}}},
+        {"search_space": {"lr": {"min": 0, "max": 1, "type": "normal"}}},
+        {"search_space": {"lr": "not-a-dict"}},
+    ],
+)
+def test_invalid_input_is_rejected(overrides):
+    with cluster() as api:
+        result = _create(**overrides)
+    assert result["success"] is False
+    assert result["error_code"] == "VALIDATION_ERROR"
+    api.create_namespaced_custom_object.assert_not_called()
+
+
+def test_all_advertised_algorithms_are_accepted():
+    """Descriptions promise these algorithms; each must build a valid CR."""
+    for algorithm in opt.ALGORITHMS:
+        with cluster():
+            result = _create(algorithm=algorithm)
+        assert result["status"] == "preview", algorithm
+        assert result["config"]["spec"]["algorithm"]["algorithmName"] == algorithm
+
+
+def test_create_failure_maps_to_sdk_error():
+    api = MagicMock()
+    api.create_namespaced_custom_object.side_effect = RuntimeError("boom")
+    with cluster(api):
+        result = _create(confirmed=True)
+    assert result["success"] is False
+    assert result["error_code"] == "SDK_ERROR"
+
+
+def test_duplicate_name_is_actionable_and_does_not_trip_breaker():
+    """A 409 is caller-fixable: it must not be reported as an infrastructure
+    failure, or the circuit breaker opens on a simple name collision."""
+    from kubernetes.client.exceptions import ApiException
+
+    from kubeflow_mcp.common.constants import is_infrastructure_error
+
+    api = MagicMock()
+    api.create_namespaced_custom_object.side_effect = ApiException(status=409, reason="Conflict")
+    with cluster(api):
+        result = _create(confirmed=True)
+
+    assert result["error_code"] == "VALIDATION_ERROR"
+    assert "already exists" in result["error"]
+    assert "delete_experiment" in result["hint"]
+    assert is_infrastructure_error(result) is False
+
+
+# ─── create_experiment_from_spec ───────────────────────────────────────────
+
+
+def _manifest(**meta):
+    return {
+        "apiVersion": "kubeflow.org/v1beta1",
+        "kind": "Experiment",
+        "metadata": {"name": "from-spec", **meta},
+        "spec": {
+            "objective": {"objectiveMetricName": "loss", "type": "minimize"},
+            "algorithm": {"algorithmName": "cmaes"},
+            "parameters": [
+                {
+                    "name": "lr",
+                    "parameterType": "double",
+                    "feasibleSpace": {"min": "0.01", "max": "0.1"},
+                }
+            ],
+            "trialTemplate": {"trialSpec": TRIAL_TEMPLATE},
+        },
+    }
+
+
+def test_from_spec_preview_stamps_label_and_namespace():
+    with cluster() as api:
+        result = opt.create_experiment_from_spec(spec=_manifest())
+    assert result["status"] == "preview"
+    metadata = result["config"]["metadata"]
+    assert metadata["namespace"] == "kubeflow"
+    assert metadata["labels"][MCP_MANAGED_LABEL] == MCP_MANAGED_VALUE
+    api.create_namespaced_custom_object.assert_not_called()
+
+
+def test_from_spec_preserves_advanced_config():
+    """The escape hatch must not strip fields create_hpo_experiment cannot model."""
+    manifest = _manifest()
+    manifest["spec"]["earlyStopping"] = {"algorithmName": "medianstop"}
+    with cluster():
+        result = opt.create_experiment_from_spec(spec=manifest)
+    assert result["config"]["spec"]["earlyStopping"] == {"algorithmName": "medianstop"}
+
+
+def test_from_spec_confirmed_creates():
+    with cluster() as api:
+        result = opt.create_experiment_from_spec(spec=_manifest(), confirmed=True)
+    assert result["success"] is True
+    assert api.create_namespaced_custom_object.call_args.kwargs["plural"] == "experiments"
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {},
+        {"metadata": {}},
+        {"metadata": {"name": "Bad_Name!"}},
+    ],
+)
+def test_from_spec_rejects_malformed_input(spec):
+    with cluster():
+        result = opt.create_experiment_from_spec(spec=spec)
+    assert result["success"] is False
+    assert result["error_code"] == "VALIDATION_ERROR"
+
+
+def test_from_spec_explicit_namespace_wins():
+    with cluster():
+        with patch(f"{_UTILS}.get_optimizer_effective_namespace", side_effect=lambda ns: ns or "d"):
+            result = opt.create_experiment_from_spec(
+                spec=_manifest(namespace="in-spec"), namespace="explicit"
+            )
+    assert result["config"]["metadata"]["namespace"] == "explicit"

--- a/kubeflow_mcp/optimizer/api/planning.py
+++ b/kubeflow_mcp/optimizer/api/planning.py
@@ -29,13 +29,22 @@ from kubeflow_mcp.common.types import (
     exception_details,
     is_k8s_not_found,
 )
+from kubeflow_mcp.optimizer.api._common import api_message
 from kubeflow_mcp.optimizer.constants import (
     EXPERIMENT_CRD_NAME,
+    EXPERIMENT_KIND,
+    EXPERIMENT_PLURAL,
+    KATIB_API_GROUP,
+    KATIB_API_VERSION,
     KATIB_CONTROLLER_LABELS,
     KATIB_CONTROLLER_NAMESPACE_DEFAULT,
 )
 
 logger = logging.getLogger(__name__)
+
+# Name for the dry-run probe in _check_webhook. Never persisted, but a distinct
+# name keeps it obvious in an audit log that this was a readiness check.
+_PROBE_NAME = "katib-pre-flight-probe"
 
 
 class CheckResult(NamedTuple):
@@ -164,6 +173,75 @@ def _check_controller() -> CheckResult:
     return CheckResult(info=info)
 
 
+def _check_webhook() -> CheckResult:
+    """Confirm the API server can actually reach Katib's admission webhooks.
+
+    A Ready controller is not sufficient. Katib registers its webhooks with
+    ``failurePolicy: Fail``, so if the API server cannot reach the controller
+    pod every create is rejected even though the CRD is installed and the pod is
+    healthy. That combination reports a green pre-flight while no experiment can
+    be created, which is the failure this check exists to catch.
+
+    Uses a server-side dry run: admission runs in full, nothing is persisted.
+    """
+    minimal = {
+        "apiVersion": f"{KATIB_API_GROUP}/{KATIB_API_VERSION}",
+        "kind": EXPERIMENT_KIND,
+        "metadata": {"name": _PROBE_NAME},
+        "spec": {
+            "objective": {"type": "maximize", "objectiveMetricName": "probe"},
+            "algorithm": {"algorithmName": "random"},
+            "maxTrialCount": 1,
+            "parallelTrialCount": 1,
+            "parameters": [
+                {
+                    "name": "probe",
+                    "parameterType": "double",
+                    "feasibleSpace": {"min": "0.1", "max": "0.2"},
+                }
+            ],
+            "trialTemplate": {"primaryContainerName": "probe", "trialSpec": {}},
+        },
+    }
+
+    try:
+        namespace = mcp_utils.get_optimizer_effective_namespace(None)
+        mcp_utils.get_custom_objects_api().create_namespaced_custom_object(
+            group=KATIB_API_GROUP,
+            version=KATIB_API_VERSION,
+            namespace=namespace,
+            plural=EXPERIMENT_PLURAL,
+            body=minimal,
+            dry_run="All",
+            _request_timeout=mcp_utils.K8S_WRITE_TIMEOUT,
+        )
+    except Exception as e:
+        status = getattr(e, "status", None)
+        # The probe spec is deliberately minimal, so the validating webhook may
+        # reject it on content. That still proves the webhook was reached, which
+        # is all this check is asking.
+        if status in (400, 422):
+            return CheckResult(info={"webhook_reachable": True})
+        if status == 403:
+            return CheckResult(
+                info={"webhook_reachable": None},
+                warnings=(
+                    "Cannot verify Katib admission webhooks: no permission to dry-run "
+                    "an Experiment create. Creation may still fail at runtime.",
+                ),
+            )
+        return CheckResult(
+            info={"webhook_reachable": False},
+            blockers=(
+                "Katib's admission webhooks are not reachable by the API server, so no "
+                f"experiment can be created: {api_message(e)} A Ready controller pod is "
+                "not sufficient; check that the API server can reach the katib-controller "
+                "Service on its webhook port.",
+            ),
+        )
+    return CheckResult(info={"webhook_reachable": True})
+
+
 def _check_trainer() -> CheckResult:
     """Report whether the trainer client is usable for cross-client workflows.
 
@@ -190,7 +268,9 @@ def katib_pre_flight() -> dict[str, Any]:
 
     1. The Experiment CRD is registered on the cluster
     2. The Katib controller pod is Running **and** passing readiness
-    3. Whether the trainer client is loaded, for cross-client workflows
+    3. The API server can actually reach Katib's admission webhooks, without
+       which every create is rejected however healthy the controller looks
+    4. Whether the trainer client is loaded, for cross-client workflows
 
     Call this FIRST before any optimizer operations. It never raises for an
     unhealthy cluster; problems are reported in ``blockers``.
@@ -198,14 +278,14 @@ def katib_pre_flight() -> dict[str, Any]:
     Returns:
         dict: Response containing ``ready`` (bool), ``blockers`` (issues that
         prevent use), ``warnings`` (non-blocking), ``katib_crd_found``,
-        ``katib_crd_versions``, ``controller_status``, ``controller_ready``
-        and ``trainer_available``.
+        ``katib_crd_versions``, ``controller_status``, ``controller_ready``,
+        ``webhook_reachable`` and ``trainer_available``.
     """
     info: dict[str, Any] = {}
     blockers: list[str] = []
     warnings: list[str] = []
 
-    for check in (_check_experiment_crd, _check_controller, _check_trainer):
+    for check in (_check_experiment_crd, _check_controller, _check_webhook, _check_trainer):
         result = check()
         info.update(result.info)
         blockers.extend(result.blockers)

--- a/kubeflow_mcp/optimizer/api/planning.py
+++ b/kubeflow_mcp/optimizer/api/planning.py
@@ -23,7 +23,12 @@ from typing import Any
 
 from kubeflow_mcp.common import utils as mcp_utils
 from kubeflow_mcp.common.constants import ErrorCode
-from kubeflow_mcp.common.types import ToolError, ToolResponse, exception_details
+from kubeflow_mcp.common.types import (
+    ToolError,
+    ToolResponse,
+    exception_details,
+    is_k8s_not_found,
+)
 from kubeflow_mcp.optimizer.constants import (
     EXPERIMENT_CRD_NAME,
     KATIB_CONTROLLER_LABELS,
@@ -32,129 +37,171 @@ from kubeflow_mcp.optimizer.constants import (
 
 logger = logging.getLogger(__name__)
 
+# Each sub-check returns the fields it learned plus anything that blocks or
+# merely warns, so katib_pre_flight stays a flat composition of independent
+# checks rather than one long branching function.
+CheckResult = tuple[dict[str, Any], list[str], list[str]]
+
+_INSTALL_HINT = "https://www.kubeflow.org/docs/components/katib/installation/"
+
+
+def _check_experiment_crd() -> CheckResult:
+    """Confirm the Katib Experiment CRD is registered on the cluster."""
+    try:
+        crd = mcp_utils.get_apiextensions_api().read_custom_resource_definition(
+            name=EXPERIMENT_CRD_NAME,
+            _request_timeout=mcp_utils.K8S_TIMEOUT,
+        )
+    except Exception as e:
+        if is_k8s_not_found(e):
+            return (
+                {"katib_crd_found": False},
+                [
+                    f"Katib Experiment CRD not found ({EXPERIMENT_CRD_NAME}). Install Katib: {_INSTALL_HINT}"
+                ],
+                [],
+            )
+        return {"katib_crd_found": False}, [f"Cannot check Katib CRD: {e}"], []
+
+    served = [v.name for v in (crd.spec.versions or []) if getattr(v, "served", True)]
+    return {"katib_crd_found": True, "katib_crd_versions": served}, [], []
+
+
+def _find_controller_pod() -> Any | None:
+    """Locate the Katib controller pod, preferring its conventional namespace."""
+    core_api = mcp_utils.get_core_v1_api()
+    pods = core_api.list_namespaced_pod(
+        namespace=KATIB_CONTROLLER_NAMESPACE_DEFAULT,
+        label_selector=KATIB_CONTROLLER_LABELS,
+        _request_timeout=mcp_utils.K8S_TIMEOUT,
+    )
+    if not pods.items:
+        pods = core_api.list_pod_for_all_namespaces(
+            label_selector=KATIB_CONTROLLER_LABELS,
+            _request_timeout=mcp_utils.K8S_TIMEOUT,
+        )
+    return pods.items[0] if pods.items else None
+
+
+def _check_controller() -> CheckResult:
+    """Confirm the Katib controller pod is both Running and Ready.
+
+    Phase alone is not enough: a pod can be ``Running`` while its container
+    fails readiness, which is exactly what a Katib install missing its
+    ClusterRoles looks like. Treating that as healthy reports a false green.
+    """
+    try:
+        pod = _find_controller_pod()
+    except Exception as e:
+        return (
+            {"controller_status": "check_failed"},
+            [],
+            [f"Cannot check Katib controller pods: {e}"],
+        )
+
+    if pod is None:
+        return (
+            {"controller_status": "not_found"},
+            [
+                "Katib controller pod not found. Checked namespace "
+                f"'{KATIB_CONTROLLER_NAMESPACE_DEFAULT}' and all namespaces."
+            ],
+            [],
+        )
+
+    phase = pod.status.phase if pod.status else "Unknown"
+    where = f"{pod.metadata.namespace}/{pod.metadata.name}"
+    info: dict[str, Any] = {
+        "controller_status": phase,
+        "controller_namespace": pod.metadata.namespace,
+        "controller_name": pod.metadata.name,
+    }
+
+    if phase != "Running":
+        return (
+            info,
+            [f"Katib controller pod is in '{phase}' state (expected 'Running'). Pod: {where}"],
+            [],
+        )
+
+    statuses = getattr(pod.status, "container_statuses", None) or []
+    not_ready = [cs.name for cs in statuses if not cs.ready]
+    if not_ready:
+        info["controller_ready"] = False
+        return (
+            info,
+            [
+                "Katib controller pod is Running but not Ready (containers failing "
+                f"readiness: {', '.join(not_ready)}). Pod: {where}. Check controller "
+                "logs and verify Katib RBAC (ClusterRole/ClusterRoleBinding) is installed."
+            ],
+            [],
+        )
+    if not statuses:
+        # Statuses not published yet: indeterminate rather than known-bad.
+        return (
+            info,
+            [],
+            [
+                "Katib controller pod reports no container statuses yet; readiness could not be confirmed."
+            ],
+        )
+
+    info["controller_ready"] = True
+    return info, [], []
+
+
+def _check_trainer() -> CheckResult:
+    """Report whether the trainer client is usable for cross-client workflows.
+
+    Never a blocker: the optimizer is fully usable on its own.
+    """
+    try:
+        mcp_utils.get_trainer_client()
+    except Exception:
+        return (
+            {"trainer_available": False},
+            [],
+            [
+                "Trainer client not available. Cross-client workflows "
+                "(optimize → train with best hyperparameters) require "
+                "--clients trainer,optimizer"
+            ],
+        )
+    return {"trainer_available": True}, [], []
+
 
 def katib_pre_flight() -> dict[str, Any]:
     """One-shot readiness check for Katib hyperparameter optimization.
 
     Validates that the Katib/Optimizer infrastructure is ready:
-    1. Experiment CRD exists on the cluster
-    2. Katib controller pod is running
-    3. Reports trainer cross-client availability
 
-    Call this FIRST before any optimizer operations.
+    1. The Experiment CRD is registered on the cluster
+    2. The Katib controller pod is Running **and** passing readiness
+    3. Whether the trainer client is loaded, for cross-client workflows
+
+    Call this FIRST before any optimizer operations. It never raises for an
+    unhealthy cluster; problems are reported in ``blockers``.
 
     Returns:
-        dict: Response containing ``blockers`` (list of issues preventing use),
-              ``warnings`` (non-blocking issues), ``katib_crd_versions``,
-              and ``controller_status``.
-
-    Raises:
-        ToolError: If cluster is unreachable (``CLUSTER_ERROR``).
+        dict: Response containing ``ready`` (bool), ``blockers`` (issues that
+        prevent use), ``warnings`` (non-blocking), ``katib_crd_found``,
+        ``katib_crd_versions``, ``controller_status``, ``controller_ready``
+        and ``trainer_available``.
     """
+    info: dict[str, Any] = {}
     blockers: list[str] = []
     warnings: list[str] = []
-    info: dict[str, Any] = {}
 
-    # ── Check 1: Experiment CRD exists ──────────────────────────────
-    try:
-        api = mcp_utils.get_apiextensions_api()
-        crd = api.read_custom_resource_definition(
-            name=EXPERIMENT_CRD_NAME,
-            _request_timeout=mcp_utils.K8S_TIMEOUT,
-        )
-        versions = [v.name for v in (crd.spec.versions or []) if getattr(v, "served", True)]
-        info["katib_crd_versions"] = versions
-        info["katib_crd_found"] = True
-    except Exception as e:
-        from kubeflow_mcp.common.types import is_k8s_not_found
+    for check in (_check_experiment_crd, _check_controller, _check_trainer):
+        found, check_blockers, check_warnings = check()
+        info.update(found)
+        blockers.extend(check_blockers)
+        warnings.extend(check_warnings)
 
-        if is_k8s_not_found(e):
-            blockers.append(
-                f"Katib Experiment CRD not found ({EXPERIMENT_CRD_NAME}). "
-                "Install Katib: https://www.kubeflow.org/docs/components/katib/installation/"
-            )
-            info["katib_crd_found"] = False
-        else:
-            blockers.append(f"Cannot check Katib CRD: {e}")
-            info["katib_crd_found"] = False
-
-    # ── Check 2: Controller pod health ──────────────────────────────
-    try:
-        core_api = mcp_utils.get_core_v1_api()
-        pods = core_api.list_namespaced_pod(
-            namespace=KATIB_CONTROLLER_NAMESPACE_DEFAULT,
-            label_selector=KATIB_CONTROLLER_LABELS,
-            _request_timeout=mcp_utils.K8S_TIMEOUT,
-        )
-        if not pods.items:
-            pods = core_api.list_pod_for_all_namespaces(
-                label_selector=KATIB_CONTROLLER_LABELS,
-                _request_timeout=mcp_utils.K8S_TIMEOUT,
-            )
-
-        if not pods.items:
-            blockers.append(
-                "Katib controller pod not found. "
-                f"Checked namespace '{KATIB_CONTROLLER_NAMESPACE_DEFAULT}' and all namespaces."
-            )
-            info["controller_status"] = "not_found"
-        else:
-            pod = pods.items[0]
-            phase = pod.status.phase if pod.status else "Unknown"
-            info["controller_status"] = phase
-            info["controller_namespace"] = pod.metadata.namespace
-            info["controller_name"] = pod.metadata.name
-
-            if phase != "Running":
-                blockers.append(
-                    f"Katib controller pod is in '{phase}' state "
-                    f"(expected 'Running'). Pod: {pod.metadata.namespace}/{pod.metadata.name}"
-                )
-            else:
-                # Phase "Running" only means the pod was admitted and started —
-                # containers can still be failing their readiness probes (e.g. a
-                # controller that cannot watch its CRDs because RBAC is missing).
-                # Without this check pre-flight reports a false green light.
-                statuses = getattr(pod.status, "container_statuses", None) or []
-                not_ready = [cs.name for cs in statuses if not cs.ready]
-                if not_ready:
-                    info["controller_ready"] = False
-                    blockers.append(
-                        "Katib controller pod is Running but not Ready "
-                        f"(containers failing readiness: {', '.join(not_ready)}). "
-                        f"Pod: {pod.metadata.namespace}/{pod.metadata.name}. "
-                        "Check controller logs and verify Katib RBAC "
-                        "(ClusterRole/ClusterRoleBinding) is installed."
-                    )
-                elif statuses:
-                    info["controller_ready"] = True
-                else:
-                    # Container statuses not published yet — readiness is
-                    # indeterminate rather than known-bad, so warn instead.
-                    warnings.append(
-                        "Katib controller pod reports no container statuses yet; "
-                        "readiness could not be confirmed."
-                    )
-    except Exception as e:
-        warnings.append(f"Cannot check Katib controller pods: {e}")
-        info["controller_status"] = "check_failed"
-
-    # ── Check 3: Trainer module availability (cross-client hint) ────
-    try:
-        mcp_utils.get_trainer_client()
-        info["trainer_available"] = True
-    except Exception:
-        info["trainer_available"] = False
-        warnings.append(
-            "Trainer client not available. Cross-client workflows "
-            "(optimize → train with best hyperparameters) require "
-            "--clients trainer,optimizer"
-        )
-
-    # ── Build response ──────────────────────────────────────────────
     info["blockers"] = blockers
     info["warnings"] = warnings
-    info["ready"] = len(blockers) == 0
+    info["ready"] = not blockers
 
     try:
         return ToolResponse(data=info).model_dump()

--- a/kubeflow_mcp/optimizer/api/planning.py
+++ b/kubeflow_mcp/optimizer/api/planning.py
@@ -1,0 +1,167 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Planning tools for Katib pre-flight checks.
+
+Mirrors the trainer planning module's compound-tool pattern:
+one call aggregates multiple sub-checks into a single response.
+"""
+
+import logging
+from typing import Any
+
+from kubeflow_mcp.common import utils as mcp_utils
+from kubeflow_mcp.common.constants import ErrorCode
+from kubeflow_mcp.common.types import ToolError, ToolResponse, exception_details
+from kubeflow_mcp.optimizer.constants import (
+    EXPERIMENT_CRD_NAME,
+    KATIB_CONTROLLER_LABELS,
+    KATIB_CONTROLLER_NAMESPACE_DEFAULT,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def katib_pre_flight() -> dict[str, Any]:
+    """One-shot readiness check for Katib hyperparameter optimization.
+
+    Validates that the Katib/Optimizer infrastructure is ready:
+    1. Experiment CRD exists on the cluster
+    2. Katib controller pod is running
+    3. Reports trainer cross-client availability
+
+    Call this FIRST before any optimizer operations.
+
+    Returns:
+        dict: Response containing ``blockers`` (list of issues preventing use),
+              ``warnings`` (non-blocking issues), ``katib_crd_versions``,
+              and ``controller_status``.
+
+    Raises:
+        ToolError: If cluster is unreachable (``CLUSTER_ERROR``).
+    """
+    blockers: list[str] = []
+    warnings: list[str] = []
+    info: dict[str, Any] = {}
+
+    # ── Check 1: Experiment CRD exists ──────────────────────────────
+    try:
+        api = mcp_utils.get_apiextensions_api()
+        crd = api.read_custom_resource_definition(
+            name=EXPERIMENT_CRD_NAME,
+            _request_timeout=mcp_utils.K8S_TIMEOUT,
+        )
+        versions = [v.name for v in (crd.spec.versions or []) if getattr(v, "served", True)]
+        info["katib_crd_versions"] = versions
+        info["katib_crd_found"] = True
+    except Exception as e:
+        from kubeflow_mcp.common.types import is_k8s_not_found
+
+        if is_k8s_not_found(e):
+            blockers.append(
+                f"Katib Experiment CRD not found ({EXPERIMENT_CRD_NAME}). "
+                "Install Katib: https://www.kubeflow.org/docs/components/katib/installation/"
+            )
+            info["katib_crd_found"] = False
+        else:
+            blockers.append(f"Cannot check Katib CRD: {e}")
+            info["katib_crd_found"] = False
+
+    # ── Check 2: Controller pod health ──────────────────────────────
+    try:
+        core_api = mcp_utils.get_core_v1_api()
+        pods = core_api.list_namespaced_pod(
+            namespace=KATIB_CONTROLLER_NAMESPACE_DEFAULT,
+            label_selector=KATIB_CONTROLLER_LABELS,
+            _request_timeout=mcp_utils.K8S_TIMEOUT,
+        )
+        if not pods.items:
+            pods = core_api.list_pod_for_all_namespaces(
+                label_selector=KATIB_CONTROLLER_LABELS,
+                _request_timeout=mcp_utils.K8S_TIMEOUT,
+            )
+
+        if not pods.items:
+            blockers.append(
+                "Katib controller pod not found. "
+                f"Checked namespace '{KATIB_CONTROLLER_NAMESPACE_DEFAULT}' and all namespaces."
+            )
+            info["controller_status"] = "not_found"
+        else:
+            pod = pods.items[0]
+            phase = pod.status.phase if pod.status else "Unknown"
+            info["controller_status"] = phase
+            info["controller_namespace"] = pod.metadata.namespace
+            info["controller_name"] = pod.metadata.name
+
+            if phase != "Running":
+                blockers.append(
+                    f"Katib controller pod is in '{phase}' state "
+                    f"(expected 'Running'). Pod: {pod.metadata.namespace}/{pod.metadata.name}"
+                )
+            else:
+                # Phase "Running" only means the pod was admitted and started —
+                # containers can still be failing their readiness probes (e.g. a
+                # controller that cannot watch its CRDs because RBAC is missing).
+                # Without this check pre-flight reports a false green light.
+                statuses = getattr(pod.status, "container_statuses", None) or []
+                not_ready = [cs.name for cs in statuses if not cs.ready]
+                if not_ready:
+                    info["controller_ready"] = False
+                    blockers.append(
+                        "Katib controller pod is Running but not Ready "
+                        f"(containers failing readiness: {', '.join(not_ready)}). "
+                        f"Pod: {pod.metadata.namespace}/{pod.metadata.name}. "
+                        "Check controller logs and verify Katib RBAC "
+                        "(ClusterRole/ClusterRoleBinding) is installed."
+                    )
+                elif statuses:
+                    info["controller_ready"] = True
+                else:
+                    # Container statuses not published yet — readiness is
+                    # indeterminate rather than known-bad, so warn instead.
+                    warnings.append(
+                        "Katib controller pod reports no container statuses yet; "
+                        "readiness could not be confirmed."
+                    )
+    except Exception as e:
+        warnings.append(f"Cannot check Katib controller pods: {e}")
+        info["controller_status"] = "check_failed"
+
+    # ── Check 3: Trainer module availability (cross-client hint) ────
+    try:
+        mcp_utils.get_trainer_client()
+        info["trainer_available"] = True
+    except Exception:
+        info["trainer_available"] = False
+        warnings.append(
+            "Trainer client not available. Cross-client workflows "
+            "(optimize → train with best hyperparameters) require "
+            "--clients trainer,optimizer"
+        )
+
+    # ── Build response ──────────────────────────────────────────────
+    info["blockers"] = blockers
+    info["warnings"] = warnings
+    info["ready"] = len(blockers) == 0
+
+    try:
+        return ToolResponse(data=info).model_dump()
+    except Exception as e:
+        logger.warning("katib_pre_flight failed: %s", e, exc_info=True)
+        return ToolError(
+            error=str(e),
+            error_code=ErrorCode.SDK_ERROR,
+            details=exception_details(e),
+        ).model_dump()

--- a/kubeflow_mcp/optimizer/api/planning.py
+++ b/kubeflow_mcp/optimizer/api/planning.py
@@ -19,7 +19,7 @@ one call aggregates multiple sub-checks into a single response.
 """
 
 import logging
-from typing import Any
+from typing import Any, NamedTuple
 
 from kubeflow_mcp.common import utils as mcp_utils
 from kubeflow_mcp.common.constants import ErrorCode
@@ -37,10 +37,22 @@ from kubeflow_mcp.optimizer.constants import (
 
 logger = logging.getLogger(__name__)
 
-# Each sub-check returns the fields it learned plus anything that blocks or
-# merely warns, so katib_pre_flight stays a flat composition of independent
-# checks rather than one long branching function.
-CheckResult = tuple[dict[str, Any], list[str], list[str]]
+
+class CheckResult(NamedTuple):
+    """What one sub-check learned, plus anything that blocks or merely warns.
+
+    Keeps ``katib_pre_flight`` a flat composition of independent checks rather
+    than one long branching function. Named rather than a bare 3-tuple because
+    ``blockers`` and ``warnings`` share a type: transposing them at a call site
+    would downgrade a blocker to a warning and report a false green, which is
+    the exact failure ``_check_controller`` exists to prevent. Construct it with
+    keywords so that mistake cannot be made silently.
+    """
+
+    info: dict[str, Any]
+    blockers: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
 
 _INSTALL_HINT = "https://www.kubeflow.org/docs/components/katib/installation/"
 
@@ -54,17 +66,20 @@ def _check_experiment_crd() -> CheckResult:
         )
     except Exception as e:
         if is_k8s_not_found(e):
-            return (
-                {"katib_crd_found": False},
-                [
-                    f"Katib Experiment CRD not found ({EXPERIMENT_CRD_NAME}). Install Katib: {_INSTALL_HINT}"
-                ],
-                [],
+            return CheckResult(
+                info={"katib_crd_found": False},
+                blockers=(
+                    f"Katib Experiment CRD not found ({EXPERIMENT_CRD_NAME}). "
+                    f"Install Katib: {_INSTALL_HINT}",
+                ),
             )
-        return {"katib_crd_found": False}, [f"Cannot check Katib CRD: {e}"], []
+        return CheckResult(
+            info={"katib_crd_found": False},
+            blockers=(f"Cannot check Katib CRD: {e}",),
+        )
 
     served = [v.name for v in (crd.spec.versions or []) if getattr(v, "served", True)]
-    return {"katib_crd_found": True, "katib_crd_versions": served}, [], []
+    return CheckResult(info={"katib_crd_found": True, "katib_crd_versions": served})
 
 
 def _find_controller_pod() -> Any | None:
@@ -93,20 +108,18 @@ def _check_controller() -> CheckResult:
     try:
         pod = _find_controller_pod()
     except Exception as e:
-        return (
-            {"controller_status": "check_failed"},
-            [],
-            [f"Cannot check Katib controller pods: {e}"],
+        return CheckResult(
+            info={"controller_status": "check_failed"},
+            warnings=(f"Cannot check Katib controller pods: {e}",),
         )
 
     if pod is None:
-        return (
-            {"controller_status": "not_found"},
-            [
+        return CheckResult(
+            info={"controller_status": "not_found"},
+            blockers=(
                 "Katib controller pod not found. Checked namespace "
-                f"'{KATIB_CONTROLLER_NAMESPACE_DEFAULT}' and all namespaces."
-            ],
-            [],
+                f"'{KATIB_CONTROLLER_NAMESPACE_DEFAULT}' and all namespaces.",
+            ),
         )
 
     phase = pod.status.phase if pod.status else "Unknown"
@@ -118,37 +131,37 @@ def _check_controller() -> CheckResult:
     }
 
     if phase != "Running":
-        return (
-            info,
-            [f"Katib controller pod is in '{phase}' state (expected 'Running'). Pod: {where}"],
-            [],
+        return CheckResult(
+            info=info,
+            blockers=(
+                f"Katib controller pod is in '{phase}' state (expected 'Running'). Pod: {where}",
+            ),
         )
 
     statuses = getattr(pod.status, "container_statuses", None) or []
     not_ready = [cs.name for cs in statuses if not cs.ready]
     if not_ready:
         info["controller_ready"] = False
-        return (
-            info,
-            [
+        return CheckResult(
+            info=info,
+            blockers=(
                 "Katib controller pod is Running but not Ready (containers failing "
                 f"readiness: {', '.join(not_ready)}). Pod: {where}. Check controller "
-                "logs and verify Katib RBAC (ClusterRole/ClusterRoleBinding) is installed."
-            ],
-            [],
+                "logs and verify Katib RBAC (ClusterRole/ClusterRoleBinding) is installed.",
+            ),
         )
     if not statuses:
         # Statuses not published yet: indeterminate rather than known-bad.
-        return (
-            info,
-            [],
-            [
-                "Katib controller pod reports no container statuses yet; readiness could not be confirmed."
-            ],
+        return CheckResult(
+            info=info,
+            warnings=(
+                "Katib controller pod reports no container statuses yet; "
+                "readiness could not be confirmed.",
+            ),
         )
 
     info["controller_ready"] = True
-    return info, [], []
+    return CheckResult(info=info)
 
 
 def _check_trainer() -> CheckResult:
@@ -159,16 +172,15 @@ def _check_trainer() -> CheckResult:
     try:
         mcp_utils.get_trainer_client()
     except Exception:
-        return (
-            {"trainer_available": False},
-            [],
-            [
+        return CheckResult(
+            info={"trainer_available": False},
+            warnings=(
                 "Trainer client not available. Cross-client workflows "
                 "(optimize → train with best hyperparameters) require "
-                "--clients trainer,optimizer"
-            ],
+                "--clients trainer,optimizer",
+            ),
         )
-    return {"trainer_available": True}, [], []
+    return CheckResult(info={"trainer_available": True})
 
 
 def katib_pre_flight() -> dict[str, Any]:
@@ -194,10 +206,10 @@ def katib_pre_flight() -> dict[str, Any]:
     warnings: list[str] = []
 
     for check in (_check_experiment_crd, _check_controller, _check_trainer):
-        found, check_blockers, check_warnings = check()
-        info.update(found)
-        blockers.extend(check_blockers)
-        warnings.extend(check_warnings)
+        result = check()
+        info.update(result.info)
+        blockers.extend(result.blockers)
+        warnings.extend(result.warnings)
 
     info["blockers"] = blockers
     info["warnings"] = warnings

--- a/kubeflow_mcp/optimizer/api/planning_test.py
+++ b/kubeflow_mcp/optimizer/api/planning_test.py
@@ -14,6 +14,7 @@
 
 """Unit tests for katib_pre_flight (CRD + controller + trainer detection)."""
 
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -39,18 +40,27 @@ def _pod(phase="Running", namespace="kubeflow", name="katib-controller-abc", rea
     )
 
 
-def _patch(apiext, core, trainer_ok=True):
-    trainer = MagicMock() if trainer_ok else None
+@contextmanager
+def _patch(apiext, core, trainer_ok=True, webhook=None):
+    """Patch every cluster call pre-flight makes.
+
+    ``webhook`` is the CustomObjects API backing the dry-run admission probe. It
+    is always patched: leaving it out lets the check reach a real cluster, which
+    both slows the suite and makes results depend on the developer's kubeconfig.
+    """
     trainer_ctx = (
-        patch(f"{_UTILS}.get_trainer_client", return_value=trainer)
+        patch(f"{_UTILS}.get_trainer_client", return_value=MagicMock())
         if trainer_ok
         else patch(f"{_UTILS}.get_trainer_client", side_effect=RuntimeError("no trainer"))
     )
-    return (
+    with (
         patch(f"{_UTILS}.get_apiextensions_api", return_value=apiext),
         patch(f"{_UTILS}.get_core_v1_api", return_value=core),
         trainer_ctx,
-    )
+        patch(f"{_UTILS}.get_custom_objects_api", return_value=webhook or MagicMock()),
+        patch(f"{_UTILS}.get_optimizer_effective_namespace", return_value="default"),
+    ):
+        yield
 
 
 def test_pre_flight_all_healthy():
@@ -58,8 +68,7 @@ def test_pre_flight_all_healthy():
     apiext.read_custom_resource_definition.return_value = _crd()
     core = MagicMock()
     core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod()])
-    a, c, t = _patch(apiext, core, trainer_ok=True)
-    with a, c, t:
+    with _patch(apiext, core, trainer_ok=True):
         result = katib_pre_flight()
     assert result["success"] is True
     data = result["data"]
@@ -78,8 +87,7 @@ def test_pre_flight_crd_missing():
     )
     core = MagicMock()
     core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod()])
-    a, c, t = _patch(apiext, core)
-    with a, c, t:
+    with _patch(apiext, core):
         result = katib_pre_flight()
     data = result["data"]
     assert data["ready"] is False
@@ -92,8 +100,7 @@ def test_pre_flight_controller_not_running():
     apiext.read_custom_resource_definition.return_value = _crd()
     core = MagicMock()
     core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod(phase="Pending")])
-    a, c, t = _patch(apiext, core)
-    with a, c, t:
+    with _patch(apiext, core):
         result = katib_pre_flight()
     data = result["data"]
     assert data["ready"] is False
@@ -107,8 +114,7 @@ def test_pre_flight_no_controller_pods():
     core = MagicMock()
     core.list_namespaced_pod.return_value = SimpleNamespace(items=[])
     core.list_pod_for_all_namespaces.return_value = SimpleNamespace(items=[])
-    a, c, t = _patch(apiext, core)
-    with a, c, t:
+    with _patch(apiext, core):
         result = katib_pre_flight()
     data = result["data"]
     assert data["ready"] is False
@@ -122,8 +128,7 @@ def test_pre_flight_controller_running_but_not_ready():
     apiext.read_custom_resource_definition.return_value = _crd()
     core = MagicMock()
     core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod(ready=False)])
-    a, c, t = _patch(apiext, core)
-    with a, c, t:
+    with _patch(apiext, core):
         result = katib_pre_flight()
     data = result["data"]
     assert data["ready"] is False
@@ -137,8 +142,7 @@ def test_pre_flight_ready_controller_sets_controller_ready():
     apiext.read_custom_resource_definition.return_value = _crd()
     core = MagicMock()
     core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod(ready=True)])
-    a, c, t = _patch(apiext, core)
-    with a, c, t:
+    with _patch(apiext, core):
         result = katib_pre_flight()
     assert result["data"]["controller_ready"] is True
 
@@ -149,8 +153,7 @@ def test_pre_flight_missing_container_statuses_warns_only():
     apiext.read_custom_resource_definition.return_value = _crd()
     core = MagicMock()
     core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod(ready=None)])
-    a, c, t = _patch(apiext, core)
-    with a, c, t:
+    with _patch(apiext, core):
         result = katib_pre_flight()
     data = result["data"]
     assert data["ready"] is True
@@ -162,14 +165,81 @@ def test_pre_flight_trainer_unavailable_is_warning_not_blocker():
     apiext.read_custom_resource_definition.return_value = _crd()
     core = MagicMock()
     core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod()])
-    a, c, t = _patch(apiext, core, trainer_ok=False)
-    with a, c, t:
+    with _patch(apiext, core, trainer_ok=False):
         result = katib_pre_flight()
     data = result["data"]
     # Trainer missing must not block optimizer-only usage.
     assert data["ready"] is True
     assert data["trainer_available"] is False
     assert any("Trainer client not available" in w for w in data["warnings"])
+
+
+def _healthy_cluster():
+    apiext = MagicMock()
+    apiext.read_custom_resource_definition.return_value = _crd()
+    core = MagicMock()
+    core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod()])
+    return apiext, core
+
+
+def test_pre_flight_blocks_when_webhook_is_unreachable():
+    """Regression: a Ready controller whose webhook the API server cannot reach.
+
+    Katib registers its webhooks with failurePolicy=Fail, so every create is
+    rejected while the CRD is installed and the pod looks perfectly healthy.
+    Reporting ready here is a false green.
+    """
+    apiext, core = _healthy_cluster()
+    webhook = MagicMock()
+    webhook.create_namespaced_custom_object.side_effect = ApiException(
+        status=500, reason="Internal Server Error"
+    )
+    with _patch(apiext, core, webhook=webhook):
+        result = katib_pre_flight()
+    data = result["data"]
+    assert data["ready"] is False
+    assert data["webhook_reachable"] is False
+    assert data["controller_ready"] is True, "the pod itself is healthy; only admission is broken"
+    assert any("admission webhooks are not reachable" in b for b in data["blockers"])
+
+
+def test_pre_flight_webhook_probe_is_a_dry_run():
+    """The probe must never persist an Experiment."""
+    apiext, core = _healthy_cluster()
+    webhook = MagicMock()
+    with _patch(apiext, core, webhook=webhook):
+        katib_pre_flight()
+    kwargs = webhook.create_namespaced_custom_object.call_args.kwargs
+    assert kwargs["dry_run"] == "All"
+    assert kwargs["plural"] == "experiments"
+
+
+def test_pre_flight_webhook_rejection_still_counts_as_reachable():
+    """A 400/422 means the webhook answered, which is all the probe asks."""
+    apiext, core = _healthy_cluster()
+    webhook = MagicMock()
+    webhook.create_namespaced_custom_object.side_effect = ApiException(
+        status=422, reason="Unprocessable Entity"
+    )
+    with _patch(apiext, core, webhook=webhook):
+        result = katib_pre_flight()
+    assert result["data"]["ready"] is True
+    assert result["data"]["webhook_reachable"] is True
+
+
+def test_pre_flight_webhook_forbidden_warns_rather_than_blocks():
+    """Without create permission the probe cannot conclude anything."""
+    apiext, core = _healthy_cluster()
+    webhook = MagicMock()
+    webhook.create_namespaced_custom_object.side_effect = ApiException(
+        status=403, reason="Forbidden"
+    )
+    with _patch(apiext, core, webhook=webhook):
+        result = katib_pre_flight()
+    data = result["data"]
+    assert data["ready"] is True
+    assert data["webhook_reachable"] is None
+    assert any("Cannot verify Katib admission webhooks" in w for w in data["warnings"])
 
 
 def test_pre_flight_controller_falls_back_to_all_namespaces():
@@ -181,8 +251,7 @@ def test_pre_flight_controller_falls_back_to_all_namespaces():
     core.list_pod_for_all_namespaces.return_value = SimpleNamespace(
         items=[_pod(namespace="katib-system")]
     )
-    a, c, t = _patch(apiext, core)
-    with a, c, t:
+    with _patch(apiext, core):
         result = katib_pre_flight()
     data = result["data"]
     assert data["ready"] is True

--- a/kubeflow_mcp/optimizer/api/planning_test.py
+++ b/kubeflow_mcp/optimizer/api/planning_test.py
@@ -1,0 +1,189 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for katib_pre_flight (CRD + controller + trainer detection)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from kubernetes.client.exceptions import ApiException
+
+from kubeflow_mcp.optimizer.api.planning import katib_pre_flight
+
+_UTILS = "kubeflow_mcp.common.utils"
+
+
+def _crd(versions=("v1beta1",)):
+    return SimpleNamespace(
+        spec=SimpleNamespace(versions=[SimpleNamespace(name=v, served=True) for v in versions])
+    )
+
+
+def _pod(phase="Running", namespace="kubeflow", name="katib-controller-abc", ready=True):
+    """Build a controller pod. Real Running pods publish container statuses."""
+    statuses = None if ready is None else [SimpleNamespace(name="katib-controller", ready=ready)]
+    return SimpleNamespace(
+        status=SimpleNamespace(phase=phase, container_statuses=statuses),
+        metadata=SimpleNamespace(namespace=namespace, name=name),
+    )
+
+
+def _patch(apiext, core, trainer_ok=True):
+    trainer = MagicMock() if trainer_ok else None
+    trainer_ctx = (
+        patch(f"{_UTILS}.get_trainer_client", return_value=trainer)
+        if trainer_ok
+        else patch(f"{_UTILS}.get_trainer_client", side_effect=RuntimeError("no trainer"))
+    )
+    return (
+        patch(f"{_UTILS}.get_apiextensions_api", return_value=apiext),
+        patch(f"{_UTILS}.get_core_v1_api", return_value=core),
+        trainer_ctx,
+    )
+
+
+def test_pre_flight_all_healthy():
+    apiext = MagicMock()
+    apiext.read_custom_resource_definition.return_value = _crd()
+    core = MagicMock()
+    core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod()])
+    a, c, t = _patch(apiext, core, trainer_ok=True)
+    with a, c, t:
+        result = katib_pre_flight()
+    assert result["success"] is True
+    data = result["data"]
+    assert data["ready"] is True
+    assert data["blockers"] == []
+    assert data["katib_crd_found"] is True
+    assert data["katib_crd_versions"] == ["v1beta1"]
+    assert data["controller_status"] == "Running"
+    assert data["trainer_available"] is True
+
+
+def test_pre_flight_crd_missing():
+    apiext = MagicMock()
+    apiext.read_custom_resource_definition.side_effect = ApiException(
+        status=404, reason="Not Found"
+    )
+    core = MagicMock()
+    core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod()])
+    a, c, t = _patch(apiext, core)
+    with a, c, t:
+        result = katib_pre_flight()
+    data = result["data"]
+    assert data["ready"] is False
+    assert data["katib_crd_found"] is False
+    assert any("CRD not found" in b for b in data["blockers"])
+
+
+def test_pre_flight_controller_not_running():
+    apiext = MagicMock()
+    apiext.read_custom_resource_definition.return_value = _crd()
+    core = MagicMock()
+    core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod(phase="Pending")])
+    a, c, t = _patch(apiext, core)
+    with a, c, t:
+        result = katib_pre_flight()
+    data = result["data"]
+    assert data["ready"] is False
+    assert data["controller_status"] == "Pending"
+    assert any("Pending" in b for b in data["blockers"])
+
+
+def test_pre_flight_no_controller_pods():
+    apiext = MagicMock()
+    apiext.read_custom_resource_definition.return_value = _crd()
+    core = MagicMock()
+    core.list_namespaced_pod.return_value = SimpleNamespace(items=[])
+    core.list_pod_for_all_namespaces.return_value = SimpleNamespace(items=[])
+    a, c, t = _patch(apiext, core)
+    with a, c, t:
+        result = katib_pre_flight()
+    data = result["data"]
+    assert data["ready"] is False
+    assert data["controller_status"] == "not_found"
+
+
+def test_pre_flight_controller_running_but_not_ready():
+    """Regression: a Running pod whose container fails readiness (e.g. missing
+    Katib RBAC) must not be reported as ready."""
+    apiext = MagicMock()
+    apiext.read_custom_resource_definition.return_value = _crd()
+    core = MagicMock()
+    core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod(ready=False)])
+    a, c, t = _patch(apiext, core)
+    with a, c, t:
+        result = katib_pre_flight()
+    data = result["data"]
+    assert data["ready"] is False
+    assert data["controller_ready"] is False
+    assert any("not Ready" in b for b in data["blockers"])
+    assert any("RBAC" in b for b in data["blockers"])
+
+
+def test_pre_flight_ready_controller_sets_controller_ready():
+    apiext = MagicMock()
+    apiext.read_custom_resource_definition.return_value = _crd()
+    core = MagicMock()
+    core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod(ready=True)])
+    a, c, t = _patch(apiext, core)
+    with a, c, t:
+        result = katib_pre_flight()
+    assert result["data"]["controller_ready"] is True
+
+
+def test_pre_flight_missing_container_statuses_warns_only():
+    """Statuses not published yet is indeterminate, not a hard blocker."""
+    apiext = MagicMock()
+    apiext.read_custom_resource_definition.return_value = _crd()
+    core = MagicMock()
+    core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod(ready=None)])
+    a, c, t = _patch(apiext, core)
+    with a, c, t:
+        result = katib_pre_flight()
+    data = result["data"]
+    assert data["ready"] is True
+    assert any("readiness could not be confirmed" in w for w in data["warnings"])
+
+
+def test_pre_flight_trainer_unavailable_is_warning_not_blocker():
+    apiext = MagicMock()
+    apiext.read_custom_resource_definition.return_value = _crd()
+    core = MagicMock()
+    core.list_namespaced_pod.return_value = SimpleNamespace(items=[_pod()])
+    a, c, t = _patch(apiext, core, trainer_ok=False)
+    with a, c, t:
+        result = katib_pre_flight()
+    data = result["data"]
+    # Trainer missing must not block optimizer-only usage.
+    assert data["ready"] is True
+    assert data["trainer_available"] is False
+    assert any("Trainer client not available" in w for w in data["warnings"])
+
+
+def test_pre_flight_controller_falls_back_to_all_namespaces():
+    apiext = MagicMock()
+    apiext.read_custom_resource_definition.return_value = _crd()
+    core = MagicMock()
+    # Not in the default kubeflow namespace, but found cluster-wide.
+    core.list_namespaced_pod.return_value = SimpleNamespace(items=[])
+    core.list_pod_for_all_namespaces.return_value = SimpleNamespace(
+        items=[_pod(namespace="katib-system")]
+    )
+    a, c, t = _patch(apiext, core)
+    with a, c, t:
+        result = katib_pre_flight()
+    data = result["data"]
+    assert data["ready"] is True
+    assert data["controller_namespace"] == "katib-system"

--- a/kubeflow_mcp/optimizer/api/resources_test.py
+++ b/kubeflow_mcp/optimizer/api/resources_test.py
@@ -1,0 +1,140 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optimizer MCP resources: registration and factual consistency.
+
+The guides are read by agents, so wrong content is worse than no content —
+these tests pin the claims that would silently rot as the tools change.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import kubeflow_mcp.optimizer as optimizer_module
+from kubeflow_mcp.optimizer import CLIENT_RESOURCES, TOOLS
+from kubeflow_mcp.optimizer.api.optimization import ALGORITHMS
+
+RESOURCE_DIR = Path(optimizer_module.__file__).parent
+
+
+def _text(filename: str) -> str:
+    return (RESOURCE_DIR / filename).read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def hpo_patterns() -> str:
+    return _text("resources/hpo-patterns.md")
+
+
+@pytest.fixture(scope="module")
+def troubleshooting() -> str:
+    return _text("resources/troubleshooting.md")
+
+
+# ─── registration ──────────────────────────────────────────────────────────
+
+
+def test_every_declared_resource_file_exists():
+    """register_resources() silently skips missing files, so assert here."""
+    for uri, (filename, _desc) in CLIENT_RESOURCES.items():
+        assert (RESOURCE_DIR / filename).is_file(), f"{uri} -> {filename} missing"
+
+
+def test_resources_register_on_the_server():
+    from kubeflow_mcp.core.resources import register_resources
+
+    mcp = _RecordingMCP()
+    complete = register_resources(mcp, {"optimizer": optimizer_module})
+    assert complete is True
+    assert set(mcp.registered) == set(CLIENT_RESOURCES)
+
+
+def test_resource_uris_are_namespaced_and_described():
+    for uri, (_filename, desc) in CLIENT_RESOURCES.items():
+        assert uri.startswith("optimizer://"), uri
+        assert desc.strip(), f"{uri} has no description"
+
+
+class _RecordingMCP:
+    """Minimal stand-in capturing what register_resources() registers."""
+
+    def __init__(self) -> None:
+        self.registered: list[str] = []
+
+    def resource(self, uri: str):
+        self.registered.append(uri)
+
+        def decorator(fn):
+            # Handler must return the file's content without touching disk again.
+            assert fn().strip(), f"{uri} resolved to empty content"
+            return fn
+
+        return decorator
+
+
+# ─── factual consistency with the implementation ───────────────────────────
+
+
+def test_every_algorithm_is_documented(hpo_patterns):
+    """The guide's algorithm table must cover exactly what the tool accepts."""
+    for algorithm in ALGORITHMS:
+        assert f'"{algorithm}"' in hpo_patterns, f"{algorithm} missing from hpo-patterns.md"
+
+
+def test_guide_does_not_claim_algorithms_need_the_raw_spec(hpo_patterns):
+    """Regression: the guide used to say tpe/cmaes/hyperband were unreachable
+    from create_hpo_experiment. Building the CR directly made that false."""
+    table = hpo_patterns.split("## Algorithm selection", 1)[1].split("##", 1)[0]
+    assert "create_experiment_from_spec" not in table
+
+
+def test_guides_only_reference_real_tools(hpo_patterns, troubleshooting):
+    """Catch tool names that were renamed or never existed."""
+    import re
+
+    known = {t.__name__ for t in TOOLS} | {
+        "fine_tune",
+        "run_custom_training",
+        "list_runtimes",
+    }
+    for doc, name in ((hpo_patterns, "hpo-patterns"), (troubleshooting, "troubleshooting")):
+        referenced = set(re.findall(r"\b([a-z_]+)\(", doc))
+        unknown = {r for r in referenced if r.endswith(("_experiment", "_trials", "_trial"))}
+        assert unknown <= known, f"{name}.md references unknown tools: {unknown - known}"
+
+
+def test_troubleshooting_documents_the_complete_vs_succeeded_trap(troubleshooting):
+    """Trial status comes from the TrainJob, so "Succeeded" never matches."""
+    assert 'status="Complete"' in troubleshooting
+    assert "Succeeded" in troubleshooting
+
+
+def test_troubleshooting_covers_the_not_ready_controller(troubleshooting):
+    """The failure mode a broken RBAC install actually produces."""
+    assert "not Ready" in troubleshooting
+    assert "RBAC" in troubleshooting
+
+
+def test_documented_limits_match_the_code(hpo_patterns):
+    from kubeflow_mcp.optimizer.api._common import DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT
+    from kubeflow_mcp.optimizer.api.optimization import (
+        MAX_PARALLEL_TRIAL_LIMIT,
+        MAX_TRIAL_COUNT_LIMIT,
+    )
+
+    assert f"**{MAX_TRIAL_COUNT_LIMIT}**" in hpo_patterns
+    assert f"**{MAX_PARALLEL_TRIAL_LIMIT}**" in hpo_patterns
+    assert f"**{DEFAULT_LIST_LIMIT}**" in hpo_patterns
+    assert f"**{MAX_LIST_LIMIT}**" in hpo_patterns

--- a/kubeflow_mcp/optimizer/api/sdk_contracts_test.py
+++ b/kubeflow_mcp/optimizer/api/sdk_contracts_test.py
@@ -1,0 +1,286 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SDK Contract Tests for the Optimizer module.
+
+Validates that the OptimizerClient SDK methods and types our MCP tools
+depend on exist with expected signatures, without requiring a cluster.
+
+Mirrors the pattern from trainer/api/sdk_contracts_test.py.
+"""
+
+import inspect
+
+import pytest
+from kubeflow.optimizer import OptimizerClient
+
+
+class TestOptimizerClientMethods:
+    """Verify OptimizerClient has the methods we depend on."""
+
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "list_jobs",
+            "get_job",
+            "delete_job",
+            "get_best_results",
+            "get_job_logs",
+            "get_job_events",
+            "wait_for_job_status",
+        ],
+    )
+    def test_method_exists(self, method_name: str):
+        assert hasattr(OptimizerClient, method_name), (
+            f"OptimizerClient.{method_name}() not found — SDK may have changed"
+        )
+        assert callable(getattr(OptimizerClient, method_name))
+
+    def test_get_job_takes_name(self):
+        sig = inspect.signature(OptimizerClient.get_job)
+        assert "name" in sig.parameters
+
+    def test_list_jobs_no_required_args(self):
+        sig = inspect.signature(OptimizerClient.list_jobs)
+        required = {
+            k
+            for k, v in sig.parameters.items()
+            if v.default is inspect.Parameter.empty and k != "self"
+        }
+        assert not required, f"list_jobs() has unexpected required params: {required}"
+
+    def test_delete_job_takes_name(self):
+        sig = inspect.signature(OptimizerClient.delete_job)
+        assert "name" in sig.parameters
+
+    def test_get_best_results_takes_name(self):
+        sig = inspect.signature(OptimizerClient.get_best_results)
+        assert "name" in sig.parameters
+
+    def test_get_job_logs_signature(self):
+        sig = inspect.signature(OptimizerClient.get_job_logs)
+        params = set(sig.parameters.keys()) - {"self"}
+        assert "name" in params
+        assert "trial_name" in params
+        assert "follow" in params
+
+    def test_get_job_events_takes_name(self):
+        sig = inspect.signature(OptimizerClient.get_job_events)
+        assert "name" in sig.parameters
+
+    def test_wait_for_job_status_signature(self):
+        sig = inspect.signature(OptimizerClient.wait_for_job_status)
+        params = set(sig.parameters.keys()) - {"self"}
+        assert "name" in params
+        assert "timeout" in params
+        assert "polling_interval" in params
+
+
+class TestOptimizeRemainsUnusable:
+    """Document *why* create_hpo_experiment builds the CR itself.
+
+    These are revisit triggers, not coverage of code we call. If any of them
+    starts failing the SDK has relaxed a constraint, and routing
+    create_hpo_experiment back through ``optimize()`` should be reconsidered.
+    """
+
+    def test_optimize_still_exists(self):
+        assert callable(OptimizerClient.optimize)
+
+    def test_optimize_still_cannot_set_a_name(self):
+        """It generates its own Experiment name, so a caller-supplied name and
+        the MCP ownership label are both unreachable through it."""
+        params = set(inspect.signature(OptimizerClient.optimize).parameters) - {"self"}
+        assert "name" not in params
+        assert "labels" not in params
+        assert "metadata" not in params
+
+    def test_trial_template_trainer_still_requires_a_python_callable(self):
+        """TrainJobTemplate.trainer is a CustomTrainer whose ``func`` is a live
+        Callable — it cannot cross the MCP/JSON boundary."""
+        import dataclasses
+
+        from kubeflow.optimizer import TrainJobTemplate
+        from kubeflow.trainer.types.types import CustomTrainer
+
+        trainer_field = next(f for f in dataclasses.fields(TrainJobTemplate) if f.name == "trainer")
+        assert trainer_field.type is CustomTrainer
+
+        func = next(f for f in dataclasses.fields(CustomTrainer) if f.name == "func")
+        assert func.default is dataclasses.MISSING, "func is required"
+
+    def test_container_trainer_still_lacks_func_args(self):
+        """The image-based trainer is the JSON-friendly alternative, but the
+        optimizer backend unconditionally writes ``trainer.func_args``, so
+        passing one raises AttributeError inside the SDK."""
+        import dataclasses
+
+        from kubeflow.trainer.types.types import CustomTrainerContainer
+
+        fields = {f.name for f in dataclasses.fields(CustomTrainerContainer)}
+        assert "func_args" not in fields
+
+
+class TestOptimizerTypeImports:
+    """Verify SDK types used by MCP tools are importable."""
+
+    def test_optimizer_client_importable(self):
+        from kubeflow.optimizer import OptimizerClient  # noqa: F811
+
+        assert OptimizerClient is not None
+
+    def test_optimization_job_importable(self):
+        from kubeflow.optimizer import OptimizationJob
+
+        assert OptimizationJob is not None
+
+    def test_result_importable(self):
+        from kubeflow.optimizer import Result
+
+        assert Result is not None
+
+    def test_trial_config_importable(self):
+        from kubeflow.optimizer import TrialConfig
+
+        assert TrialConfig is not None
+
+    def test_objective_importable(self):
+        from kubeflow.optimizer import Objective
+
+        assert Objective is not None
+
+    def test_search_importable(self):
+        from kubeflow.optimizer import Search
+
+        assert hasattr(Search, "uniform")
+        assert hasattr(Search, "loguniform")
+        assert hasattr(Search, "choice")
+
+    def test_random_search_importable(self):
+        from kubeflow.optimizer import RandomSearch
+
+        assert RandomSearch is not None
+
+    def test_grid_search_importable(self):
+        from kubeflow.optimizer import GridSearch
+
+        assert GridSearch is not None
+
+    def test_train_job_template_importable(self):
+        from kubeflow.optimizer import TrainJobTemplate
+
+        assert TrainJobTemplate is not None
+
+    def test_kubernetes_backend_config_importable(self):
+        from kubeflow.optimizer import KubernetesBackendConfig
+
+        assert KubernetesBackendConfig is not None
+
+
+class TestOptimizerTypeFields:
+    """Verify SDK dataclass fields match our usage."""
+
+    def test_optimization_job_fields(self):
+        from kubeflow.optimizer import OptimizationJob
+
+        field_names = set(OptimizationJob.__dataclass_fields__.keys())
+        expected = {"name", "status", "trials", "search_space", "objectives", "algorithm"}
+        assert expected <= field_names, f"Missing fields: {expected - field_names}"
+
+    def test_trial_config_fields(self):
+        from kubeflow.optimizer import TrialConfig
+
+        field_names = set(TrialConfig.__dataclass_fields__.keys())
+        assert "num_trials" in field_names
+        assert "parallel_trials" in field_names
+
+    def test_objective_fields(self):
+        from kubeflow.optimizer import Objective
+
+        field_names = set(Objective.__dataclass_fields__.keys())
+        assert "metric" in field_names
+        assert "direction" in field_names
+
+    def test_result_fields(self):
+        from kubeflow.optimizer import Result
+
+        field_names = set(Result.__dataclass_fields__.keys())
+        assert "parameters" in field_names
+        assert "metrics" in field_names
+
+
+class TestKatibApiModels:
+    """Verify kubeflow_katib_api models used for raw spec creation."""
+
+    def test_v1beta1_experiment_importable(self):
+        from kubeflow_katib_api.models import V1beta1Experiment
+
+        assert V1beta1Experiment is not None
+
+    def test_v1beta1_experiment_spec_importable(self):
+        from kubeflow_katib_api.models import V1beta1ExperimentSpec
+
+        assert V1beta1ExperimentSpec is not None
+
+    def test_v1beta1_trial_template_importable(self):
+        from kubeflow_katib_api.models import V1beta1TrialTemplate
+
+        assert V1beta1TrialTemplate is not None
+
+    def test_v1beta1_algorithm_spec_importable(self):
+        from kubeflow_katib_api.models import V1beta1AlgorithmSpec
+
+        assert V1beta1AlgorithmSpec is not None
+
+    def test_v1beta1_objective_spec_importable(self):
+        from kubeflow_katib_api.models import V1beta1ObjectiveSpec
+
+        assert V1beta1ObjectiveSpec is not None
+
+    def test_v1beta1_early_stopping_spec_importable(self):
+        from kubeflow_katib_api.models import V1beta1EarlyStoppingSpec
+
+        assert V1beta1EarlyStoppingSpec is not None
+
+
+class TestOptimizerConstants:
+    """Verify SDK constants used by our code."""
+
+    def test_constants_importable(self):
+        from kubeflow.optimizer.constants import constants
+
+        assert constants is not None
+
+    def test_api_group(self):
+        from kubeflow.optimizer.constants import constants
+
+        assert constants.GROUP == "kubeflow.org"
+
+    def test_api_version(self):
+        from kubeflow.optimizer.constants import constants
+
+        assert constants.VERSION == "v1beta1"
+
+    def test_experiment_plural(self):
+        from kubeflow.optimizer.constants import constants
+
+        assert constants.EXPERIMENT_PLURAL == "experiments"
+
+    def test_status_values(self):
+        from kubeflow.optimizer.constants import constants
+
+        assert constants.OPTIMIZATION_JOB_COMPLETE == "Complete"
+        assert constants.OPTIMIZATION_JOB_FAILED == "Failed"
+        assert constants.OPTIMIZATION_JOB_RUNNING == "Running"
+        assert constants.OPTIMIZATION_JOB_CREATED == "Created"

--- a/kubeflow_mcp/optimizer/constants/__init__.py
+++ b/kubeflow_mcp/optimizer/constants/__init__.py
@@ -1,0 +1,48 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optimizer-specific constants.
+
+Uses ``kubeflow.optimizer.constants.constants`` for CRD group/version/plurals
+so values stay in sync with the SDK. Additional MCP-specific constants
+(controller labels, CRD names) are defined here.
+"""
+
+from kubeflow.optimizer.constants import constants as sdk_constants
+
+# ─── Re-exported from SDK ───────────────────────────────────────────────────
+# Use these instead of hardcoding strings so they track SDK changes.
+
+KATIB_API_GROUP = sdk_constants.GROUP  # "kubeflow.org"
+KATIB_API_VERSION = sdk_constants.VERSION  # "v1beta1"
+EXPERIMENT_PLURAL = sdk_constants.EXPERIMENT_PLURAL  # "experiments"
+EXPERIMENT_KIND = sdk_constants.EXPERIMENT_KIND  # "Experiment"
+
+# The SDK does not expose a Suggestion plural constant, so it is defined here.
+# Used for direct CustomObjectsApi access (list_suggestions, get_suggestion).
+SUGGESTION_PLURAL = "suggestions"
+
+# ─── OptimizationJob status values (from SDK) ──────────────────────────────
+
+OPTIMIZATION_JOB_CREATED = sdk_constants.OPTIMIZATION_JOB_CREATED
+OPTIMIZATION_JOB_RUNNING = sdk_constants.OPTIMIZATION_JOB_RUNNING
+OPTIMIZATION_JOB_COMPLETE = sdk_constants.OPTIMIZATION_JOB_COMPLETE
+OPTIMIZATION_JOB_FAILED = sdk_constants.OPTIMIZATION_JOB_FAILED
+
+# ─── MCP-specific constants ────────────────────────────────────────────────
+# These are not in the SDK and are specific to MCP server's pre-flight checks.
+
+EXPERIMENT_CRD_NAME = f"{EXPERIMENT_PLURAL}.{KATIB_API_GROUP}"
+KATIB_CONTROLLER_LABELS = "katib.kubeflow.org/component=controller"
+KATIB_CONTROLLER_NAMESPACE_DEFAULT = "kubeflow"

--- a/kubeflow_mcp/optimizer/constants/__init__.py
+++ b/kubeflow_mcp/optimizer/constants/__init__.py
@@ -33,6 +33,13 @@ EXPERIMENT_KIND = sdk_constants.EXPERIMENT_KIND  # "Experiment"
 # Used for direct CustomObjectsApi access (list_suggestions, get_suggestion).
 SUGGESTION_PLURAL = "suggestions"
 
+# Katib's integer parameter type. The SDK defines DOUBLE_PARAMETER and
+# CATEGORICAL_PARAMETERS but has no int equivalent, because its ``Search``
+# helpers only emit those two. Katib itself supports "int", and HPO needs it
+# for genuinely discrete ordered ranges (layer counts, batch sizes), so the
+# value is defined here rather than re-exported.
+INT_PARAMETER = "int"
+
 # ─── OptimizationJob status values (from SDK) ──────────────────────────────
 
 OPTIMIZATION_JOB_CREATED = sdk_constants.OPTIMIZATION_JOB_CREATED

--- a/kubeflow_mcp/optimizer/resources/hpo-patterns.md
+++ b/kubeflow_mcp/optimizer/resources/hpo-patterns.md
@@ -1,0 +1,157 @@
+# HPO Workflow Patterns & Algorithm Selection
+
+## Standard workflow
+
+```
+katib_pre_flight() → list_experiments() → create_hpo_experiment(confirmed=False)
+                   → create_hpo_experiment(confirmed=True) → wait_for_experiment()
+                   → get_best_trial()
+```
+
+### 1. Pre-flight
+
+```
+katib_pre_flight()
+```
+
+Verifies the Experiment CRD exists, the Katib controller pod is **Running and
+Ready**, and reports whether the trainer client is loaded. If `blockers` is
+non-empty, stop and surface them — creating an experiment against a broken
+control plane produces an Experiment that is never reconciled.
+
+### 2. Preview, then submit
+
+`create_hpo_experiment` is two-phase. Call it with `confirmed=False` first, show
+the returned `config` (the full Experiment manifest) to the user, and only then
+re-call with `confirmed=True`.
+
+```
+create_hpo_experiment(
+    name="lr-search",
+    objective_metric="accuracy",
+    objective_type="maximize",
+    search_space={
+        "lr": {"min": 0.001, "max": 0.1, "type": "loguniform"},
+        "batch_size": {"choices": [16, 32, 64]},
+    },
+    algorithm="random",
+    max_trial_count=12,
+    parallel_trial_count=3,
+    trial_template={
+        "apiVersion": "trainer.kubeflow.org/v1alpha1",
+        "kind": "TrainJob",
+        "spec": {
+            "runtimeRef": {"name": "torch-distributed"},
+            "trainer": {
+                "image": "my-registry/trainer:latest",
+                "args": [
+                    "--lr=${trialParameters.lr}",
+                    "--batch-size=${trialParameters.batch_size}",
+                ],
+            },
+        },
+    },
+    confirmed=False,
+)
+```
+
+### 3. Monitor
+
+```
+get_experiment_status(name)      # lightweight poll — prefer this
+get_experiment_trials(name)      # trials with params/metrics (limit applies)
+get_experiment_trial_logs(name)  # logs from the best trial so far
+get_experiment_events(name)      # K8s events — scheduling / image pull issues
+```
+
+`wait_for_experiment(name)` blocks the MCP connection until the experiment
+reaches `Complete` or `Failed`. Prefer polling `get_experiment_status()` unless
+the user explicitly wants to wait.
+
+### 4. Results
+
+```
+get_best_trial(name)             # optimal hyperparameters + metrics
+get_successful_trials(name)      # successful trials, for comparison
+```
+
+## `trial_template` — the part that usually goes wrong
+
+`trial_template` is the Katib **trialSpec**: the workload Katib clones once per
+trial. It is *not* a Katib-specific wrapper — it is a complete resource
+manifest with `apiVersion`, `kind` and `spec`.
+
+Every tuned parameter must be referenced with `${trialParameters.<name>}`, and
+the name must match a key in `search_space`. A parameter that is searched but
+never referenced is silently ignored — trials all run with the same config and
+the results look flat.
+
+`create_hpo_experiment` sets `primaryContainerName` to the Trainer's `node`
+container, so the template should describe a **TrainJob**. For a plain
+`batch/v1` Job or another kind, use `create_experiment_from_spec()` and set
+`primaryContainerName` yourself, otherwise metrics are never collected.
+
+Use `list_runtimes()` (trainer client) to find a valid `runtimeRef`.
+
+## Algorithm selection
+
+All algorithms below are available directly from `create_hpo_experiment` via
+the `algorithm=` parameter.
+
+| Algorithm | `algorithm=` | Best for | Notes |
+|---|---|---|---|
+| Random search | `"random"` | Default. Wide spaces, easy parallelism | Strong baseline; scales with `parallel_trial_count` |
+| Grid search | `"grid"` | Small discrete/categorical spaces | Trial count grows multiplicatively — keep the space tiny |
+| Bayesian optimization | `"bayesianoptimization"` | Expensive trials, few parameters | Sequential; low `parallel_trial_count` works best |
+| TPE | `"tpe"` | Mixed continuous + categorical | Good general-purpose sequential choice |
+| Multivariate TPE | `"multivariate-tpe"` | Correlated parameters | Models parameter interactions |
+| CMA-ES | `"cmaes"` | Continuous parameters, few dimensions | Continuous only — no categoricals |
+| Sobol | `"sobol"` | Even coverage of a continuous space | Quasi-random; deterministic sequence |
+| Hyperband | `"hyperband"` | Long trials where early stopping pays | Manages its own budget across brackets |
+
+Rules of thumb: start with `random` to establish a baseline; move to `tpe` or
+`bayesianoptimization` when each trial is expensive; use `grid` only when the
+full cross-product is small enough to enumerate.
+
+## Search space
+
+| Type | Form | Produces |
+|---|---|---|
+| Continuous, uniform | `{"min": 0.5, "max": 0.99}` | `double`, uniform distribution |
+| Continuous, log-scale | `{"min": 1e-5, "max": 1e-1, "type": "loguniform"}` | `double`, logUniform |
+| Categorical | `{"choices": [16, 32, 64]}` | `categorical` (values are stringified) |
+
+`uniform` is the default when `type` is omitted. Use `loguniform` for anything
+spanning orders of magnitude — learning rates and weight decay especially;
+a uniform range from 1e-5 to 1e-1 spends 90% of its samples above 0.01.
+
+## Budget and response limits
+
+- `max_trial_count` is required, capped at **1000**
+- `parallel_trial_count` capped at **100**
+- `max_failed_trials` optional — the experiment fails once it is exceeded
+- Collection tools accept `limit` (default **50**, max **500**). `total` always
+  reports the true count, so compare the two to detect truncation.
+
+Trial pods are retained (`retain=true`) so logs remain readable after a trial
+finishes. A large experiment therefore leaves one pod per trial behind — keep
+`max_trial_count` proportionate and clean up with `delete_experiment()`.
+
+## Beyond `create_hpo_experiment`
+
+Use `create_experiment_from_spec()` for anything the flat parameters do not
+model — **early stopping** (e.g. `medianstop`), custom metrics collectors,
+resume policies, or NAS. It takes a complete `V1beta1Experiment` manifest,
+validates it against the Katib schema, and applies the same preview/confirm
+flow. It is restricted to the `ml-engineer` persona and above.
+
+## Cross-client: optimize, then train
+
+```
+best = get_best_trial("lr-search")
+# best["parameters"] -> {"lr": "0.0123", "batch_size": "32"}
+# feed those into fine_tune() or run_custom_training()
+```
+
+Parameter values arrive as **strings** (Katib stores them that way); cast them
+before use in a typed training API.

--- a/kubeflow_mcp/optimizer/resources/hpo-patterns.md
+++ b/kubeflow_mcp/optimizer/resources/hpo-patterns.md
@@ -119,11 +119,27 @@ full cross-product is small enough to enumerate.
 |---|---|---|
 | Continuous, uniform | `{"min": 0.5, "max": 0.99}` | `double`, uniform distribution |
 | Continuous, log-scale | `{"min": 1e-5, "max": 1e-1, "type": "loguniform"}` | `double`, logUniform |
+| Discrete range | `{"min": 2, "max": 8, "type": "int"}` | `int`, uniform distribution |
 | Categorical | `{"choices": [16, 32, 64]}` | `categorical` (values are stringified) |
 
 `uniform` is the default when `type` is omitted. Use `loguniform` for anything
 spanning orders of magnitude — learning rates and weight decay especially;
 a uniform range from 1e-5 to 1e-1 spends 90% of its samples above 0.01.
+
+Use `int` for whole numbers with a meaningful order (layer counts, batch sizes,
+epochs). `min`, `max` and the optional `step` must all be integers. Reaching for
+`choices` instead throws the ordering away: categorical values are unordered, so
+the algorithm cannot learn that 4 sits between 2 and 8. Keep `choices` for
+genuinely unordered options such as optimizer names or activation functions.
+
+## Metrics collection
+
+`primary_container_name` names the container Katib collects metrics from, and it
+is derived from `trial_template`: the container in the template's pod spec, or
+`node` when the template has none (a `TrainJob`). Set it explicitly only when the
+metric-producing container is not the one that gets picked, such as a pod whose
+first container is a sidecar. A name matching no container in the trial pod
+collects nothing, and the experiment stalls without an error.
 
 ## Budget and response limits
 

--- a/kubeflow_mcp/optimizer/resources/troubleshooting.md
+++ b/kubeflow_mcp/optimizer/resources/troubleshooting.md
@@ -1,0 +1,86 @@
+# Katib Troubleshooting Guide
+
+## Start here
+
+```
+katib_pre_flight()          # CRD present? controller Running AND Ready?
+get_experiment_status(name) # experiment-level state + trial counts
+get_experiment_events(name) # K8s events: scheduling, image pull, quota
+get_suggestion(name)        # algorithm state when trials never appear
+```
+
+## Control-plane problems
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Katib Experiment CRD not found` | Katib not installed | `kubectl apply -k "github.com/kubeflow/katib.git/manifests/v1beta1/installs/katib-standalone?ref=v0.19.0"` |
+| `Katib controller pod not found` | Wrong namespace, or install incomplete | `kubectl get pods -A -l katib.kubeflow.org/component=controller` |
+| **`Running but not Ready`** | Controller cannot watch its CRDs — almost always missing RBAC | Verify `kubectl get clusterrole katib-controller`. Installing Katib as a non-cluster-admin silently skips ClusterRoles: Kubernetes refuses to let a user grant permissions it does not itself hold. Re-apply the manifests as cluster-admin. |
+| Controller `CrashLoopBackOff` | Config error or OOM | `kubectl logs -n kubeflow -l katib.kubeflow.org/component=controller` |
+| `katib-db-manager` CrashLoopBackOff | Cannot reach `katib-mysql` | Check the MySQL pod and its PVC — a `Pending` PVC means no storage class could bind |
+
+A controller in phase `Running` is **not** proof of health; `katib_pre_flight`
+checks container readiness for this reason and reports `controller_ready`.
+
+## Experiment problems
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Experiment 'x' already exists` | Name collision | Pick another name, or `delete_experiment(name, confirmed=True)`. Reported as a validation error — it does not trip the circuit breaker |
+| `Namespace 'x' not allowed by policy` | Namespace outside the server's allowlist | Pass an allowed `namespace=`, or run the server without the restriction |
+| `Experiment 'x' was not created by MCP` | Non-admin persona touching an external experiment | Expected. `data-scientist`/`ml-engineer` may only mutate MCP-created experiments; use `platform-admin` |
+| Stuck in `Created`, no trials | Suggestion not ready, or the trial template is invalid | `get_suggestion(name)` for algorithm state, then `get_experiment_events(name)` |
+| All trials fail immediately | Bad image, bad command, or unresolvable `runtimeRef` | `get_experiment_trial_logs(name)`; failure patterns (OOM, missing module, permissions) are auto-detected and returned in `failure_hint` |
+| Trials run but no metrics | The objective metric name does not match what the script prints, or `primaryContainerName` is wrong for the trial kind | Ensure the script emits the metric named in `objective_metric`; for non-TrainJob templates use `create_experiment_from_spec()` |
+| Results look flat / identical | A searched parameter is never referenced in the template | Every `search_space` key needs a `${trialParameters.<key>}` reference in `trial_template` |
+| `Timeout after Ns` from `wait_for_experiment` | Trials slower than the timeout | Not a failure — the experiment is still running. Poll `get_experiment_status()`, or raise `timeout_seconds` (max 3600) |
+
+## Status values
+
+Experiment status and trial status come from **different** sources — do not
+filter one with the other's vocabulary.
+
+**Experiment** (`get_experiment_status`, `list_experiments`):
+
+| Status | Meaning |
+|---|---|
+| `Created` | Accepted; no trials running yet |
+| `Running` | Trials executing |
+| `Complete` | Finished; best result available |
+| `Failed` | Failed (e.g. `max_failed_trials` exceeded) |
+
+**Trial** (`get_experiment_trials`, `get_trial`) — derived from the underlying
+TrainJob, so it uses TrainJob vocabulary: `Created`, `Running`, `Complete`,
+`Failed`, `Suspended`.
+
+Filter succeeded trials with `status="Complete"`, **not** `"Succeeded"`.
+`list_experiments(status="Succeeded")` is accepted as an alias for `Complete`
+at the experiment level, but `get_experiment_trials` has no such alias.
+
+## No best trial available
+
+`get_best_trial` returns `best_trial: null` rather than an error when Katib has
+not yet recorded an optimal trial. Check in order:
+
+1. `get_experiment_status(name)` — still `Created`/`Running`? Nothing to report yet.
+2. `get_experiment_trials(name, status="Complete")` — any trial actually finished?
+3. `get_experiment_trial_logs(name)` — is the objective metric being printed at all?
+
+If trials complete but no metrics are recorded, the metrics collector is not
+seeing the output — verify the metric name and the primary container.
+
+## Suspend and resume
+
+`update_experiment(name, action="suspend")` sets `parallelTrialCount` to 0;
+running trials finish, no new ones start. The previous value is saved to the
+`kubeflow-mcp/pre-suspend-parallel-trial-count` annotation and restored on
+`action="resume"`. Suspending an already-suspended experiment is a no-op.
+
+If someone edits `parallelTrialCount` by hand while suspended, resume restores
+the **annotated** value, not the hand-edited one.
+
+## Cleanup
+
+`delete_experiment(name, confirmed=True)` removes the experiment along with its
+trials and suggestion. It is irreversible — the first call returns a preview.
+Retained trial pods are removed with the experiment.

--- a/kubeflow_mcp/optimizer/types/__init__.py
+++ b/kubeflow_mcp/optimizer/types/__init__.py
@@ -316,11 +316,69 @@ def trial_counts_from_cr(status: dict[str, Any]) -> dict[str, int]:
     Preferred over deriving counts from ``OptimizationJob.trials``: Katib tracks
     ``trialsEarlyStopped`` here, a state that never appears on the underlying
     TrainJob and is therefore invisible to the SDK view.
+
+    Counters Katib has not published are omitted rather than reported as zero,
+    so callers that need a stable set of keys should seed their own defaults
+    (see :func:`experiment_summary_from_cr`).
     """
     return {
         key: int(status[field])
         for field, key in _CR_TRIAL_COUNTERS.items()
         if isinstance(status.get(field), int)
+    }
+
+
+def experiment_summary_from_cr(item: dict[str, Any]) -> dict[str, Any]:
+    """Summarize a raw Experiment CR, matching :func:`experiment_summary`'s shape.
+
+    Lets ``list_experiments`` read the Experiment list in a single API call
+    instead of going through ``OptimizerClient.list_jobs()``, which resolves
+    every trial's TrainJob individually. Everything a summary needs is already
+    on the CR.
+
+    The four SDK-derived counters are seeded to 0 before the CR's own counters
+    are applied: Katib omits them entirely until trials exist, and dropping keys
+    the SDK path always emitted would be a silent contract change. Counters only
+    the CR knows about (pending, killed, early stopped) are additive.
+    """
+    metadata = item.get("metadata") or {}
+    status = item.get("status") or {}
+
+    data: dict[str, Any] = {
+        "name": metadata.get("name"),
+        "status": experiment_phase(status),
+        # Left as the raw RFC3339 string Kubernetes emits, as with the
+        # lastTransitionTime values in conditions_to_list.
+        "creation_timestamp": metadata.get("creationTimestamp"),
+        "total_trials": 0,
+        "running_trials": 0,
+        "succeeded_trials": 0,
+        "failed_trials": 0,
+    }
+    data.update(trial_counts_from_cr(status))
+    return data
+
+
+def suggestion_to_dict(item: dict[str, Any]) -> dict[str, Any]:
+    """Serialize a raw Suggestion CR from ``CustomObjectsApi``.
+
+    Shared by ``list_suggestions`` and ``get_suggestion`` so both describe the
+    same resource with the same field names. They previously carried separate
+    serializers that disagreed: one emitted a single ``condition``, the other a
+    ``conditions`` list.
+    """
+    metadata = item.get("metadata") or {}
+    spec = item.get("spec") or {}
+    status = item.get("status") or {}
+    return {
+        "name": metadata.get("name"),
+        "algorithm": (spec.get("algorithm") or {}).get("algorithmName"),
+        "requests": spec.get("requests"),
+        "suggestion_count": status.get("suggestionCount"),
+        "conditions": [
+            {"type": c.get("type"), "status": c.get("status"), "reason": c.get("reason")}
+            for c in (status.get("conditions") or [])
+        ],
     }
 
 

--- a/kubeflow_mcp/optimizer/types/__init__.py
+++ b/kubeflow_mcp/optimizer/types/__init__.py
@@ -1,0 +1,299 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optimizer-specific type helpers.
+
+Serializers that convert kubeflow.optimizer SDK dataclasses
+(``OptimizationJob``, ``Trial``, ``Result``, ``Metric``, ``Objective``,
+search-space objects, ``Event``) into plain JSON-serializable dicts for
+MCP tool responses.
+
+Kept here (rather than inline in api/*.py) so discovery and monitoring
+tools produce identical field names for the same SDK objects.
+"""
+
+from typing import Any
+
+from kubeflow_mcp.common.constants import JobStatus
+
+# Trial status comes from the Trial's underlying TrainJob (``trial.trainjob.status``),
+# so these are TrainJob statuses — not the OptimizationJob statuses in
+# optimizer/constants. ``POD_SUCCEEDED`` is tolerated defensively because pod-level
+# phase and TrainJob completion are reported with different words.
+_SUCCESS_STATUSES = {JobStatus.COMPLETE, JobStatus.POD_SUCCEEDED}
+_FAILED_STATUSES = {JobStatus.FAILED}
+_RUNNING_STATUSES = {JobStatus.RUNNING}
+
+
+def _enum_value(value: Any) -> Any:
+    """Return ``value.value`` for enums, otherwise the value unchanged."""
+    return getattr(value, "value", value)
+
+
+def _isoformat(value: Any) -> str | None:
+    """Best-effort ISO-8601 string for datetime-like values."""
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def metric_to_dict(metric: Any) -> dict[str, Any]:
+    """Serialize an optimizer ``Metric`` (name, min, max, latest)."""
+    return {
+        "name": getattr(metric, "name", None),
+        "min": getattr(metric, "min", None),
+        "max": getattr(metric, "max", None),
+        "latest": getattr(metric, "latest", None),
+    }
+
+
+def metrics_to_list(metrics: Any) -> list[dict[str, Any]]:
+    """Serialize a list of ``Metric`` objects."""
+    return [metric_to_dict(m) for m in (metrics or [])]
+
+
+def trial_status(trial: Any) -> str:
+    """Derive a trial's status from its underlying TrainJob.
+
+    The optimizer ``Trial`` dataclass has no status field of its own; the
+    execution state lives on ``trial.trainjob.status``.
+    """
+    trainjob = getattr(trial, "trainjob", None)
+    return getattr(trainjob, "status", None) or "Unknown"
+
+
+def trial_to_dict(trial: Any) -> dict[str, Any]:
+    """Serialize an optimizer ``Trial`` (name, parameters, metrics, status)."""
+    trainjob = getattr(trial, "trainjob", None)
+    return {
+        "name": getattr(trial, "name", None),
+        "status": trial_status(trial),
+        "parameters": dict(getattr(trial, "parameters", {}) or {}),
+        "metrics": metrics_to_list(getattr(trial, "metrics", None)),
+        "trainjob": getattr(trainjob, "name", None),
+    }
+
+
+def objective_to_dict(objective: Any) -> dict[str, Any]:
+    """Serialize an ``Objective`` (metric + direction enum)."""
+    return {
+        "metric": getattr(objective, "metric", None),
+        "direction": _enum_value(getattr(objective, "direction", None)),
+    }
+
+
+def search_space_entry_to_dict(space: Any) -> dict[str, Any]:
+    """Serialize a single search-space entry.
+
+    Handles both ``ContinuousSearchSpace`` (min/max/distribution) and
+    ``CategoricalSearchSpace`` (choices).
+    """
+    if hasattr(space, "choices"):
+        return {"type": "categorical", "choices": list(space.choices or [])}
+    if hasattr(space, "min") and hasattr(space, "max"):
+        return {
+            "type": "continuous",
+            "min": space.min,
+            "max": space.max,
+            "distribution": _enum_value(getattr(space, "distribution", None)),
+        }
+    return {"type": "unknown", "value": str(space)}
+
+
+def search_space_to_dict(search_space: Any) -> dict[str, Any]:
+    """Serialize the ``dict[str, SearchSpace]`` map on an OptimizationJob."""
+    if not search_space:
+        return {}
+    return {name: search_space_entry_to_dict(space) for name, space in search_space.items()}
+
+
+def algorithm_to_dict(algorithm: Any) -> dict[str, Any]:
+    """Serialize an algorithm object (RandomSearch / GridSearch)."""
+    if algorithm is None:
+        return {}
+    data: dict[str, Any] = {"name": type(algorithm).__name__}
+    random_state = getattr(algorithm, "random_state", None)
+    if random_state is not None:
+        data["random_state"] = random_state
+    return data
+
+
+def trial_counts(job: Any) -> dict[str, int]:
+    """Aggregate trial counts by status for an OptimizationJob."""
+    trials = getattr(job, "trials", None) or []
+    running = succeeded = failed = 0
+    for trial in trials:
+        status = trial_status(trial)
+        if status in _SUCCESS_STATUSES:
+            succeeded += 1
+        elif status in _FAILED_STATUSES:
+            failed += 1
+        elif status in _RUNNING_STATUSES:
+            running += 1
+    return {
+        "total_trials": len(trials),
+        "running_trials": running,
+        "succeeded_trials": succeeded,
+        "failed_trials": failed,
+    }
+
+
+def trial_config_to_dict(trial_config: Any) -> dict[str, Any]:
+    """Serialize a ``TrialConfig`` (num_trials, parallel_trials, max_failed_trials)."""
+    if trial_config is None:
+        return {}
+    return {
+        "num_trials": getattr(trial_config, "num_trials", None),
+        "parallel_trials": getattr(trial_config, "parallel_trials", None),
+        "max_failed_trials": getattr(trial_config, "max_failed_trials", None),
+    }
+
+
+def experiment_summary(job: Any) -> dict[str, Any]:
+    """Serialize an OptimizationJob to a compact summary (for list views)."""
+    data: dict[str, Any] = {
+        "name": getattr(job, "name", None),
+        "status": getattr(job, "status", None) or "Unknown",
+        "creation_timestamp": _isoformat(getattr(job, "creation_timestamp", None)),
+    }
+    data.update(trial_counts(job))
+    return data
+
+
+def experiment_to_dict(job: Any) -> dict[str, Any]:
+    """Serialize an OptimizationJob to full detail (for get views)."""
+    data = experiment_summary(job)
+    data["objectives"] = [objective_to_dict(o) for o in (getattr(job, "objectives", None) or [])]
+    data["algorithm"] = algorithm_to_dict(getattr(job, "algorithm", None))
+    data["search_space"] = search_space_to_dict(getattr(job, "search_space", None))
+    data["trial_config"] = trial_config_to_dict(getattr(job, "trial_config", None))
+    return data
+
+
+def result_to_dict(result: Any) -> dict[str, Any] | None:
+    """Serialize a ``Result`` (best parameters + metrics), or None."""
+    if result is None:
+        return None
+    return {
+        "parameters": dict(getattr(result, "parameters", {}) or {}),
+        "metrics": metrics_to_list(getattr(result, "metrics", None)),
+    }
+
+
+def event_to_dict(event: Any) -> dict[str, Any]:
+    """Serialize a trainer/optimizer ``Event`` object."""
+    return {
+        "involved_object_kind": getattr(event, "involved_object_kind", "") or "",
+        "involved_object_name": getattr(event, "involved_object_name", "") or "",
+        "reason": getattr(event, "reason", "") or "",
+        "message": getattr(event, "message", "") or "",
+        "event_time": _isoformat(getattr(event, "event_time", None)) or "",
+    }
+
+
+def is_success_status(status: str | None) -> bool:
+    """Return True if a status string denotes a successful/complete trial."""
+    return status in _SUCCESS_STATUSES
+
+
+# ─── Experiment CR (raw) ───────────────────────────────────────────────────
+# OptimizationJob does not expose conditions, the current optimal trial, or the
+# early-stopping spec, so these read the Experiment custom resource directly.
+# Field names follow the v1beta1 wire format (camelCase) as generated in
+# kubeflow_katib_api.models.
+
+# status counters -> the response key each maps to
+_CR_TRIAL_COUNTERS = {
+    "trials": "total_trials",
+    "trialsSucceeded": "succeeded_trials",
+    "trialsFailed": "failed_trials",
+    "trialsRunning": "running_trials",
+    "trialsPending": "pending_trials",
+    "trialsKilled": "killed_trials",
+    "trialsEarlyStopped": "early_stopped_trials",
+}
+
+
+def cr_conditions(status: dict[str, Any]) -> list[dict[str, Any]]:
+    """Serialize ``status.conditions`` from an Experiment CR.
+
+    Conditions carry the reason an experiment failed or stalled, which is the
+    detail agents need and which ``OptimizationJob`` drops entirely.
+    """
+    return [
+        {
+            "type": c.get("type"),
+            "status": c.get("status"),
+            "reason": c.get("reason"),
+            "message": c.get("message"),
+            "last_transition_time": c.get("lastTransitionTime"),
+        }
+        for c in (status.get("conditions") or [])
+    ]
+
+
+def cr_optimal_trial(status: dict[str, Any]) -> dict[str, Any] | None:
+    """Serialize ``status.currentOptimalTrial``, or None when unset.
+
+    Katib leaves the name empty until a trial has produced metrics, so an
+    object with no ``bestTrialName`` is reported as "no best trial yet".
+    """
+    optimal = status.get("currentOptimalTrial") or {}
+    name = optimal.get("bestTrialName")
+    if not name:
+        return None
+    return {
+        "name": name,
+        "parameters": {
+            pa.get("name"): pa.get("value")
+            for pa in (optimal.get("parameterAssignments") or [])
+            if pa.get("name") is not None
+        },
+        "metrics": [
+            {
+                "name": m.get("name"),
+                "min": m.get("min"),
+                "max": m.get("max"),
+                "latest": m.get("latest"),
+            }
+            for m in ((optimal.get("observation") or {}).get("metrics") or [])
+        ],
+    }
+
+
+def cr_trial_counts(status: dict[str, Any]) -> dict[str, int]:
+    """Trial counts as reported by the Experiment CR itself.
+
+    Preferred over deriving counts from ``OptimizationJob.trials``: Katib tracks
+    ``trialsEarlyStopped`` here, a state that never appears on the underlying
+    TrainJob and is therefore invisible to the SDK view.
+    """
+    return {
+        key: int(status[field])
+        for field, key in _CR_TRIAL_COUNTERS.items()
+        if isinstance(status.get(field), int)
+    }
+
+
+def cr_early_stopping(spec: dict[str, Any]) -> dict[str, Any] | None:
+    """Serialize ``spec.earlyStopping``, or None when not configured."""
+    early = spec.get("earlyStopping") or {}
+    if not early:
+        return None
+    return {
+        "algorithm": early.get("algorithmName"),
+        "settings": {s.get("name"): s.get("value") for s in (early.get("algorithmSettings") or [])},
+    }

--- a/kubeflow_mcp/optimizer/types/__init__.py
+++ b/kubeflow_mcp/optimizer/types/__init__.py
@@ -26,6 +26,16 @@ tools produce identical field names for the same SDK objects.
 from typing import Any
 
 from kubeflow_mcp.common.constants import JobStatus
+from kubeflow_mcp.optimizer.constants import (
+    OPTIMIZATION_JOB_COMPLETE,
+    OPTIMIZATION_JOB_CREATED,
+    OPTIMIZATION_JOB_FAILED,
+    OPTIMIZATION_JOB_RUNNING,
+)
+
+# Katib spells the success condition on the Experiment CR "Succeeded", while the
+# SDK reports the resulting job status as "Complete".
+_CR_CONDITION_SUCCEEDED = "Succeeded"
 
 # Trial status comes from the Trial's underlying TrainJob (``trial.trainjob.status``),
 # so these are TrainJob statuses — not the OptimizationJob statuses in
@@ -131,7 +141,7 @@ def algorithm_to_dict(algorithm: Any) -> dict[str, Any]:
     return data
 
 
-def trial_counts(job: Any) -> dict[str, int]:
+def trial_counts_from_job(job: Any) -> dict[str, int]:
     """Aggregate trial counts by status for an OptimizationJob."""
     trials = getattr(job, "trials", None) or []
     running = succeeded = failed = 0
@@ -169,7 +179,7 @@ def experiment_summary(job: Any) -> dict[str, Any]:
         "status": getattr(job, "status", None) or "Unknown",
         "creation_timestamp": _isoformat(getattr(job, "creation_timestamp", None)),
     }
-    data.update(trial_counts(job))
+    data.update(trial_counts_from_job(job))
     return data
 
 
@@ -227,7 +237,33 @@ _CR_TRIAL_COUNTERS = {
 }
 
 
-def cr_conditions(status: dict[str, Any]) -> list[dict[str, Any]]:
+def experiment_phase(status: dict[str, Any]) -> str:
+    """Derive the OptimizationJob status string from Experiment CR status.
+
+    Mirrors the SDK's own derivation in
+    ``kubeflow.optimizer.backends.kubernetes.backend.__get_optimization_job_from_cr``
+    so a CR-sourced status matches what ``OptimizerClient.get_job()`` reports:
+    a true ``Succeeded`` condition means Complete, a true ``Failed`` condition
+    means Failed, otherwise Running if any trial is running, else Created.
+
+    The SDK checks each trial's TrainJob for the running case; the CR's own
+    ``trialsRunning`` counter carries the same information without fetching
+    every trial.
+    """
+    for condition in status.get("conditions") or []:
+        if condition.get("status") != "True":
+            continue
+        if condition.get("type") == _CR_CONDITION_SUCCEEDED:
+            return OPTIMIZATION_JOB_COMPLETE
+        if condition.get("type") == OPTIMIZATION_JOB_FAILED:
+            return OPTIMIZATION_JOB_FAILED
+
+    if status.get("trialsRunning"):
+        return OPTIMIZATION_JOB_RUNNING
+    return OPTIMIZATION_JOB_CREATED
+
+
+def conditions_to_list(status: dict[str, Any]) -> list[dict[str, Any]]:
     """Serialize ``status.conditions`` from an Experiment CR.
 
     Conditions carry the reason an experiment failed or stalled, which is the
@@ -245,7 +281,7 @@ def cr_conditions(status: dict[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
-def cr_optimal_trial(status: dict[str, Any]) -> dict[str, Any] | None:
+def optimal_trial_to_dict(status: dict[str, Any]) -> dict[str, Any] | None:
     """Serialize ``status.currentOptimalTrial``, or None when unset.
 
     Katib leaves the name empty until a trial has produced metrics, so an
@@ -274,7 +310,7 @@ def cr_optimal_trial(status: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
-def cr_trial_counts(status: dict[str, Any]) -> dict[str, int]:
+def trial_counts_from_cr(status: dict[str, Any]) -> dict[str, int]:
     """Trial counts as reported by the Experiment CR itself.
 
     Preferred over deriving counts from ``OptimizationJob.trials``: Katib tracks
@@ -288,7 +324,7 @@ def cr_trial_counts(status: dict[str, Any]) -> dict[str, int]:
     }
 
 
-def cr_early_stopping(spec: dict[str, Any]) -> dict[str, Any] | None:
+def early_stopping_to_dict(spec: dict[str, Any]) -> dict[str, Any] | None:
     """Serialize ``spec.earlyStopping``, or None when not configured."""
     early = spec.get("earlyStopping") or {}
     if not early:

--- a/kubeflow_mcp/optimizer/types_test.py
+++ b/kubeflow_mcp/optimizer/types_test.py
@@ -106,7 +106,7 @@ def test_trial_counts():
             _trial("d", "Created"),  # neither running/succeeded/failed
         ]
     )
-    assert ser.trial_counts(job) == {
+    assert ser.trial_counts_from_job(job) == {
         "total_trials": 4,
         "running_trials": 1,
         "succeeded_trials": 1,

--- a/kubeflow_mcp/optimizer/types_test.py
+++ b/kubeflow_mcp/optimizer/types_test.py
@@ -1,0 +1,175 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for optimizer SDK→dict serializers."""
+
+from datetime import datetime, timezone
+from enum import Enum
+from types import SimpleNamespace
+
+from kubeflow_mcp.optimizer import types as ser
+
+
+class _Direction(Enum):
+    MAXIMIZE = "maximize"
+
+
+def _metric(name="acc", latest="0.9"):
+    return SimpleNamespace(name=name, min="0.5", max="0.9", latest=latest)
+
+
+def _trial(name, status="Complete"):
+    return SimpleNamespace(
+        name=name,
+        parameters={"lr": "0.01"},
+        trainjob=SimpleNamespace(name=f"{name}-job", status=status),
+        metrics=[_metric()],
+    )
+
+
+def test_metric_to_dict():
+    assert ser.metric_to_dict(_metric()) == {
+        "name": "acc",
+        "min": "0.5",
+        "max": "0.9",
+        "latest": "0.9",
+    }
+
+
+def test_trial_status_from_trainjob():
+    assert ser.trial_status(_trial("t1", "Running")) == "Running"
+    # Missing trainjob → Unknown, not a crash.
+    assert ser.trial_status(SimpleNamespace(trainjob=None)) == "Unknown"
+
+
+def test_trial_to_dict():
+    d = ser.trial_to_dict(_trial("t1", "Complete"))
+    assert d["name"] == "t1"
+    assert d["status"] == "Complete"
+    assert d["parameters"] == {"lr": "0.01"}
+    assert d["trainjob"] == "t1-job"
+    assert d["metrics"][0]["name"] == "acc"
+
+
+def test_objective_to_dict_unwraps_enum():
+    obj = SimpleNamespace(metric="accuracy", direction=_Direction.MAXIMIZE)
+    assert ser.objective_to_dict(obj) == {"metric": "accuracy", "direction": "maximize"}
+
+
+def test_search_space_continuous():
+    space = SimpleNamespace(min=0.001, max=0.1, distribution=SimpleNamespace(value="uniform"))
+    out = ser.search_space_entry_to_dict(space)
+    assert out == {"type": "continuous", "min": 0.001, "max": 0.1, "distribution": "uniform"}
+
+
+def test_search_space_categorical():
+    space = SimpleNamespace(choices=[16, 32, 64])
+    assert ser.search_space_entry_to_dict(space) == {
+        "type": "categorical",
+        "choices": [16, 32, 64],
+    }
+
+
+def test_search_space_to_dict_map():
+    spaces = {"lr": SimpleNamespace(choices=[1, 2])}
+    assert ser.search_space_to_dict(spaces) == {"lr": {"type": "categorical", "choices": [1, 2]}}
+    assert ser.search_space_to_dict(None) == {}
+
+
+def test_algorithm_to_dict():
+    assert ser.algorithm_to_dict(SimpleNamespace(random_state=42)) == {
+        "name": "SimpleNamespace",
+        "random_state": 42,
+    }
+    # random_state None is omitted.
+    assert ser.algorithm_to_dict(SimpleNamespace(random_state=None)) == {"name": "SimpleNamespace"}
+    assert ser.algorithm_to_dict(None) == {}
+
+
+def test_trial_counts():
+    job = SimpleNamespace(
+        trials=[
+            _trial("a", "Complete"),
+            _trial("b", "Running"),
+            _trial("c", "Failed"),
+            _trial("d", "Created"),  # neither running/succeeded/failed
+        ]
+    )
+    assert ser.trial_counts(job) == {
+        "total_trials": 4,
+        "running_trials": 1,
+        "succeeded_trials": 1,
+        "failed_trials": 1,
+    }
+
+
+def test_trial_config_to_dict():
+    tc = SimpleNamespace(num_trials=10, parallel_trials=2, max_failed_trials=3)
+    assert ser.trial_config_to_dict(tc) == {
+        "num_trials": 10,
+        "parallel_trials": 2,
+        "max_failed_trials": 3,
+    }
+    assert ser.trial_config_to_dict(None) == {}
+
+
+def test_experiment_summary_and_full():
+    job = SimpleNamespace(
+        name="exp",
+        status="Running",
+        creation_timestamp=datetime(2026, 7, 21, tzinfo=timezone.utc),
+        trials=[_trial("t1")],
+        objectives=[SimpleNamespace(metric="acc", direction=_Direction.MAXIMIZE)],
+        algorithm=SimpleNamespace(random_state=None),
+        search_space={},
+        trial_config=SimpleNamespace(num_trials=1, parallel_trials=1, max_failed_trials=None),
+    )
+    summary = ser.experiment_summary(job)
+    assert summary["name"] == "exp"
+    assert summary["total_trials"] == 1
+    assert summary["creation_timestamp"].startswith("2026-07-21")
+
+    full = ser.experiment_to_dict(job)
+    assert full["objectives"][0]["direction"] == "maximize"
+    assert "trial_config" in full
+    assert "search_space" in full
+
+
+def test_result_to_dict():
+    assert ser.result_to_dict(None) is None
+    result = SimpleNamespace(parameters={"lr": "0.01"}, metrics=[_metric()])
+    out = ser.result_to_dict(result)
+    assert out["parameters"] == {"lr": "0.01"}
+    assert out["metrics"][0]["name"] == "acc"
+
+
+def test_event_to_dict():
+    ev = SimpleNamespace(
+        involved_object_kind="Pod",
+        involved_object_name="exp-trial-0",
+        reason="Scheduled",
+        message="assigned",
+        event_time=datetime(2026, 7, 21, tzinfo=timezone.utc),
+    )
+    out = ser.event_to_dict(ev)
+    assert out["involved_object_kind"] == "Pod"
+    assert out["reason"] == "Scheduled"
+    assert out["event_time"].startswith("2026-07-21")
+
+
+def test_is_success_status():
+    assert ser.is_success_status("Complete") is True
+    assert ser.is_success_status("Succeeded") is True
+    assert ser.is_success_status("Failed") is False
+    assert ser.is_success_status(None) is False

--- a/kubeflow_mcp/trainer/api/architecture_test.py
+++ b/kubeflow_mcp/trainer/api/architecture_test.py
@@ -382,9 +382,34 @@ class TestResourceLoading:
 
 
 class TestPhaseToSection:
-    def test_all_phases_mapped(self):
-        for phase in TOOL_PHASES:
-            assert phase in PHASE_TO_SECTION, f"Phase '{phase}' not in PHASE_TO_SECTION"
+    def test_all_trainer_phases_mapped(self):
+        """Each client maps only its own phases.
+
+        TOOL_PHASES is global and also carries other clients' phases (e.g. the
+        optimizer's), so assert against the phases this client actually owns
+        rather than every key in the registry.
+        """
+        trainer_phases = {TOOL_TO_PHASE[t.__name__] for t in TOOLS if t.__name__ in TOOL_TO_PHASE}
+        unmapped = trainer_phases - set(PHASE_TO_SECTION)
+        assert not unmapped, f"Trainer phases missing from PHASE_TO_SECTION: {unmapped}"
+
+    def test_every_phase_belongs_to_some_client(self):
+        """No phase may be orphaned: every entry in the global registry must be
+        claimed by a loaded client's PHASE_TO_SECTION."""
+        import importlib
+
+        from kubeflow_mcp.core.server import CLIENT_MODULES
+
+        claimed: set[str] = set()
+        for path in CLIENT_MODULES.values():
+            try:
+                mod = importlib.import_module(path)
+            except ImportError:
+                continue
+            claimed |= set(getattr(mod, "PHASE_TO_SECTION", {}))
+
+        orphaned = set(TOOL_PHASES) - claimed - {"health"}
+        assert not orphaned, f"Phases not claimed by any client: {orphaned}"
 
     def test_discovery_maps_to_none(self):
         assert PHASE_TO_SECTION["discovery"] is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ dependencies = [
     "pyyaml>=6.0",
     "click>=8.0",
     "kubeflow==0.4.1",
+    # Imported directly by the optimizer client to build V1beta1Experiment CRs.
+    # Ships as a dependency of `kubeflow`, but declared here because we import
+    # it ourselves rather than only reaching it through the SDK.
+    "kubeflow-katib-api>=0.19.0",
     "huggingface-hub>=0.20",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,12 @@ dependencies = [
     # it ourselves rather than only reaching it through the SDK.
     "kubeflow-katib-api>=0.19.0",
     "huggingface-hub>=0.20",
+    # Arrives transitively via `kubeflow`, but constrained here: 36.0.0 and
+    # 36.0.1 look up the bearer token under a different api_key than the
+    # kubeconfig and in-cluster loaders write it to, so no Authorization header
+    # is sent and every call fails with a bare 401. Fixed in 36.0.2.
+    # https://github.com/kubernetes-client/python/issues/2595
+    "kubernetes!=36.0.0,!=36.0.1",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1544,6 +1544,7 @@ dependencies = [
     { name = "fastmcp" },
     { name = "huggingface-hub" },
     { name = "kubeflow" },
+    { name = "kubeflow-katib-api" },
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
@@ -1592,6 +1593,7 @@ requires-dist = [
     { name = "kubeflow", extras = ["hub"], marker = "extra == 'hub'", specifier = "==0.4.1" },
     { name = "kubeflow", extras = ["spark"], marker = "extra == 'all'", specifier = "==0.4.1" },
     { name = "kubeflow", extras = ["spark"], marker = "extra == 'spark'", specifier = "==0.4.1" },
+    { name = "kubeflow-katib-api", specifier = ">=0.19.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1545,6 +1545,7 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "kubeflow" },
     { name = "kubeflow-katib-api" },
+    { name = "kubernetes" },
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
@@ -1594,6 +1595,7 @@ requires-dist = [
     { name = "kubeflow", extras = ["spark"], marker = "extra == 'all'", specifier = "==0.4.1" },
     { name = "kubeflow", extras = ["spark"], marker = "extra == 'spark'", specifier = "==0.4.1" },
     { name = "kubeflow-katib-api", specifier = ">=0.19.0" },
+    { name = "kubernetes", specifier = "!=36.0.0,!=36.0.1" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]


### PR DESCRIPTION
## Description

Implements the Katib optimizer client from KEP-34: 17 MCP tools for experiment
planning, discovery, monitoring, creation and lifecycle.

> [!NOTE]
> Stacked on #157. That PR is the first commit here and drops out of this diff
> once it merges. Review #157 first.

| Phase | Tools |
|---|---|
| Planning | `katib_pre_flight` |
| Discovery | `list_experiments`, `get_experiment`, `get_experiment_status`, `get_trial`, `get_successful_trials`, `list_suggestions` |
| Monitoring | `get_experiment_trials`, `get_best_trial`, `get_suggestion`, `wait_for_experiment`, `get_experiment_trial_logs`, `get_experiment_events` |
| Optimization | `create_hpo_experiment`, `create_experiment_from_spec` |
| Lifecycle | `delete_experiment`, `update_experiment` |

**Key decisions**

- `OptimizerClient.optimize()` is unusable from MCP, so both creation tools build the `V1beta1Experiment` CR directly. This also reaches all 8 Katib algorithms instead of the 2 the SDK's typed classes express.
- `update_experiment` pauses via `spec.parallelTrialCount = 0`, not `spec.resumePolicy`, which governs restart after completion rather than a mid-run pause.
- `check_namespace_allowed()` gains an optional `resolver` so optimizer tools validate the namespace they actually target. The trainer path is unchanged.
- `get_experiment_status` reads the Experiment CR rather than `get_job()`, so it agrees with `get_experiment` and is cheaper.

<details>
<summary>Why <code>optimize()</code> cannot be used</summary>

It requires `TrainJobTemplate.trainer` to be a `CustomTrainer` holding a live
Python callable, which cannot cross the MCP/JSON boundary. It also generates its
own Experiment name and sets no labels, so a caller-supplied name and the MCP
ownership label are both unreachable. `SDK_COMPATIBILITY` records this under
`uncovered_methods`, and SDK contract tests fail if any constraint is relaxed.
</details>

<details>
<summary>Behaviour change in <code>get_experiment_status</code></summary>

It previously derived trial counts from TrainJob statuses while `get_experiment`
read the CR, so the two reported different numbers under the same field names.
It now also returns `early_stopped_trials`, `pending_trials` and
`killed_trials`. Counts differ from before whenever trials were early stopped.
The previous numbers were wrong.
</details>

<details>
<summary>Correctness fixes and API details</summary>

- `create_hpo_experiment` derives `primaryContainerName` from the trial template instead of hardcoding `node`, which silently collected no metrics from a plain `batch/v1` Job. Overridable via `primary_container_name`.
- Search space accepts `int` (with optional `step`). The SDK's `Search` emits only `double` and `categorical`, so an ordered discrete range could otherwise only be `choices`, which algorithms treat as unordered.
- `get_trial(name, trial)` takes the experiment as `name`, matching every other tool and `get_training_logs(name, step)`.
- `delete_experiment` and `update_experiment` report a missing experiment as `RESOURCE_NOT_FOUND` instead of blaming ownership.
- A create rejected by an unreachable Katib webhook now hints at `katib_pre_flight()`.
- `pyproject.toml` excludes `kubernetes` 36.0.0 and 36.0.1, which send no `Authorization` header at all (fixed upstream in 36.0.2, kubernetes-client/python#2595).
</details>

**Not included:** live validation against a running experiment. Katib on our test
cluster is missing its ClusterRoles, so the controller never becomes Ready and
every create is rejected by its own admission webhook.

## Related Issue

Implements KEP-34 (`docs/proposals/KEP-34.md`).

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested

- 742 passed, 14 deselected. Optimizer coverage 95 percent, every file above the 80 percent KEP target.
- Architecture tests bind advertised algorithms, search types and limits to the implementation, so the docs cannot drift from the code.
- The namespace-allowlist sweep is derived from `TOOLS`, so a new tool cannot skip coverage.
- Exercised live: pre-flight, all read-only tools, every not-found path, and create validation and preview. Pre-flight correctly reported the broken controller rather than a false green.
