### PR TITLE
fix: clarify update training job confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ Agent calls: fine_tune(..., confirmed=True) → TrainJob "train-gemma-abc" creat
 Agent calls: get_training_logs("train-gemma-abc") → training progress...
 ```
 
-Every mutating tool requires `confirmed=True` — agents always preview before submitting.
+Most mutating tools require `confirmed=True` and return a preview before making changes.
+`update_training_job` is a legacy exception and immediately suspends or resumes a training job.
 
 ### MCP Client Config
 


### PR DESCRIPTION
## Description

Clarifies the README confirmation behavior for mutating tools.

Most mutating tools return a preview and require `confirmed=True` before making changes. However, `update_training_job` is a legacy exception: it immediately suspends or resumes a training job without a confirmation parameter.

## Related Issue

Fixes #128

## Checklist

- [ ] I have read the [CONTRIBUTING](./CONTRIBUTING.md) guide
- [ ] Tests pass locally (`make test-python`)
- [ ] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

Manually verified that `update_training_job` has no `confirmed` parameter and directly applies the suspend/resume update.