### PR TITLE
fix: preserve OTLP endpoint query parameters

### DIFF
--- a/kubeflow_mcp/core/telemetry.py
+++ b/kubeflow_mcp/core/telemetry.py
@@ -77,7 +77,7 @@ def _normalize_and_validate_endpoint(endpoint: str | None) -> str:
     # Append the standard OTLP trace path when only a base URL is provided,
     # matching the OTel SDK convention for OTEL_EXPORTER_OTLP_ENDPOINT.
     if not parsed.path or parsed.path == "/":
-        normalized_endpoint = normalized_endpoint.rstrip("/") + "/v1/traces"
+        normalized_endpoint = parsed._replace(path="/v1/traces").geturl()
     return normalized_endpoint
 
 

--- a/kubeflow_mcp/core/telemetry_test.py
+++ b/kubeflow_mcp/core/telemetry_test.py
@@ -218,6 +218,13 @@ def test_setup_tracing_rejects_invalid_endpoint() -> None:
         telemetry.setup_tracing("localhost:4318/v1/traces")
 
 
+def test_normalize_endpoint_preserves_query_parameters() -> None:
+    assert (
+        telemetry._normalize_and_validate_endpoint("https://collector.example.com?tenant=demo")
+        == "https://collector.example.com/v1/traces?tenant=demo"
+    )
+
+
 def test_setup_tracing_reuses_existing_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: dict[str, object] = {}
 


### PR DESCRIPTION
## Description

Preserves query parameters when OpenTelemetry OTLP endpoints are normalized.

Previously, a base endpoint with a query parameter could append `/v1/traces` inside the query string. The endpoint is now rebuilt from the parsed URL, so the trace path appears before query parameters.

A focused regression test covers this behavior.

## Related Issue

Fixes #139

## Checklist

- [ ] I have read the [CONTRIBUTING](./CONTRIBUTING.md) guide
- [ ] Tests pass locally (`make test-python`)
- [ ] Linting passes (`make verify`)
- [ ] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manually tested (describe below)

Ran:

```bash
uv run pytest -q kubeflow_mcp/core/telemetry_test.py
uv run ruff check kubeflow_mcp/core/telemetry.py kubeflow_mcp/core/telemetry_test.py
uv run ruff format --check kubeflow_mcp/core/telemetry.py kubeflow_mcp/core/telemetry_test.py
```

All 13 telemetry tests passed, and lint/format checks passed.