### PR TITLE
fix(docs): update SECURITY.md dependency scanning to OSV-Scanner

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,7 @@ Fix timelines depend on severity: critical — ASAP, high — 2 weeks, medium �
 ## Prevention Mechanisms
 
 - **Code Reviews**: All changes are reviewed by maintainers via Prow `/lgtm` + `/approve`.
-- **Dependency Management**: Dependabot monitors dependencies; `pip-audit` runs in CI.
+- **Dependency Management**: Dependabot monitors dependencies; the nightly OSV-Scanner workflow scans `uv.lock` for known CVEs, uploads findings to the GitHub Security tab, and opens automated fix PRs.
 - **Continuous Integration**: Automated tests, linting, and security checks on every PR.
 - **Image Scanning**: Container images are scanned for vulnerabilities via Trivy.
 - **Input Validation**: AST-based script safety checks, K8s name validation, training parameter bounds (`core/security.py`).


### PR DESCRIPTION
## Description

One-line docs fix: SECURITY.md (merged via #14) still says `pip-audit` runs in CI, but pip-audit was replaced by the nightly OSV-Scanner workflow in #30. This updates the Prevention Mechanisms line to describe the current setup — nightly scan of `uv.lock`, findings in the Security tab, automated fix PRs (e.g. #137).

Follow-up promised on the #30 review thread.

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] revert: Revert a change
- [ ] chore: Maintenance / tooling

## Checklist

- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] Commit messages follow conventional format

## Related Issues

Follow-up to #30 / #14
