### PR TITLE
fix(ci): create GitHub release as draft before uploading assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,15 +4,10 @@ on:
   push:
     branches:
       - main
-      - 'release-*'
+      - "release-*"
     paths:
-      - 'kubeflow_mcp/__init__.py'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Expected version for the Test PyPI dry run (must match kubeflow_mcp/__init__.py)'
-        required: false
-        type: string
+      - "kubeflow_mcp/__init__.py"
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -28,14 +23,14 @@ jobs:
       branch: ${{ steps.vars.outputs.branch }}
       is-prerelease: ${{ steps.vars.outputs.is-prerelease }}
     steps:
-      # workflow_dispatch has no `branches:` filter (GitHub Actions ignores that
-      # key outside push/pull_request), so without this check any branch could be
-      # dispatched and published to Test PyPI. Fail fast, before checkout, so a
-      # disallowed dispatch gets a clear red X instead of a silent skip.
+      # A dispatch runs the full release (branch, tag, publish), so it must not be
+      # startable from an arbitrary branch. GitHub Actions ignores a `branches:`
+      # filter on workflow_dispatch, so this is enforced here instead. Runs before
+      # checkout so a disallowed dispatch fails fast with a clear reason.
       - name: Reject dispatch from non-release branches
         if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release-')
         run: |
-          echo "ERROR: Test PyPI dry runs may only be dispatched from 'main' or 'release-*' (got '${GITHUB_REF_NAME}')." >&2
+          echo "ERROR: Release may only be dispatched from 'main' or 'release-*' (got '${GITHUB_REF_NAME}')." >&2
           exit 1
 
       - uses: actions/checkout@v6
@@ -49,51 +44,32 @@ jobs:
 
       - name: Check version and branch
         id: vars
-        env:
-          EXPECTED_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           VERSION=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' kubeflow_mcp/__init__.py)
 
-          if [[ -z "$VERSION" ]]; then
-            echo "ERROR: Could not read __version__ from kubeflow_mcp/__init__.py" >&2
-            exit 1
-          fi
-
-          # Guard: only a proper X.Y.Z or X.Y.ZrcN version triggers a release.
-          # This prevents an accidental dev/placeholder bump (e.g. 0.1.0-dev) from
-          # cutting a release. Bump with `make release VERSION=X.Y.Z[rcN]`.
+          # Guard: only a proper X.Y.Z or X.Y.ZrcN version starts a release. Without
+          # this, an unrelated edit to __init__.py while the version is a placeholder
+          # (e.g. 0.1.0-dev) would cut a bogus release. Bump with `make release`.
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$ ]]; then
             echo "ERROR: Version '$VERSION' is not a release version (expected X.Y.Z or X.Y.ZrcN)." >&2
             echo "Bump the version with 'make release VERSION=X.Y.Z[rcN]' before releasing." >&2
             exit 1
           fi
 
-          if [[ -n "${EXPECTED_VERSION:-}" && "$EXPECTED_VERSION" != "$VERSION" ]]; then
-            echo "ERROR: Expected version '$EXPECTED_VERSION' but kubeflow_mcp/__init__.py has '$VERSION'." >&2
-            exit 1
-          fi
-
           MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
           BRANCH=release-$MAJOR_MINOR
 
-          # On a manual dry run, build the dispatched ref as-is and never touch
-          # release branches or tags.
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            BRANCH="${GITHUB_REF_NAME}"
-          fi
-
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
           if [[ "$VERSION" =~ rc[0-9]+$ ]]; then
-            echo "is-prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "is-prerelease=true" >> $GITHUB_OUTPUT
           else
-            echo "is-prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "is-prerelease=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Ensure release branch exists and contains version bump
-        if: github.event_name == 'push'
         run: |
           set -euo pipefail
           VERSION="${{ steps.vars.outputs.version }}"
@@ -134,28 +110,28 @@ jobs:
           ref: ${{ needs.prepare.outputs.branch }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
-          python-version: '3.11'
+          python-version: "3.11"
           enable-cache: true
 
-      - name: Run lint and formatting checks
-        run: make verify
+      - name: Setup build environment
+        run: |
+          make verify
 
       - name: Run unit tests
-        run: make test-python
+        run: |
+          make test-python
 
       - name: Verify version
         run: |
-          set -euo pipefail
-          EXPECTED_VERSION="${{ needs.prepare.outputs.version }}"
+          TAG_VERSION="${{ needs.prepare.outputs.version }}"
           CODE_VERSION="$(uv run python -c "import kubeflow_mcp; print(kubeflow_mcp.__version__)")"
-          echo "Expected version: $EXPECTED_VERSION"
-          echo "Code version:     $CODE_VERSION"
-          if [[ "$EXPECTED_VERSION" != "$CODE_VERSION" ]]; then
-            echo "Version mismatch"; exit 1
-          fi
-          echo "Version verified: $EXPECTED_VERSION"
+          echo "Tag version: $TAG_VERSION"
+          echo "Code version: $CODE_VERSION"
+          if [[ "$TAG_VERSION" != "$CODE_VERSION" ]]; then
+            echo "Version mismatch"; exit 1; fi
+          echo "Version verified: $TAG_VERSION"
 
       - name: Build and validate package
         run: |
@@ -171,7 +147,6 @@ jobs:
   create-tag:
     name: Create and push tag
     needs: [prepare, build]
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -180,38 +155,15 @@ jobs:
           ref: ${{ needs.prepare.outputs.branch }}
       - name: Create tag
         run: |
-          set -euo pipefail
           VERSION="${{ needs.prepare.outputs.version }}"
           if git ls-remote --tags origin "$VERSION" | grep -q "refs/tags/$VERSION"; then
-            echo "Tag $VERSION already exists. Skipping"; exit 0
-          fi
+            echo "Tag $VERSION already exists. Skipping"; exit 0; fi
           git tag "$VERSION"
           git push origin "$VERSION"
-
-  publish-test-pypi:
-    name: Publish to Test PyPI
-    needs: [prepare, build]
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    environment:
-      name: test-pypi
-      url: https://test.pypi.org/project/kubeflow-mcp/
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v7
-        with:
-          name: dist-${{ needs.prepare.outputs.version }}
-          path: dist/
-      - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          verbose: true
 
   publish-pypi:
     name: Publish to PyPI
     needs: [prepare, build, create-tag]
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment:
       name: release
@@ -230,7 +182,6 @@ jobs:
   docker:
     name: Publish Docker image
     needs: [prepare, create-tag]
-    if: github.event_name == 'push'
     permissions:
       contents: read
       packages: write
@@ -244,7 +195,6 @@ jobs:
   github-release:
     name: Create GitHub Release
     needs: [prepare, build, create-tag, publish-pypi]
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment:
       name: release
@@ -260,9 +210,9 @@ jobs:
           name: dist-${{ needs.prepare.outputs.version }}
           path: dist/
       # NOTE: Changelog extraction is temporarily disabled while changelog/git-cliff
-      # support is being added to the repo separately. GitHub's auto-generated notes are
-      # used in the meantime. Once CHANGELOG/CHANGELOG-X.Y.md exists, restore this step,
-      # set `body: ${{ steps.changelog.outputs.changelog }}`, and flip
+      # support is being added to the repo separately (#72). GitHub's auto-generated
+      # notes are used in the meantime. Once CHANGELOG/CHANGELOG-X.Y.md exists, restore
+      # this step, set `body: ${{ steps.changelog.outputs.changelog }}`, and flip
       # `generate_release_notes` back to false.
       # - name: Extract changelog
       #   if: needs.prepare.outputs.is-prerelease != 'true'
@@ -287,14 +237,23 @@ jobs:
       #       echo "changelog<<EOF"
       #       echo "$CHANGELOG"
       #       echo "EOF"
-      #     } >> "$GITHUB_OUTPUT"
+      #     } >> $GITHUB_OUTPUT
+
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ needs.prepare.outputs.version }}
           name: ${{ needs.prepare.outputs.version }}
-          draft: false
+          # Create the release as a draft so assets are uploaded before publication.
+          # With immutable releases enabled, a published release locks its assets, so
+          # they must be attached while the release is still a draft.
+          draft: true
           prerelease: ${{ needs.prepare.outputs.is-prerelease == 'true' }}
           generate_release_notes: true
           files: |
             dist/*
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ needs.prepare.outputs.version }}" --draft=false

--- a/docs/release/RELEASE.md
+++ b/docs/release/RELEASE.md
@@ -92,8 +92,9 @@ Merging the version bump triggers the `Release` workflow (it fires only when
 3. **Tag** — creates and pushes the `X.Y.Z` tag.
 4. **Publish to PyPI** — trusted publishing (requires approval).
 5. **Publish Docker image** — builds and pushes `ghcr.io/<owner>/<repo>` (see below).
-6. **GitHub Release** — attaches the built artifacts and the changelog body (requires
-   approval).
+6. **GitHub Release** — creates the release as a draft, attaches the built artifacts, then
+   publishes it (requires approval). It is created as a draft first because immutable
+   releases lock a release's assets once it is published.
 
 A version that is not a valid `X.Y.Z` / `X.Y.ZrcN` string (for example a `-dev`
 placeholder) is rejected by the workflow so an accidental bump cannot cut a release.
@@ -116,33 +117,36 @@ Also confirm the [PyPI project](https://pypi.org/project/kubeflow-mcp/), the
 [GitHub Release](https://github.com/kubeflow/mcp-server/releases), and the container image
 were published.
 
-## Test PyPI Dry Run
+## Manual Dispatch
 
-Use this to validate a build end-to-end without touching production. Running the `Release`
-workflow via **`workflow_dispatch`** builds the selected ref and publishes **only to Test
-PyPI** — it does not create a branch, tag, GitHub Release, or Docker image.
+The `Release` workflow can also be started manually from GitHub Actions →
+`Release` → `Run workflow`. A dispatch runs the **same full release** as a version-bump
+push: it creates the release branch, tags, publishes to PyPI, pushes the image, and creates
+the GitHub Release. It is not a dry run.
 
-Dispatch is only allowed from `main` or an existing `release-X.Y` branch — the workflow
+Dispatch is only allowed from `main` or an existing `release-X.Y` branch; the workflow
 rejects a dispatch from any other branch. (GitHub Actions ignores a `branches:` filter on
-`workflow_dispatch`, so this is enforced by an explicit check instead.) This means the RC
-bump must land on `main` (or `release-X.Y`) before you can dry run it — you cannot dispatch
-from a feature branch.
+`workflow_dispatch`, so this is enforced by an explicit check.)
 
-1. Bump the version with `make release VERSION=X.Y.ZrcN` and merge it to `main` (or
-   `release-X.Y`).
-2. Open GitHub Actions → `Release` → `Run workflow`, select `main` (or the `release-X.Y`
-   branch), and enter the expected version string (validated against
-   `kubeflow_mcp/__init__.py`).
-3. Approve the `test-pypi` environment.
-4. Verify the upload:
+Use a dispatch to resume a release whose run failed part-way (for example, an approval
+timed out). Steps that already completed are skipped: an existing tag is left alone, and
+PyPI rejects a re-upload of an existing version.
 
-   ```sh
-   pip install \
-     --index-url https://test.pypi.org/simple/ \
-     --extra-index-url https://pypi.org/simple/ \
-     kubeflow-mcp==X.Y.ZrcN
-   kubeflow-mcp --version
-   ```
+## Pre-releases
+
+Publish a release candidate by bumping to an `rcN` version:
+
+```sh
+make release VERSION=X.Y.ZrcN
+```
+
+RC versions publish to PyPI like any other release, but the GitHub Release is marked as a
+pre-release and the container image gets only the exact-version tag (no `latest`, no moving
+major/minor tags). Install one explicitly:
+
+```sh
+pip install kubeflow-mcp==X.Y.ZrcN
+```
 
 ## Docker Image
 
@@ -193,14 +197,13 @@ Run these from the repository root before releasing.
    ```
 
 Trusted publishing cannot be exercised locally because it depends on GitHub Actions OIDC
-tokens and the configured environments — use the Test PyPI dry run for that.
+tokens and the configured environments.
 
 ## Trusted Publisher Setup
 
-Configure trusted publishing for both PyPI and Test PyPI. The workflow uses `id-token: write`
-and reads no PyPI token from secrets.
+The workflow publishes with `id-token: write` and reads no PyPI token from secrets.
 
-For PyPI, add a publisher for the `kubeflow-mcp` project:
+On PyPI, add a trusted publisher for the `kubeflow-mcp` project:
 
 | Field | Value |
 | --- | --- |
@@ -209,14 +212,5 @@ For PyPI, add a publisher for the `kubeflow-mcp` project:
 | Workflow name | `release.yaml` |
 | Environment name | `release` |
 
-For Test PyPI, add a publisher for the `kubeflow-mcp` project:
-
-| Field | Value |
-| --- | --- |
-| Owner | `kubeflow` |
-| Repository name | `mcp-server` |
-| Workflow name | `release.yaml` |
-| Environment name | `test-pypi` |
-
-Create matching GitHub environments named `release` and `test-pypi`, and configure required
-reviewers on each so publishing waits for manual approval.
+Create a matching GitHub environment named `release` and configure required reviewers on it
+so publishing waits for manual approval.


### PR DESCRIPTION
## Description

The `github-release` job created the release with `draft: false` while attaching `dist/*`. With immutable releases enabled, a published release locks its assets, so the upload fails.

Fixes it the same way the SDK does:

- create the release as a draft, upload assets, then publish with `gh release edit "$VERSION" --draft=false`
- pin `softprops/action-gh-release` to a commit SHA (v3)

While here, brings the workflow to parity with [kubeflow/sdk](https://github.com/kubeflow/sdk/blob/main/.github/workflows/release.yaml): drops the Test PyPI job and the `workflow_dispatch` input (now `{}`), removes the per-job `if: github.event_name == 'push'` guards so a dispatch behaves like a version-bump push, and bumps `astral-sh/setup-uv` to v7. RELEASE.md updated to match.

Two guards are kept on purpose, both noted in the workflow:

- dispatch is restricted to `main`/`release-*` (per review on #28, and it matters more now that a dispatch cuts a real release)
- the version must be `X.Y.Z[rcN]`, so an unrelated edit to `__init__.py` while the version is the `0.1.0-dev` placeholder can't cut a bogus release

## Related Issue

Fixes #115

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

`make verify` (incl. `check-yaml`) and `make test-python` (218 passed) pass locally. Workflow YAML parses with the expected job graph, and the pinned SHA `3d0d9888` is confirmed to be exactly what the `v3` tag resolves to.

The publish path itself can't be exercised before merge, since it needs the `release` environment and OIDC on the canonical repo.
