### PR TITLE
chore(ci): add git-cliff changelog generation and release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -209,47 +209,43 @@ jobs:
         with:
           name: dist-${{ needs.prepare.outputs.version }}
           path: dist/
-      # NOTE: Changelog extraction is temporarily disabled while changelog/git-cliff
-      # support is being added to the repo separately (#72). GitHub's auto-generated
-      # notes are used in the meantime. Once CHANGELOG/CHANGELOG-X.Y.md exists, restore
-      # this step, set `body: ${{ steps.changelog.outputs.changelog }}`, and flip
-      # `generate_release_notes` back to false.
-      # - name: Extract changelog
-      #   if: needs.prepare.outputs.is-prerelease != 'true'
-      #   id: changelog
-      #   run: |
-      #     VERSION="${{ needs.prepare.outputs.version }}"
-      #     MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
-      #     CHANGELOG_FILE="CHANGELOG/CHANGELOG-${MAJOR_MINOR}.md"
-      #     set -euo pipefail
-      #     [[ -f "$CHANGELOG_FILE" ]] || { echo "ERROR: $CHANGELOG_FILE not found" >&2; exit 1; }
-      #     HEADER_REGEX="^#\{1,2\} \\[${VERSION//./\\.}\\]"
-      #     SECTION=$(sed -n "/$HEADER_REGEX/,\$p" "$CHANGELOG_FILE")
-      #     [[ -n "$SECTION" ]] || { echo "ERROR: No changelog section for $VERSION in \"$CHANGELOG_FILE\"" >&2; exit 1; }
-      #     NEXT_VERSION=$(echo "$SECTION" | grep -m1 "^#\{1,2\} \\[[0-9]" || true)
-      #     if [[ -n "$NEXT_VERSION" ]]; then
-      #         CHANGELOG=$(echo "$SECTION" | sed '1d' | sed '/^#\{1,2\} \[[0-9]/,$d')
-      #     else
-      #         CHANGELOG=$(echo "$SECTION" | sed '1d')
-      #     fi
-      #     [[ -n "$CHANGELOG" ]] || { echo "ERROR: Empty changelog body for $VERSION in \"$CHANGELOG_FILE\"" >&2; exit 1; }
-      #     {
-      #       echo "changelog<<EOF"
-      #       echo "$CHANGELOG"
-      #       echo "EOF"
-      #     } >> $GITHUB_OUTPUT
+      - name: Extract changelog
+        if: needs.prepare.outputs.is-prerelease != 'true'
+        id: changelog
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+          CHANGELOG_FILE="CHANGELOG/CHANGELOG-${MAJOR_MINOR}.md"
+          set -euo pipefail
+          [[ -f "$CHANGELOG_FILE" ]] || { echo "ERROR: $CHANGELOG_FILE not found" >&2; exit 1; }
+          HEADER_REGEX="^#\{1,2\} \\[${VERSION//./\\.}\\]"
+          SECTION=$(sed -n "/$HEADER_REGEX/,\$p" "$CHANGELOG_FILE")
+          [[ -n "$SECTION" ]] || { echo "ERROR: No changelog section for $VERSION in \"$CHANGELOG_FILE\"" >&2; exit 1; }
+          NEXT_VERSION=$(echo "$SECTION" | grep -m1 "^#\{1,2\} \\[[0-9]" || true)
+          if [[ -n "$NEXT_VERSION" ]]; then
+              CHANGELOG=$(echo "$SECTION" | sed '1d' | sed '/^#\{1,2\} \[[0-9]/,$d')
+          else
+              CHANGELOG=$(echo "$SECTION" | sed '1d')
+          fi
+          [[ -n "$CHANGELOG" ]] || { echo "ERROR: Empty changelog body for $VERSION in \"$CHANGELOG_FILE\"" >&2; exit 1; }
+          {
+            echo "changelog<<EOF"
+            echo "$CHANGELOG"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ needs.prepare.outputs.version }}
           name: ${{ needs.prepare.outputs.version }}
+          body: ${{ steps.changelog.outputs.changelog }}
           # Create the release as a draft so assets are uploaded before publication.
           # With immutable releases enabled, a published release locks its assets, so
           # they must be attached while the release is still a draft.
           draft: true
           prerelease: ${{ needs.prepare.outputs.is-prerelease == 'true' }}
-          generate_release_notes: true
+          generate_release_notes: false
           files: |
             dist/*
 

--- a/Makefile
+++ b/Makefile
@@ -107,31 +107,62 @@ endif
 
 ##@ Release
 
+# Bump version and generate changelog with git-cliff (Docker), matching kubeflow/sdk.
+# Usage: make release VERSION=0.1.0
+# Optional: GITHUB_TOKEN=... (or export it) for contributor attribution / New Contributors.
+# Scope: prefer PREV_TAG..upstream/release-X.Y, else --unreleased. RC versions skip changelog.
 .PHONY: release
-release: install-dev ## Bump the version in kubeflow_mcp/__init__.py (VERSION=X.Y.Z[rcN])
+release: install-dev ## Bump version and generate changelog (VERSION=X.Y.Z[rcN])
 	@if [ -z "$(VERSION)" ] || ! echo "$(VERSION)" | grep -E -q '^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$$'; then \
 		echo "Error: VERSION must be set in X.Y.Z or X.Y.ZrcN format. Usage: make release VERSION=X.Y.Z[rcN]"; \
 		exit 1; \
 	fi
 	@$(SED) -i 's/^__version__ = ".*"/__version__ = "$(VERSION)"/' kubeflow_mcp/__init__.py
 	@echo "Version bumped to $(VERSION) in kubeflow_mcp/__init__.py"
-# NOTE: Changelog generation via git-cliff is temporarily disabled — changelog/git-cliff
-# support is being added to the repo separately. Re-enable the block below (plus the
-# git-cliff dev dependency in pyproject.toml and a cliff.toml) once that work lands.
-#	@if echo "$(VERSION)" | grep -E -q 'rc[0-9]+$$'; then \
-#		echo "Skipping changelog generation for RC release $(VERSION)"; \
-#	else \
-#		MAJOR_MINOR=$$(echo "$(VERSION)" | cut -d. -f1,2); \
-#		CHANGELOG_PATH="CHANGELOG/CHANGELOG-$$MAJOR_MINOR.md"; \
-#		echo "Generating changelog for $(VERSION) (unreleased)"; \
-#		CLIFF_CMD="uv run git-cliff --unreleased --tag $(VERSION)"; \
-#		if [ -f "$$CHANGELOG_PATH" ]; then \
-#			$$CLIFF_CMD --prepend "$$CHANGELOG_PATH"; \
-#		else \
-#			$$CLIFF_CMD -o "$$CHANGELOG_PATH"; \
-#		fi; \
-#		echo "Changelog generated at $$CHANGELOG_PATH"; \
-#	fi
+	@if echo "$(VERSION)" | grep -E -q 'rc[0-9]+$$'; then \
+		echo "Skipping changelog generation for RC release $(VERSION)"; \
+	else \
+		git fetch upstream --tags --prune; \
+		MAJOR_MINOR=$$(echo "$(VERSION)" | cut -d. -f1,2); \
+		CHANGELOG_PATH="CHANGELOG/CHANGELOG-$$MAJOR_MINOR.md"; \
+		RELEASE_BRANCH="release-$$MAJOR_MINOR"; \
+		RELEASE_SHA=$$(git rev-parse --verify --quiet "refs/remotes/upstream/$$RELEASE_BRANCH"); \
+		if [ -n "$$RELEASE_SHA" ]; then \
+			PREV_TAG=$$(git describe --tags --abbrev=0 --match '[0-9]*' --exclude '*rc*' "$$RELEASE_SHA" 2>/dev/null || true); \
+			if [ -n "$$PREV_TAG" ]; then \
+				CLIFF_SCOPE="$$PREV_TAG..$$RELEASE_SHA"; \
+				echo "Generating changelog for $(VERSION) (range: $$PREV_TAG..$$RELEASE_BRANCH @ $$RELEASE_SHA)"; \
+			else \
+				CLIFF_SCOPE="--unreleased"; \
+				echo "Generating changelog for $(VERSION) (no prior tag on $$RELEASE_BRANCH; using --unreleased)"; \
+			fi; \
+		elif [ ! -f "$$CHANGELOG_PATH" ]; then \
+			CLIFF_SCOPE="--unreleased"; \
+			echo "Generating changelog for $(VERSION) (new release line $$MAJOR_MINOR, branch $$RELEASE_BRANCH not created yet; using --unreleased)"; \
+		else \
+			echo "Error: branch $$RELEASE_BRANCH not found locally or on upstream, but $$CHANGELOG_PATH exists. Run: git fetch upstream $$RELEASE_BRANCH"; \
+			exit 1; \
+		fi; \
+		mkdir -p CHANGELOG; \
+		export GITHUB_TOKEN="$(GITHUB_TOKEN)"; \
+		CLIFF_CMD="docker run --rm -u $$(id -u):$$(id -g) -v $(PROJECT_DIR):/app"; \
+		if [ -n "$$GITHUB_TOKEN" ]; then \
+			CLIFF_CMD="$$CLIFF_CMD -e GITHUB_TOKEN"; \
+		fi; \
+		CLIFF_CMD="$$CLIFF_CMD -w /app ghcr.io/orhun/git-cliff/git-cliff:latest $$CLIFF_SCOPE --tag $(VERSION)"; \
+		# Prepend only when a prior release heading exists; stubs/empty files use -o
+		# so the first entry is not written above a '# Changelog' intro.
+		if [ -f "$$CHANGELOG_PATH" ] && grep -qE '^# \[[0-9]+\.[0-9]+\.[0-9]+\]' "$$CHANGELOG_PATH"; then \
+			$$CLIFF_CMD --prepend "$$CHANGELOG_PATH"; \
+		else \
+			$$CLIFF_CMD -o "$$CHANGELOG_PATH"; \
+		fi; \
+		echo "Changelog generated at $$CHANGELOG_PATH"; \
+	fi
+	@echo ""
+	@echo "Release commit for $(VERSION) is ready."
+	@echo "Review the changelog changes if needed, then commit with:"
+	@echo "git add -A && git commit -s -m 'Prepare Release $(VERSION)'"
 
 ##@ Cleanup
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-.PHONY: help uv install-dev verify format test-python test-scripts test test-cov clean inspector
+.PHONY: help uv install-dev verify format test-python test-scripts test test-cov clean inspector release changelog
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -107,12 +107,8 @@ endif
 
 ##@ Release
 
-# Bump version and generate changelog with git-cliff (Docker), matching kubeflow/sdk.
-# Usage: make release VERSION=0.1.0
-# Optional: GITHUB_TOKEN=... (or export it) for contributor attribution / New Contributors.
-# Scope: prefer PREV_TAG..upstream/release-X.Y, else --unreleased. RC versions skip changelog.
 .PHONY: release
-release: install-dev ## Bump version and generate changelog (VERSION=X.Y.Z[rcN])
+release: install-dev ## Bump the version in kubeflow_mcp/__init__.py (VERSION=X.Y.Z[rcN])
 	@if [ -z "$(VERSION)" ] || ! echo "$(VERSION)" | grep -E -q '^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$$'; then \
 		echo "Error: VERSION must be set in X.Y.Z or X.Y.ZrcN format. Usage: make release VERSION=X.Y.Z[rcN]"; \
 		exit 1; \
@@ -122,47 +118,64 @@ release: install-dev ## Bump version and generate changelog (VERSION=X.Y.Z[rcN])
 	@if echo "$(VERSION)" | grep -E -q 'rc[0-9]+$$'; then \
 		echo "Skipping changelog generation for RC release $(VERSION)"; \
 	else \
-		git fetch upstream --tags --prune; \
-		MAJOR_MINOR=$$(echo "$(VERSION)" | cut -d. -f1,2); \
-		CHANGELOG_PATH="CHANGELOG/CHANGELOG-$$MAJOR_MINOR.md"; \
-		RELEASE_BRANCH="release-$$MAJOR_MINOR"; \
-		RELEASE_SHA=$$(git rev-parse --verify --quiet "refs/remotes/upstream/$$RELEASE_BRANCH"); \
-		if [ -n "$$RELEASE_SHA" ]; then \
-			PREV_TAG=$$(git describe --tags --abbrev=0 --match '[0-9]*' --exclude '*rc*' "$$RELEASE_SHA" 2>/dev/null || true); \
-			if [ -n "$$PREV_TAG" ]; then \
-				CLIFF_SCOPE="$$PREV_TAG..$$RELEASE_SHA"; \
-				echo "Generating changelog for $(VERSION) (range: $$PREV_TAG..$$RELEASE_BRANCH @ $$RELEASE_SHA)"; \
-			else \
-				CLIFF_SCOPE="--unreleased"; \
-				echo "Generating changelog for $(VERSION) (no prior tag on $$RELEASE_BRANCH; using --unreleased)"; \
-			fi; \
-		elif [ ! -f "$$CHANGELOG_PATH" ]; then \
-			CLIFF_SCOPE="--unreleased"; \
-			echo "Generating changelog for $(VERSION) (new release line $$MAJOR_MINOR, branch $$RELEASE_BRANCH not created yet; using --unreleased)"; \
-		else \
-			echo "Error: branch $$RELEASE_BRANCH not found locally or on upstream, but $$CHANGELOG_PATH exists. Run: git fetch upstream $$RELEASE_BRANCH"; \
-			exit 1; \
-		fi; \
-		mkdir -p CHANGELOG; \
-		export GITHUB_TOKEN="$(GITHUB_TOKEN)"; \
-		CLIFF_CMD="docker run --rm -u $$(id -u):$$(id -g) -v $(PROJECT_DIR):/app"; \
-		if [ -n "$$GITHUB_TOKEN" ]; then \
-			CLIFF_CMD="$$CLIFF_CMD -e GITHUB_TOKEN"; \
-		fi; \
-		CLIFF_CMD="$$CLIFF_CMD -w /app ghcr.io/orhun/git-cliff/git-cliff:latest $$CLIFF_SCOPE --tag $(VERSION)"; \
-		# Prepend only when a prior release heading exists; stubs/empty files use -o
-		# so the first entry is not written above a '# Changelog' intro.
-		if [ -f "$$CHANGELOG_PATH" ] && grep -qE '^# \[[0-9]+\.[0-9]+\.[0-9]+\]' "$$CHANGELOG_PATH"; then \
-			$$CLIFF_CMD --prepend "$$CHANGELOG_PATH"; \
-		else \
-			$$CLIFF_CMD -o "$$CHANGELOG_PATH"; \
-		fi; \
-		echo "Changelog generated at $$CHANGELOG_PATH"; \
+		$(MAKE) changelog VERSION=$(VERSION); \
 	fi
 	@echo ""
 	@echo "Release commit for $(VERSION) is ready."
 	@echo "Review the changelog changes if needed, then commit with:"
 	@echo "git add -A && git commit -s -m 'Prepare Release $(VERSION)'"
+
+# Generate or prepend a changelog entry with git-cliff (Docker), matching kubeflow/sdk.
+# Usage: make changelog VERSION=0.1.0
+# Dry-run (stdout only): make changelog VERSION=0.1.0 DRY_RUN=1
+# Optional: GITHUB_TOKEN=... (or export it) for contributor attribution / New Contributors.
+# Scope: prefer PREV_TAG..upstream/release-X.Y, else --unreleased.
+.PHONY: changelog
+changelog: ## Generate changelog. Usage: make changelog VERSION=X.Y.Z [DRY_RUN=1]
+	@if [ -z "$(VERSION)" ] || ! echo "$(VERSION)" | grep -E -q '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		echo "Error: VERSION must be set in X.Y.Z format. Usage: make changelog VERSION=0.1.0"; \
+		exit 1; \
+	fi
+	@git fetch upstream --tags --prune
+	@MAJOR_MINOR=$$(echo "$(VERSION)" | cut -d. -f1,2); \
+	CHANGELOG_PATH="CHANGELOG/CHANGELOG-$$MAJOR_MINOR.md"; \
+	RELEASE_BRANCH="release-$$MAJOR_MINOR"; \
+	RELEASE_SHA=$$(git rev-parse --verify --quiet "refs/remotes/upstream/$$RELEASE_BRANCH"); \
+	if [ -n "$$RELEASE_SHA" ]; then \
+		PREV_TAG=$$(git describe --tags --abbrev=0 --match '[0-9]*' --exclude '*rc*' "$$RELEASE_SHA" 2>/dev/null || true); \
+		if [ -n "$$PREV_TAG" ]; then \
+			CLIFF_SCOPE="$$PREV_TAG..$$RELEASE_SHA"; \
+			echo "Generating changelog for $(VERSION) (range: $$PREV_TAG..$$RELEASE_BRANCH @ $$RELEASE_SHA)"; \
+		else \
+			CLIFF_SCOPE="--unreleased"; \
+			echo "Generating changelog for $(VERSION) (no prior tag on $$RELEASE_BRANCH; using --unreleased)"; \
+		fi; \
+	elif [ ! -f "$$CHANGELOG_PATH" ]; then \
+		CLIFF_SCOPE="--unreleased"; \
+		echo "Generating changelog for $(VERSION) (new release line $$MAJOR_MINOR, branch $$RELEASE_BRANCH not created yet; using --unreleased)"; \
+	else \
+		echo "Error: branch $$RELEASE_BRANCH not found locally or on upstream, but $$CHANGELOG_PATH exists. Run: git fetch upstream $$RELEASE_BRANCH"; \
+		exit 1; \
+	fi; \
+	mkdir -p CHANGELOG; \
+	export GITHUB_TOKEN="$(GITHUB_TOKEN)"; \
+	CLIFF_CMD="docker run --rm -u $$(id -u):$$(id -g) -v $(PROJECT_DIR):/app"; \
+	if [ -n "$$GITHUB_TOKEN" ]; then \
+		CLIFF_CMD="$$CLIFF_CMD -e GITHUB_TOKEN"; \
+	fi; \
+	CLIFF_CMD="$$CLIFF_CMD -w /app ghcr.io/orhun/git-cliff/git-cliff:latest $$CLIFF_SCOPE --tag $(VERSION)"; \
+	# Prepend only when a prior release heading exists; stubs/empty files use -o
+	# so the first entry is not written above a '# Changelog' intro.
+	if [ "$(DRY_RUN)" = "1" ]; then \
+		echo "DRY_RUN=1: printing changelog to stdout (not writing $$CHANGELOG_PATH)"; \
+		$$CLIFF_CMD; \
+	elif [ -f "$$CHANGELOG_PATH" ] && grep -qE '^# \[[0-9]+\.[0-9]+\.[0-9]+\]' "$$CHANGELOG_PATH"; then \
+		$$CLIFF_CMD --prepend "$$CHANGELOG_PATH"; \
+		echo "Changelog written to $$CHANGELOG_PATH"; \
+	else \
+		$$CLIFF_CMD -o "$$CHANGELOG_PATH"; \
+		echo "Changelog written to $$CHANGELOG_PATH"; \
+	fi
 
 ##@ Cleanup
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,68 @@
+[remote.github]
+owner = "kubeflow"
+repo = "mcp-server"
+
+[changelog]
+body = """
+{%- if version -%}
+# [{{ version }}](https://github.com/kubeflow/mcp-server/releases/tag/{{ version }}) ({{ timestamp | date(format="%Y-%m-%d") }})
+{% else %}
+# [Unreleased]
+{%- endif %}
+
+{%- set group_order = ["🚀 Features", "🐛 Bug Fixes", "⚙️ Miscellaneous Tasks", "⏪ Reverts"] -%}
+
+{%- for group_name in group_order %}
+{%- set group_commits = commits | filter(attribute="group", value=group_name) -%}
+{%- if group_commits | length > 0 %}
+## {{ group_name }}
+
+{% for commit in group_commits | reverse -%}
+{%- set message = commit.message | split(pat="\n") | first | trim -%}
+{%- set parts = message | split(pat=" (#") -%}
+  {% if parts | length > 1 and parts | last | trim | split(pat=")") | length > 1 -%}
+  {%- set pr_part = parts | last | trim -%}
+  {%- set pr_number = pr_part | replace(from=")", to="") -%}
+  - {{ parts | slice(end=-1) | join(sep=" (#") }} ([#{{ pr_number }}](https://github.com/kubeflow/mcp-server/pull/{{ pr_number }}){% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %})
+  {% else -%}
+  - {{ message }}{% if commit.remote.username %} (@{{ commit.remote.username }}){% endif %}
+  {% endif -%}
+{% endfor %}
+
+{%- endif %}
+{%- endfor %}
+
+{%- if github -%}
+{%- set new_contributors = github.contributors | filter(attribute="is_first_time", value=true) -%}
+{%- if new_contributors | length != 0 %}
+## New Contributors
+{% for contributor in new_contributors %}
+- @{{ contributor.username }} made their first contribution in \
+  [#{{ contributor.pr_number }}](https://github.com/kubeflow/mcp-server/pull/{{ contributor.pr_number }})
+{%- endfor %}
+{%- endif %}
+{%- endif %}
+
+"""
+
+trim = true
+
+footer = ""
+
+[git]
+conventional_commits = false
+filter_unconventional = false
+split_commits = false
+
+# Only stable release tags
+tag_pattern = "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+ignore_tags = ".*-(alpha|beta|rc).*"
+
+# Manually define groups based on conventional patterns
+commit_parsers = [
+  { message = "^(\\[[^]]+\\]\\s*)?feat(\\(.*\\))?:", group = "🚀 Features" },
+  { message = "^(\\[[^]]+\\]\\s*)?fix(\\(.*\\))?:", group = "🐛 Bug Fixes" },
+  { message = "^(\\[[^]]+\\]\\s*)?chore(\\(.*\\))?:", group = "⚙️ Miscellaneous Tasks" },
+  { message = "^(\\[[^]]+\\]\\s*)?revert(\\(.*\\))?:", group = "⏪ Reverts" },
+  { message = ".*", skip = true },
+]

--- a/docs/release/RELEASE.md
+++ b/docs/release/RELEASE.md
@@ -71,7 +71,7 @@ make release VERSION=X.Y.Z      # e.g. make release VERSION=0.1.0
 This updates:
 
 - `kubeflow_mcp/__init__.py` → `__version__ = "X.Y.Z"`
-- `CHANGELOG/CHANGELOG-X.Y.md` → a new top entry `## [X.Y.Z] (YYYY-MM-DD)`
+- `CHANGELOG/CHANGELOG-X.Y.md` → a new top entry `# [X.Y.Z] (YYYY-MM-DD)`
   (skipped for `rcN`)
 
 ### 2. Open a pull request


### PR DESCRIPTION
## Description

Add automated changelog generation with [git-cliff](https://git-cliff.org/), following the kubeflow/sdk pattern:

- Add `cliff.toml` configured for `kubeflow/mcp-server` with conventional commit groups (`feat` / `fix` / `chore` / `revert`)
- Add `CHANGELOG/` with per-minor series files (`CHANGELOG-0.1.md` for the current `0.1.x` line)
- Add `make changelog VERSION=X.Y.Z` to generate or prepend changelog entries via the git-cliff Docker image

Full release-workflow / on-tag automation remains tracked in #16.

## Related Issue

Fixes #59

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

Verified `make help` exposes the `changelog` target. Changelog generation can be exercised with:

```bash
make changelog VERSION=0.1.0
# optional: GITHUB_TOKEN=... make changelog VERSION=0.1.0