### PR TITLE
fix: document KUBEFLOW_MCP_INSTRUCTION_TIER environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ dependencies.
 | `KUBEFLOW_MCP_JWT_AUDIENCE` | _(none)_ | Expected JWT audience |
 | `KUBEFLOW_MCP_CLIENTS` | `trainer` | Comma-separated client modules to load |
 | `KUBEFLOW_MCP_PERSONA` | `readonly` | Tool persona (`readonly`, `data-scientist`, `ml-engineer`, `platform-admin`) |
+| `KUBEFLOW_MCP_INSTRUCTION_TIER` | `full` | Instruction verbosity (`full`, `compact`, `minimal`) |
 | `KUBEFLOW_MCP_ALLOWED_HOSTS` | _(loopback)_ | Comma-separated `Host` header allowlist for DNS rebinding protection; `:*` port wildcard supported (e.g. `mcp.example.com,mcp.example.com:*`) |
 | `KUBEFLOW_MCP_ALLOWED_ORIGINS` | _(loopback)_ | Comma-separated `Origin` header allowlist; `:*` port wildcard supported (e.g. `https://mcp.example.com`) |
 | `KUBEFLOW_MCP_DNS_REBINDING_PROTECTION` | `true` | Set `false` to disable Host/Origin validation (not recommended) |


### PR DESCRIPTION
## Description

Adds the `KUBEFLOW_MCP_INSTRUCTION_TIER` environment variable to the Environment variables table in the README. 

Users can configure the instruction verbosity using this environment variable, which defaults to `full`. Adding this row ensures the documentation is consistent with the CLI help output and the configuration loader in `kubeflow_mcp/core/config.py`.

## Related Issue

Fixes #145

## Checklist

- [ ] I have read the [CONTRIBUTING](./CONTRIBUTING.md) guide
- [ ] Tests pass locally (`make test-python`)
- [ ] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

Manually verified that the README renders the table correctly and accurately reflects the `full`, `compact`, and `minimal` configuration options.
