### PR TITLE
chore: kubeflow MCP Server release 0.1.1

### DIFF
--- a/CHANGELOG/CHANGELOG-0.1.md
+++ b/CHANGELOG/CHANGELOG-0.1.md
@@ -1,9 +1,9 @@
-# [0.1.0](https://github.com/kubeflow/mcp-server/releases/tag/0.1.0) (2026-08-10)
+# [0.1.1](https://github.com/kubeflow/mcp-server/releases/tag/0.1.1) (2026-08-11)
 
 This is the first official release of the Kubeflow MCP Server.
 
 ```
-pip install kubeflow-mcp==0.1.0
+pip install kubeflow-mcp==0.1.1
 ```
 
 The Kubeflow MCP Server exposes Kubeflow Trainer operations as [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) tools, letting AI agents plan, submit, monitor, and manage training jobs conversationally. Learn more about the highlights in the blog post:

--- a/kubeflow_mcp/__init__.py
+++ b/kubeflow_mcp/__init__.py
@@ -14,4 +14,4 @@
 
 """Kubeflow MCP Server - AI-powered interface for Kubeflow Training."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/kubeflow/mcp-server",
     "source": "github"
   },
-  "version": "0.1.0",
+  "version": "0.1.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "kubeflow-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Description

Re-release of 0.1.0 to work around a PyPI filename reuse restriction.
The 0.1.0 wheel was previously uploaded and deleted from PyPI, permanently
blocking that filename. This bumps to 0.1.1 with identical content.
cc: @andreyvelich

## Related Issue

Fixes the PyPI publish failure in https://github.com/kubeflow/mcp-server/actions/runs/31501365444