### PR TITLE
fix: correct OpenTelemetry installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ kubeflow-mcp agent \
 
 OpenTelemetry tracing is optional and can be enabled without changing tool code.
 
-- Install optional dependencies: `pip install ".[otel]"`
+- Install optional dependencies from source: `uv sync --group otel`
 - Enable tracing with CLI flag or env var:
 
 ```bash


### PR DESCRIPTION
## Description

Corrects the OpenTelemetry installation command in the README.

The previous command, `pip install ".[otel]"`, does not install the tracing dependencies because `otel` is configured as a uv dependency group. The README now documents:

```bash
uv sync --group otel
```

## Related Issue

Fixes #126 

## Checklist

- [ ] I have read the [CONTRIBUTING](./CONTRIBUTING.md) guide
- [ ] Tests pass locally (`make test-python`)
- [ ] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

Manually verified that the README command matches the `otel` dependency group in `pyproject.toml`.