### PR TITLE
fix: prefer project-local configuration

### DIFF
--- a/kubeflow_mcp/core/config.py
+++ b/kubeflow_mcp/core/config.py
@@ -68,12 +68,12 @@ logger = logging.getLogger(__name__)
 
 
 def _get_config_paths() -> list[Path]:
-    """Config file locations, searched in order. Evaluated lazily so cwd is fresh."""
+    """Config file locations, searched in order with project-local config first."""
     return [
+        Path.cwd() / ".kubeflow-mcp.yaml",
         Path.home() / ".kubeflow-mcp.yaml",
         Path.home() / ".kubeflow-mcp.yml",
         Path.home() / ".config" / "kubeflow-mcp" / "config.yaml",
-        Path.cwd() / ".kubeflow-mcp.yaml",
     ]
 
 

--- a/kubeflow_mcp/core/config_test.py
+++ b/kubeflow_mcp/core/config_test.py
@@ -24,6 +24,7 @@ from tests.common import TestCase
 
 from kubeflow_mcp.core.config import (
     ServerConfig,
+    _find_config_file,
     load_config,
 )
 
@@ -116,6 +117,20 @@ def test_load_config_ignores_non_mapping_yaml(tmp_path, caplog):
 
     assert cfg.server.clients == ["trainer"]
     assert "Config root must be a mapping" in caplog.text
+
+
+def test_find_config_file_prefers_project_local_config(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    (home_dir / ".kubeflow-mcp.yaml").write_text("server:\n  persona: readonly\n")
+    local_config = tmp_path / ".kubeflow-mcp.yaml"
+    local_config.write_text("server:\n  persona: ml-engineer\n")
+
+    with (
+        patch("kubeflow_mcp.core.config.Path.home", return_value=home_dir),
+        patch("kubeflow_mcp.core.config.Path.cwd", return_value=tmp_path),
+    ):
+        assert _find_config_file() == local_config
 
 
 # TODO(test): test config_path that doesn't exist falls back to default search


### PR DESCRIPTION
## Description

Makes project-local `.kubeflow-mcp.yaml` configuration take precedence over global configuration files.

Previously, configuration files in the user's home directory were checked before the current working directory. This prevented a repository from overriding global settings.

The project-local configuration path is now checked first. A focused unit test verifies that the local configuration is selected when both local and global files exist.

## Related Issue

Fixes #148

## Checklist

- [ ] I have read the [CONTRIBUTING](./CONTRIBUTING.md) guide
- [ ] Tests pass locally (`make test-python`)
- [ ] Linting passes (`make verify`)
- [ ] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manually tested (describe below)

Ran:

```bash
uv run pytest -q kubeflow_mcp/core/config_test.py
uv run ruff check kubeflow_mcp/core/config.py kubeflow_mcp/core/config_test.py
uv run ruff format --check kubeflow_mcp/core/config.py kubeflow_mcp/core/config_test.py
```

All 11 configuration tests passed, and lint/format checks passed.