### PR TITLE
chore: add unit tests for common utils, types, and constants (#68)

### DIFF
--- a/kubeflow_mcp/common/constants_test.py
+++ b/kubeflow_mcp/common/constants_test.py
@@ -15,6 +15,9 @@
 """Tests for common/constants.py — error classification, phase maps."""
 
 from kubeflow_mcp.common.constants import (
+    TOOL_NEXT_HINTS,
+    TOOL_PHASES,
+    TOOL_TO_PHASE,
     ErrorCode,
     is_infrastructure_error,
 )
@@ -39,9 +42,52 @@ class TestIsInfrastructureError:
     def test_success_result_is_not_infrastructure(self):
         assert is_infrastructure_error({"data": {"ok": True}}) is False
 
-    # TODO(test): test SDK_ERROR classification
-    # TODO(test): test CIRCUIT_OPEN classification
-    # TODO(test): test RATE_LIMITED classification
-    # TODO(test): test TOOL_PHASES contains all expected phases
-    # TODO(test): test TOOL_TO_PHASE covers all registered tools
-    # TODO(test): test TOOL_NEXT_HINTS provides hints for training tools
+    def test_sdk_error_is_infrastructure(self):
+        result = {"error": "sdk failed", "error_code": ErrorCode.SDK_ERROR}
+        assert is_infrastructure_error(result) is True
+
+    def test_circuit_open_is_not_infrastructure(self):
+        result = {"error": "circuit open", "error_code": ErrorCode.CIRCUIT_OPEN}
+        assert is_infrastructure_error(result) is False
+
+    def test_rate_limited_is_not_infrastructure(self):
+        result = {"error": "rate limited", "error_code": ErrorCode.RATE_LIMITED}
+        assert is_infrastructure_error(result) is False
+
+
+class TestToolPhases:
+    def test_contains_all_expected_phases(self):
+        expected = {
+            "planning",
+            "discovery",
+            "training",
+            "monitoring",
+            "lifecycle",
+            "platform",
+            "health",
+        }
+        assert set(TOOL_PHASES.keys()) == expected
+
+    def test_tool_to_phase_covers_all_tools(self):
+        all_tools = {tool for tools in TOOL_PHASES.values() for tool in tools}
+        assert set(TOOL_TO_PHASE.keys()) == all_tools
+
+    def test_tool_to_phase_reverse_mapping_is_correct(self):
+        for phase, tools in TOOL_PHASES.items():
+            for tool in tools:
+                assert TOOL_TO_PHASE[tool] == phase
+
+
+class TestToolNextHints:
+    def test_training_tools_have_hints(self):
+        for tool in TOOL_PHASES["training"]:
+            assert tool in TOOL_NEXT_HINTS, f"Missing hint for training tool: {tool}"
+
+    def test_monitoring_tools_have_hints(self):
+        for tool in TOOL_PHASES["monitoring"]:
+            assert tool in TOOL_NEXT_HINTS, f"Missing hint for monitoring tool: {tool}"
+
+    def test_hints_are_non_empty_strings(self):
+        for tool, hint in TOOL_NEXT_HINTS.items():
+            assert isinstance(hint, str), f"Hint for {tool} is not a string"
+            assert len(hint) > 0, f"Hint for {tool} is empty"

--- a/kubeflow_mcp/common/types_test.py
+++ b/kubeflow_mcp/common/types_test.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+from unittest.mock import patch
 
 from kubeflow_mcp.common.types import (
     PreviewResponse,
@@ -52,8 +53,21 @@ class TestIsK8sNotFound:
     def test_returns_false_for_module_not_found(self):
         assert is_k8s_not_found(ModuleNotFoundError("not found")) is False
 
-    # TODO(test): test chained exception (__cause__) with ApiException 404
-    # TODO(test): test chained exception (__context__) with ApiException 404
+    def test_chained_cause_with_api_404(self):
+        from kubernetes.client.exceptions import ApiException
+
+        cause = ApiException(status=404)
+        exc = RuntimeError("wrapper")
+        exc.__cause__ = cause
+        assert is_k8s_not_found(exc) is True
+
+    def test_chained_context_with_api_404(self):
+        from kubernetes.client.exceptions import ApiException
+
+        context = ApiException(status=404)
+        exc = RuntimeError("wrapper")
+        exc.__context__ = context
+        assert is_k8s_not_found(exc) is True
 
 
 class TestExceptionDetails:
@@ -83,8 +97,30 @@ class TestExceptionDetails:
         finally:
             root.setLevel(original)
 
-    # TODO(test): test traceback included at DEBUG level
-    # TODO(test): test traceback excluded when format_exc returns "NoneType: None"
+    def test_includes_traceback_at_debug_level(self):
+        root = logging.getLogger("kubeflow_mcp")
+        original = root.level
+        root.setLevel(logging.DEBUG)
+        try:
+            try:
+                raise RuntimeError("boom")
+            except RuntimeError as e:
+                details = exception_details(e)
+                assert "traceback" in details
+                assert "RuntimeError" in details["traceback"]
+        finally:
+            root.setLevel(original)
+
+    @patch("kubeflow_mcp.common.types.traceback.format_exc", return_value="NoneType: None")
+    def test_excludes_traceback_when_format_exc_returns_nonetype(self, _mock_fmt):
+        root = logging.getLogger("kubeflow_mcp")
+        original = root.level
+        root.setLevel(logging.DEBUG)
+        try:
+            details = exception_details(RuntimeError("boom"))
+            assert "traceback" not in details
+        finally:
+            root.setLevel(original)
 
 
 class TestResponseModels:
@@ -106,5 +142,21 @@ class TestResponseModels:
         assert d["status"] == "preview"
         assert d["success"] is True
 
-    # TODO(test): test ToolError with hint field
-    # TODO(test): test ToolError with details dict
+    def test_tool_error_with_hint(self):
+        e = ToolError(
+            error="job not found",
+            error_code="RESOURCE_NOT_FOUND",
+            hint="Use list_training_jobs to find available jobs",
+        )
+        d = e.model_dump()
+        assert d["hint"] == "Use list_training_jobs to find available jobs"
+
+    def test_tool_error_with_details(self):
+        e = ToolError(
+            error="sdk failure",
+            error_code="SDK_ERROR",
+            details={"exception": "RuntimeError", "message": "connection reset"},
+        )
+        d = e.model_dump()
+        assert d["details"]["exception"] == "RuntimeError"
+        assert d["details"]["message"] == "connection reset"

--- a/kubeflow_mcp/common/utils_test.py
+++ b/kubeflow_mcp/common/utils_test.py
@@ -16,20 +16,69 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from kubeflow_mcp.common.utils import _get_api_client, reset_clients
+from kubeflow_mcp.common.utils import (
+    MCP_MANAGED_LABEL,
+    MCP_MANAGED_VALUE,
+    _get_api_client,
+    get_core_v1_api,
+    get_custom_objects_api,
+    get_trainer_client_for_namespace,
+    get_trainer_effective_namespace,
+    is_mcp_managed,
+    reset_clients,
+)
+
+PATCH_CUSTOM_API = "kubeflow_mcp.common.utils.get_custom_objects_api"
+PATCH_GET_API_CLIENT = "kubeflow_mcp.common.utils._get_api_client"
+PATCH_TRAINER_CLIENT = "kubeflow_mcp.common.utils.get_trainer_client"
 
 
 class TestIsMcpManaged:
-    """is_mcp_managed(name, namespace) makes a K8s API call.
-    Tests require mocking the CustomObjects API.
-    """
+    @patch(PATCH_CUSTOM_API)
+    def test_returns_true_when_label_present(self, mock_api_fn):
+        mock_api = MagicMock()
+        mock_api.get_namespaced_custom_object.return_value = {
+            "metadata": {"labels": {MCP_MANAGED_LABEL: MCP_MANAGED_VALUE}}
+        }
+        mock_api_fn.return_value = mock_api
+        assert is_mcp_managed("my-job", "default") is True
 
-    # TODO(test): test returns True when label present (mock get_custom_objects_api)
-    # TODO(test): test returns False when label absent
-    # TODO(test): test returns None on API error
-    pass
+    @patch(PATCH_CUSTOM_API)
+    def test_returns_false_when_label_missing(self, mock_api_fn):
+        mock_api = MagicMock()
+        mock_api.get_namespaced_custom_object.return_value = {
+            "metadata": {"labels": {"other-label": "value"}}
+        }
+        mock_api_fn.return_value = mock_api
+        assert is_mcp_managed("my-job", "default") is False
+
+    @patch(PATCH_CUSTOM_API)
+    def test_returns_false_when_no_labels(self, mock_api_fn):
+        mock_api = MagicMock()
+        mock_api.get_namespaced_custom_object.return_value = {"metadata": {}}
+        mock_api_fn.return_value = mock_api
+        assert is_mcp_managed("my-job", "default") is False
+
+    @patch(PATCH_CUSTOM_API)
+    def test_returns_false_on_404(self, mock_api_fn):
+        from kubernetes.client.exceptions import ApiException
+
+        mock_api = MagicMock()
+        mock_api.get_namespaced_custom_object.side_effect = ApiException(
+            status=404, reason="Not Found"
+        )
+        mock_api_fn.return_value = mock_api
+        assert is_mcp_managed("missing-job", "default") is False
+
+    @patch(PATCH_CUSTOM_API)
+    def test_returns_none_on_other_api_error(self, mock_api_fn):
+        mock_api = MagicMock()
+        mock_api.get_namespaced_custom_object.side_effect = Exception("connection refused")
+        mock_api_fn.return_value = mock_api
+        assert is_mcp_managed("my-job", "default") is None
 
 
 class TestResetClients:
@@ -55,8 +104,89 @@ class TestResetClients:
 
         reset_clients()
 
-    # TODO(test): test get_core_v1_api returns singleton
-    # TODO(test): test get_core_v1_api returns same instance on second call
-    # TODO(test): test get_trainer_effective_namespace reads kubeconfig default
-    # TODO(test): test get_trainer_client_for_namespace creates client with given ns
-    # TODO(test): test get_custom_objects_api returns singleton
+
+class TestGetCoreV1Api:
+    @patch(PATCH_GET_API_CLIENT)
+    def test_returns_core_v1_api_instance(self, mock_api_client):
+        mock_api_client.return_value = MagicMock()
+        result = get_core_v1_api()
+        from kubernetes.client import CoreV1Api
+
+        assert isinstance(result, CoreV1Api)
+
+    @patch(PATCH_GET_API_CLIENT)
+    def test_uses_shared_api_client(self, mock_api_client):
+        shared_client = MagicMock()
+        mock_api_client.return_value = shared_client
+        get_core_v1_api()
+        mock_api_client.assert_called_once()
+
+
+class TestGetCustomObjectsApi:
+    @patch(PATCH_GET_API_CLIENT)
+    def test_returns_custom_objects_api_instance(self, mock_api_client):
+        mock_api_client.return_value = MagicMock()
+        result = get_custom_objects_api()
+        from kubernetes.client import CustomObjectsApi
+
+        assert isinstance(result, CustomObjectsApi)
+
+    @patch(PATCH_GET_API_CLIENT)
+    def test_uses_shared_api_client(self, mock_api_client):
+        shared_client = MagicMock()
+        mock_api_client.return_value = shared_client
+        get_custom_objects_api()
+        mock_api_client.assert_called_once()
+
+
+class TestGetTrainerEffectiveNamespace:
+    def test_explicit_namespace_returned(self):
+        assert get_trainer_effective_namespace("my-ns") == "my-ns"
+
+    @patch(PATCH_TRAINER_CLIENT)
+    def test_reads_backend_namespace(self, mock_trainer):
+        mock_trainer.return_value = SimpleNamespace(
+            backend=SimpleNamespace(namespace="from-kubeconfig")
+        )
+        assert get_trainer_effective_namespace(None) == "from-kubeconfig"
+
+    @patch(PATCH_TRAINER_CLIENT)
+    def test_falls_back_to_default(self, mock_trainer):
+        mock_trainer.return_value = SimpleNamespace(backend=SimpleNamespace())
+        assert get_trainer_effective_namespace(None) == "default"
+
+
+class TestGetTrainerClientForNamespace:
+    @patch(PATCH_TRAINER_CLIENT)
+    def test_none_returns_singleton(self, mock_trainer):
+        sentinel = MagicMock(name="singleton")
+        mock_trainer.return_value = sentinel
+        result = get_trainer_client_for_namespace(None)
+        assert result is sentinel
+
+    @patch("kubeflow_mcp.common.utils.TrainerClient")
+    def test_explicit_namespace_creates_new_client(self, mock_cls):
+        from kubeflow_mcp.common.utils import _ns_client_cache, _ns_client_lock
+
+        with _ns_client_lock:
+            _ns_client_cache.pop("test-ns", None)
+        mock_cls.return_value = MagicMock(name="scoped-client")
+        result = get_trainer_client_for_namespace("test-ns")
+        assert result is mock_cls.return_value
+        mock_cls.assert_called_once()
+        with _ns_client_lock:
+            _ns_client_cache.pop("test-ns", None)
+
+    @patch("kubeflow_mcp.common.utils.TrainerClient")
+    def test_cached_namespace_returns_same_client(self, mock_cls):
+        from kubeflow_mcp.common.utils import _ns_client_cache, _ns_client_lock
+
+        with _ns_client_lock:
+            _ns_client_cache.pop("cache-ns", None)
+        mock_cls.return_value = MagicMock(name="scoped-client")
+        first = get_trainer_client_for_namespace("cache-ns")
+        second = get_trainer_client_for_namespace("cache-ns")
+        assert first is second
+        assert mock_cls.call_count == 1
+        with _ns_client_lock:
+            _ns_client_cache.pop("cache-ns", None)


### PR DESCRIPTION
 ## Summary
  Fixes of #68 (common/utils, common/types, common/constants sections).

  - Clear all 17 `TODO(test)` markers across `utils_test.py`, `types_test.py`, and `constants_test.py`
  - Add tests for K8s client singletons (`get_core_v1_api`, `get_custom_objects_api`)
  - Add tests for `get_trainer_effective_namespace` (explicit, backend, default fallback)
  - Add tests for `get_trainer_client_for_namespace` (singleton, scoped, caching)
  - Add tests for `is_k8s_not_found` chained exception paths (`__cause__`, `__context__`)
  - Add tests for `exception_details` traceback inclusion/exclusion at DEBUG level
  - Add tests for `ToolError` with `hint` and `details` fields
  - Add tests for `is_infrastructure_error` (`SDK_ERROR`, `CIRCUIT_OPEN`, `RATE_LIMITED`)
  - Add tests for `TOOL_PHASES`, `TOOL_TO_PHASE`, `TOOL_NEXT_HINTS` completeness

  ## Test plan
  - [x] `make test-python` — 412 passed
  - [x] All 17 `TODO(test)` markers cleared
  - [x] No real cluster calls — all K8s interactions mocked
