### PR TITLE
fix: codeql issue for incomplete URL substring sanitization

### DIFF
--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -224,15 +224,18 @@ override-dependencies = [
     "requests==2.30.0",
 ]
 """
+        advisory_url = "https://new.com"
         exit_code, updated = self.run_update(
-            pyproject, "requests", "requests==2.31.0", "2025-01-15", "https://new.com"
+            pyproject, "requests", "requests==2.31.0", "2025-01-15", advisory_url
         )
 
         assert exit_code == 0
         assert '"requests==2.31.0",' in updated
         assert "2.30.0" not in updated  # Old version removed
         assert "2025-01-15" in updated  # New date
-        assert "https://new.com" in updated  # New advisory
+        assert (
+            f"# requests==2.31.0 - Added 2025-01-15 for security fix - {advisory_url}" in updated
+        )  # New advisory comment
 
     def test_add_second_override(self):
         """Add second package to existing overrides"""


### PR DESCRIPTION
## Description
CodeQL flagged as an incomplete URL substring sanitization check pattern in `test_update_existing_override` test .

The assertion is updated check the entire formatted override comment line (`f"# requests==2.31.0 - Added 2025-01-15 for security fix - {advisory_url}" in updated`), which avoids the substring check pattern.
<!-- What does this PR do? -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes https://github.com/kubeflow/mcp-server/security/code-scanning/5

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [x] Unit tests
- [x] Integration tests
- [x] E2E tests
- [x] Manually tested (describe below)
