### PR TITLE
fix: clarify log format default

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ dependencies.
 | `KUBEFLOW_MCP_ALLOWED_HOSTS` | _(loopback)_ | Comma-separated `Host` header allowlist for DNS rebinding protection; `:*` port wildcard supported (e.g. `mcp.example.com,mcp.example.com:*`) |
 | `KUBEFLOW_MCP_ALLOWED_ORIGINS` | _(loopback)_ | Comma-separated `Origin` header allowlist; `:*` port wildcard supported (e.g. `https://mcp.example.com`) |
 | `KUBEFLOW_MCP_DNS_REBINDING_PROTECTION` | `true` | Set `false` to disable Host/Origin validation (not recommended) |
-| `LOG_FORMAT` | `json` | Log format (`json`, `console`) |
+| `LOG_FORMAT` | _(auto)_ | Log format (`json`, `console`); defaults to `console` in an interactive terminal and `json` otherwise |
 | `LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 
 **MCP client config (HTTP transport)**


### PR DESCRIPTION
## Description

Clarifies that `LOG_FORMAT` is auto-detected when it is not configured.

The README previously documented `json` as the fixed default. In practice, the server uses `console` for an interactive terminal and `json` otherwise.

## Related Issue

Fixes #130 

## Checklist

- [ ] I have read the [CONTRIBUTING](./CONTRIBUTING.md) guide
- [ ] Tests pass locally (`make test-python`)
- [ ] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

Manually verified that the README entry matches the auto-detection logic in `kubeflow_mcp/core/logging.py`.