### PR TITLE
fix: handle non-mapping YAML config

### DIFF
--- a/kubeflow_mcp/core/config.py
+++ b/kubeflow_mcp/core/config.py
@@ -191,7 +191,14 @@ def _load_yaml_config(path: Path) -> dict[str, Any]:
 
         with open(path) as f:
             data = yaml.safe_load(f)
-            return data if data else {}
+            if data is None:
+                return {}
+            if not isinstance(data, dict):
+                logger.warning(
+                    "Config root must be a mapping; ignoring %s (got %s)", path, type(data).__name__
+                )
+                return {}
+            return data
     except ImportError:
         logger.warning("PyYAML not installed, skipping config file")
         return {}

--- a/kubeflow_mcp/core/config_test.py
+++ b/kubeflow_mcp/core/config_test.py
@@ -108,6 +108,16 @@ def test_load_config_env_overrides_file(tmp_path):
     assert cfg.server.persona == "platform-admin"
 
 
+def test_load_config_ignores_non_mapping_yaml(tmp_path, caplog):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("- trainer\n- optimizer\n")
+
+    cfg = load_config(config_path=config_file)
+
+    assert cfg.server.clients == ["trainer"]
+    assert "Config root must be a mapping" in caplog.text
+
+
 # TODO(test): test config_path that doesn't exist falls back to default search
 # TODO(test): test malformed YAML handled gracefully
 # TODO(test): test auth config env overrides (KUBEFLOW_MCP_AUTH_TOKEN, KUBEFLOW_MCP_JWKS_URI)


### PR DESCRIPTION
## Description

Handles YAML configuration files whose root value is not a mapping.

Previously, valid YAML with a list or scalar root could reach `load_config()` and raise `AttributeError` when the loader called `.get()` on a non-dictionary value.

The loader now logs a warning and safely falls back to default configuration values. A focused regression test covers a YAML list root.

## Related Issue

Fixes #141

## Checklist

- [ ] I have read the [CONTRIBUTING](./CONTRIBUTING.md) guide
- [ ] Tests pass locally (`make test-python`)
- [ ] Linting passes (`make verify`)
- [ ] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manually tested (describe below)

Ran:

```bash
uv run pytest -q kubeflow_mcp/core/config_test.py
uv run ruff check kubeflow_mcp/core/config.py kubeflow_mcp/core/config_test.py
uv run ruff format --check kubeflow_mcp/core/config.py kubeflow_mcp/core/config_test.py
```

All 10 configuration tests passed, and lint/format checks passed.