### PR TITLE
fix: make CLI serve example copyable

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,17 +180,27 @@ claude mcp add kubeflow -- kubeflow-mcp serve
 ### `kubeflow-mcp serve`
 
 ```bash
+# Modules: trainer, optimizer (stub), hub (stub)
+# Persona: readonly | data-scientist | ml-engineer | platform-admin
+# Mode: full | progressive | semantic
+# Instruction tier: full | compact | minimal
+# Transport: stdio | http | sse
+# Auth token: bearer token for HTTP auth (dev/staging)
+# OTel endpoint: optional OTLP HTTP endpoint for tracing
+# Log level: DEBUG | INFO | WARNING | ERROR
+# Log format: console | json (auto-detected if omitted)
+# No banner: suppress the FastMCP startup banner
 kubeflow-mcp serve \
-  --clients trainer \             # modules: trainer, optimizer (stub), hub (stub)
-  --persona ml-engineer \         # readonly | data-scientist | ml-engineer | platform-admin
-  --mode full \                   # full | progressive | semantic
-  --instruction-tier full \       # full | compact | minimal
-  --transport stdio \             # stdio | http | sse
-  --auth-token SECRET \           # bearer token for HTTP auth (dev/staging)
-  --otel-endpoint URL \           # OTLP HTTP endpoint (optional tracing)
-  --log-level INFO \              # DEBUG | INFO | WARNING | ERROR
-  --log-format console \          # console | json (auto-detected if omitted)
-  --no-banner                     # suppress startup banner
+  --clients trainer \
+  --persona ml-engineer \
+  --mode full \
+  --instruction-tier full \
+  --transport stdio \
+  --auth-token SECRET \
+  --otel-endpoint URL \
+  --log-level INFO \
+  --log-format console \
+  --no-banner
 ```
 
 `--mode progressive` exposes 3 meta-tools (~85 tokens) for hierarchical discovery. `--mode semantic` exposes 2 meta-tools (~69 tokens) using embedding search. Both reduce token consumption significantly for agent workflows.


### PR DESCRIPTION
## Description

Makes the `kubeflow-mcp serve` README example safe to copy and paste in Bash.

Inline comments after line-continuation backslashes were moved above the command. Each continuation backslash is now immediately followed by a newline, while the option explanations remain available.

## Related Issue

Fixes #143

## Checklist

- [ ] I have read the [CONTRIBUTING](./CONTRIBUTING.md) guide
- [ ] Tests pass locally (`make test-python`)
- [ ] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

Manually verified that no Bash continuation line has spaces or an inline comment after its trailing backslash.