### PR TITLE
fix: correct MCP_TRANSPORT default

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ dependencies.
 
 | Variable | Default | Description |
 |---|---|---|
-| `MCP_TRANSPORT` | `http` | Transport protocol (`http`, `sse`, `stdio`) |
+| `MCP_TRANSPORT` | `stdio` | Transport protocol (`http`, `sse`, `stdio`) |
 | `KUBEFLOW_MCP_AUTH_TOKEN` | _(none)_ | Bearer token for HTTP auth |
 | `KUBEFLOW_MCP_JWKS_URI` | _(none)_ | JWKS endpoint for JWT verification (production) |
 | `KUBEFLOW_MCP_JWT_ISSUER` | _(none)_ | Expected JWT issuer |


### PR DESCRIPTION
## Description

Corrects the documented default value of `MCP_TRANSPORT` in the README from `http` to `stdio`, matching the actual server configuration.

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #123

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [ ] Tests pass locally (`make test-python`)
- [ ] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (git commit -s)

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)
Manually verified that the README value matches the default transport configured in `kubeflow_mcp/core/config.py`.
