### PR TITLE
fix: remove unavailable agent command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,19 +218,6 @@ Without auth configured, the server logs a warning that the HTTP endpoint is ope
 
 </details>
 
-<details>
-<summary>Agent Subcommand</summary>
-
-```bash
-kubeflow-mcp agent \
-  --backend ollama \              # ollama (default; more backends planned)
-  --model qwen3:8b \              # model name for the backend
-  --mode full \                   # full | progressive | semantic
-  --thinking                      # enable thinking output (supported models)
-```
-
-</details>
-
 ## Observability
 
 OpenTelemetry tracing is optional and can be enabled without changing tool code.
@@ -247,9 +234,6 @@ kubeflow-mcp serve
 
 Each tool invocation emits a span with attributes:
 `tool.name`, `tool.args_preview`, `tool.success`, `tool.duration_ms`, `kubeflow.persona`, and `correlation_id`.
-
-> **Note:** `kubeflow-mcp agent --otel-endpoint ...` emits spans under a separate
-> `kubeflow-mcp-agent` service in Jaeger, distinct from the `kubeflow-mcp` server spans.
 
 ## Development
 


### PR DESCRIPTION
## Description

Remove the unsupported `kubeflow-mcp agent` command from the README, along with the agent-specific OpenTelemetry claim. The agent runtime is planned for Phase 3 and is not currently available in this repository.

## Related Issue

Fixes #120

## Checklist

- [ ] I have read the [CONTRIBUTING](./CONTRIBUTING.md) guide
- [ ] Tests pass locally (`make test-python`)
- [ ] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

Manually verified that the README no longer documents `kubeflow-mcp agent` or agent-specific OpenTelemetry behavior.