### PR TITLE
chore(ci): prepare 0.1.0rc1 and MCP Registry metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,13 +108,19 @@ endif
 ##@ Release
 
 .PHONY: release
-release: install-dev ## Bump the version in kubeflow_mcp/__init__.py (VERSION=X.Y.Z[rcN])
+release: install-dev ## Bump version in __init__.py and server.json (VERSION=X.Y.Z[rcN])
 	@if [ -z "$(VERSION)" ] || ! echo "$(VERSION)" | grep -E -q '^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$$'; then \
 		echo "Error: VERSION must be set in X.Y.Z or X.Y.ZrcN format. Usage: make release VERSION=X.Y.Z[rcN]"; \
 		exit 1; \
 	fi
+	@if [ ! -f server.json ]; then \
+		echo "Error: server.json not found (required for MCP Registry metadata)"; \
+		exit 1; \
+	fi
 	@$(SED) -i 's/^__version__ = ".*"/__version__ = "$(VERSION)"/' kubeflow_mcp/__init__.py
 	@echo "Version bumped to $(VERSION) in kubeflow_mcp/__init__.py"
+	@$(SED) -E -i 's/"version": "[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?"/"version": "$(VERSION)"/g' server.json
+	@echo "Version bumped to $(VERSION) in server.json"
 	@if echo "$(VERSION)" | grep -E -q 'rc[0-9]+$$'; then \
 		echo "Skipping changelog generation for RC release $(VERSION)"; \
 	else \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kubeflow MCP Server
 
+<!-- mcp-name: io.github.kubeflow/mcp-server -->
+
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue)](https://www.python.org) [![Join Slack](https://img.shields.io/badge/Join_Slack-blue?logo=slack)](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels) [![Coverage Status](https://coveralls.io/repos/github/kubeflow/mcp-server/badge.svg?branch=main)](https://coveralls.io/github/kubeflow/mcp-server?branch=main) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kubeflow/mcp-server)
 
 Proposal: [KEP-936](https://github.com/kubeflow/community/tree/master/proposals/936-kubeflow-mcp-server) · [ROADMAP](ROADMAP.md) · [SECURITY](SECURITY.md) · [CONTRIBUTING](CONTRIBUTING.md)

--- a/docs/release/RELEASE.md
+++ b/docs/release/RELEASE.md
@@ -71,12 +71,13 @@ make release VERSION=X.Y.Z      # e.g. make release VERSION=0.1.0
 This updates:
 
 - `kubeflow_mcp/__init__.py` → `__version__ = "X.Y.Z"`
+- `server.json` → top-level and PyPI package `version` fields (MCP Registry metadata)
 - `CHANGELOG/CHANGELOG-X.Y.md` → a new top entry `# [X.Y.Z] (YYYY-MM-DD)`
   (skipped for `rcN`)
 
 ### 2. Open a pull request
 
-- Review `kubeflow_mcp/__init__.py` and `CHANGELOG/CHANGELOG-X.Y.md`.
+- Review `kubeflow_mcp/__init__.py`, `server.json`, and `CHANGELOG/CHANGELOG-X.Y.md`.
 - **Latest minor series:** open the PR against `main`.
 - **Older minor-series patch** (e.g. `0.1.1` when `main` is on `0.2.x`): check out the
   `release-X.Y` branch and open the PR against it.

--- a/kubeflow_mcp/__init__.py
+++ b/kubeflow_mcp/__init__.py
@@ -14,4 +14,4 @@
 
 """Kubeflow MCP Server - AI-powered interface for Kubeflow Training."""
 
-__version__ = "0.1.0-dev"
+__version__ = "0.1.0rc1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,12 @@ otel = [
     "opentelemetry-sdk>=1.29.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/kubeflow/mcp-server"
+Documentation = "https://github.com/kubeflow/mcp-server#readme"
+Source = "https://github.com/kubeflow/mcp-server"
+Issues = "https://github.com/kubeflow/mcp-server/issues"
+
 [project.scripts]
 kubeflow-mcp = "kubeflow_mcp.cli:cli"
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.kubeflow/mcp-server",
+  "title": "Kubeflow MCP Server",
+  "description": "AI-assisted Kubeflow Training via Model Context Protocol — plan, submit, monitor, and manage TrainJobs.",
+  "repository": {
+    "url": "https://github.com/kubeflow/mcp-server",
+    "source": "github"
+  },
+  "version": "0.1.0rc1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "kubeflow-mcp",
+      "version": "0.1.0rc1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Bump to `0.1.0rc1` to cut the first pre-release candidate
- Add MCP Registry metadata (`server.json`, README `mcp-name` marker)
- Have `make release` keep `server.json` version in sync

## Test plan

- [ ] `make release VERSION=0.1.0rc1` leaves `__init__.py` and `server.json` aligned
- [ ] After merge: Release workflow runs; approve `release` env (PyPI + GitHub Release)
- [ ] `pip install kubeflow-mcp==0.1.0rc1 && kubeflow-mcp --version`
- [ ] Follow-up (org Owner): `mcp-publisher publish` for #116