### PR TITLE
fix(core): move log failure patterns to a shared module

### DIFF
--- a/kubeflow_mcp/common/failures.py
+++ b/kubeflow_mcp/common/failures.py
@@ -1,0 +1,96 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Failure-pattern detection for workload logs.
+
+Shared by every client module that surfaces pod logs. Katib trials run as
+TrainJobs, so trainer and optimizer classify the same failure signatures —
+keeping the table here avoids one client module importing another's internals.
+"""
+
+import re
+
+FAILURE_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
+    (
+        re.compile(r"CUDA out of memory", re.IGNORECASE),
+        "OOM",
+        "Reduce batch_size, enable quantization (int8/int4), or request a larger GPU.",
+    ),
+    (
+        re.compile(r"OutOfMemoryError", re.IGNORECASE),
+        "OOM",
+        "Reduce batch_size, enable quantization (int8/int4), or request a larger GPU.",
+    ),
+    (
+        re.compile(r"RuntimeError: CUDA error", re.IGNORECASE),
+        "CUDA_ERROR",
+        "Check GPU driver compatibility and CUDA version in the runtime image.",
+    ),
+    (
+        re.compile(r"ModuleNotFoundError: No module named", re.IGNORECASE),
+        "MISSING_MODULE",
+        "Add the missing package to the 'packages' list.",
+    ),
+    (
+        re.compile(r"ImportError", re.IGNORECASE),
+        "IMPORT_ERROR",
+        "Verify package versions; add missing package to 'packages'.",
+    ),
+    (
+        re.compile(r"FileNotFoundError", re.IGNORECASE),
+        "FILE_NOT_FOUND",
+        "Check dataset/model paths and volume mounts.",
+    ),
+    # HF cache pattern MUST come before the generic PermissionError catch-all
+    # so that /.cache/huggingface failures are classified correctly.
+    (
+        re.compile(
+            r"Permission denied.*(?:huggingface|HF_HOME)|(?:huggingface|HF_HOME).*Permission denied",
+            re.IGNORECASE,
+        ),
+        "HF_CACHE_WRITE_ERROR",
+        "Set env var HF_HOME=/workspace to store HuggingFace cache on a writable volume mount.",
+    ),
+    (
+        re.compile(
+            r"PermissionError: \[Errno 13\] Permission denied: '/\.local|Permission denied: '/\.local",
+            re.IGNORECASE,
+        ),
+        "OPENSHIFT_PIP_ERROR",
+        "On OpenShift under a restricted SCC, pip install --user fails on read-only /.local. Do NOT use the 'packages' parameter in run_custom_training(). Instead, install packages inside your script to /workspace/lib using subprocess and append to sys.path. Read trainer://guides/platform-fixes for details.",
+    ),
+    (
+        re.compile(r"PermissionError|Access Denied", re.IGNORECASE),
+        "PERMISSION_ERROR",
+        "Check service account permissions and storage credentials.",
+    ),
+    (
+        re.compile(r"Connection(Error|Refused|Reset)", re.IGNORECASE),
+        "NETWORK_ERROR",
+        "Check network policies, DNS, and endpoint reachability.",
+    ),
+    (
+        re.compile(r"Traceback \(most recent call last\)", re.IGNORECASE),
+        "PYTHON_EXCEPTION",
+        "Review the traceback above for the root cause.",
+    ),
+]
+
+
+def extract_failure_hint(logs: str) -> dict[str, str] | None:
+    """Pattern-match common failure signatures and return an actionable hint."""
+    for pattern, category, suggestion in FAILURE_PATTERNS:
+        if pattern.search(logs):
+            return {"category": category, "suggestion": suggestion}
+    return None

--- a/kubeflow_mcp/trainer/api/monitoring.py
+++ b/kubeflow_mcp/trainer/api/monitoring.py
@@ -15,11 +15,11 @@
 """Monitoring tools for training job logs and events."""
 
 import logging
-import re
 from collections import deque
 from typing import Any
 
 from kubeflow_mcp.common.constants import ErrorCode
+from kubeflow_mcp.common.failures import extract_failure_hint
 from kubeflow_mcp.common.types import ToolError, ToolResponse, exception_details, is_k8s_not_found
 from kubeflow_mcp.common.utils import (
     get_core_v1_api,
@@ -38,80 +38,6 @@ MAX_LOG_LINES = 1000
 MAX_EVENT_LIMIT = 500
 MAX_WAIT_TIMEOUT = 3600
 MIN_POLLING_INTERVAL = 1
-
-_FAILURE_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
-    (
-        re.compile(r"CUDA out of memory", re.IGNORECASE),
-        "OOM",
-        "Reduce batch_size, enable quantization (int8/int4), or request a larger GPU.",
-    ),
-    (
-        re.compile(r"OutOfMemoryError", re.IGNORECASE),
-        "OOM",
-        "Reduce batch_size, enable quantization (int8/int4), or request a larger GPU.",
-    ),
-    (
-        re.compile(r"RuntimeError: CUDA error", re.IGNORECASE),
-        "CUDA_ERROR",
-        "Check GPU driver compatibility and CUDA version in the runtime image.",
-    ),
-    (
-        re.compile(r"ModuleNotFoundError: No module named", re.IGNORECASE),
-        "MISSING_MODULE",
-        "Add the missing package to the 'packages' list.",
-    ),
-    (
-        re.compile(r"ImportError", re.IGNORECASE),
-        "IMPORT_ERROR",
-        "Verify package versions; add missing package to 'packages'.",
-    ),
-    (
-        re.compile(r"FileNotFoundError", re.IGNORECASE),
-        "FILE_NOT_FOUND",
-        "Check dataset/model paths and volume mounts.",
-    ),
-    # HF cache pattern MUST come before the generic PermissionError catch-all
-    # so that /.cache/huggingface failures are classified correctly.
-    (
-        re.compile(
-            r"Permission denied.*(?:huggingface|HF_HOME)|(?:huggingface|HF_HOME).*Permission denied",
-            re.IGNORECASE,
-        ),
-        "HF_CACHE_WRITE_ERROR",
-        "Set env var HF_HOME=/workspace to store HuggingFace cache on a writable volume mount.",
-    ),
-    (
-        re.compile(
-            r"PermissionError: \[Errno 13\] Permission denied: '/\.local|Permission denied: '/\.local",
-            re.IGNORECASE,
-        ),
-        "OPENSHIFT_PIP_ERROR",
-        "On OpenShift under a restricted SCC, pip install --user fails on read-only /.local. Do NOT use the 'packages' parameter in run_custom_training(). Instead, install packages inside your script to /workspace/lib using subprocess and append to sys.path. Read trainer://guides/platform-fixes for details.",
-    ),
-    (
-        re.compile(r"PermissionError|Access Denied", re.IGNORECASE),
-        "PERMISSION_ERROR",
-        "Check service account permissions and storage credentials.",
-    ),
-    (
-        re.compile(r"Connection(Error|Refused|Reset)", re.IGNORECASE),
-        "NETWORK_ERROR",
-        "Check network policies, DNS, and endpoint reachability.",
-    ),
-    (
-        re.compile(r"Traceback \(most recent call last\)", re.IGNORECASE),
-        "PYTHON_EXCEPTION",
-        "Review the traceback above for the root cause.",
-    ),
-]
-
-
-def _extract_failure_hint(logs: str) -> dict[str, str] | None:
-    """Pattern-match common failure signatures and return an actionable hint."""
-    for pattern, category, suggestion in _FAILURE_PATTERNS:
-        if pattern.search(logs):
-            return {"category": category, "suggestion": suggestion}
-    return None
 
 
 def _is_pod_for_step(pod: Any, step: str) -> bool:
@@ -224,7 +150,7 @@ def get_training_logs(
             "lines": len(sanitized.split("\n")),
         }
 
-        hint = _extract_failure_hint(logs)
+        hint = extract_failure_hint(logs)
         if hint:
             data["failure_hint"] = hint
             data["next_steps"] = [

--- a/kubeflow_mcp/trainer/api/monitoring_test.py
+++ b/kubeflow_mcp/trainer/api/monitoring_test.py
@@ -32,7 +32,7 @@ from kubeflow_mcp.trainer.api.monitoring import (
 )
 
 
-def testextract_failure_hint_openshift_pip_error():
+def test_extract_failure_hint_openshift_pip_error():
     # Test exact PermissionError trace
     logs = (
         "Installing collected packages: torch\n"
@@ -52,7 +52,7 @@ def testextract_failure_hint_openshift_pip_error():
     assert hint_generic["category"] == "OPENSHIFT_PIP_ERROR"
 
 
-def testextract_failure_hint_generic_permission_error():
+def test_extract_failure_hint_generic_permission_error():
     # Test a generic permission error does not trigger OpenShift pip error
     logs = "PermissionError: [Errno 13] Permission denied: '/workspace/data.csv'"
     hint = extract_failure_hint(logs)
@@ -142,7 +142,7 @@ def test_normal_log_not_matched():
     assert extract_failure_hint("Training completed successfully. Epoch 5/5 finished.") is None
 
 
-def testextract_failure_hint_suggestion_text():
+def test_extract_failure_hint_suggestion_text():
     cuda = extract_failure_hint("RuntimeError: CUDA error: device-side assert triggered")
     assert cuda is not None
     assert "GPU driver compatibility" in cuda["suggestion"]

--- a/kubeflow_mcp/trainer/api/monitoring_test.py
+++ b/kubeflow_mcp/trainer/api/monitoring_test.py
@@ -22,10 +22,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from tests.common import TestCase
 
+from kubeflow_mcp.common.failures import FAILURE_PATTERNS, extract_failure_hint
 from kubeflow_mcp.trainer.api.monitoring import (
-    _FAILURE_PATTERNS,
     MAX_LOG_LINES,
-    _extract_failure_hint,
     _is_pod_for_step,
     get_training_events,
     get_training_logs,
@@ -33,14 +32,14 @@ from kubeflow_mcp.trainer.api.monitoring import (
 )
 
 
-def test_extract_failure_hint_openshift_pip_error():
+def testextract_failure_hint_openshift_pip_error():
     # Test exact PermissionError trace
     logs = (
         "Installing collected packages: torch\n"
         "PermissionError: [Errno 13] Permission denied: '/.local'\n"
         "ERROR: Job failed"
     )
-    hint = _extract_failure_hint(logs)
+    hint = extract_failure_hint(logs)
     assert hint is not None
     assert hint["category"] == "OPENSHIFT_PIP_ERROR"
     assert "On OpenShift under a restricted SCC" in hint["suggestion"]
@@ -48,15 +47,15 @@ def test_extract_failure_hint_openshift_pip_error():
 
     # Test generic permission denied on /.local
     logs_generic = "Permission denied: '/.local/bin/pip'"
-    hint_generic = _extract_failure_hint(logs_generic)
+    hint_generic = extract_failure_hint(logs_generic)
     assert hint_generic is not None
     assert hint_generic["category"] == "OPENSHIFT_PIP_ERROR"
 
 
-def test_extract_failure_hint_generic_permission_error():
+def testextract_failure_hint_generic_permission_error():
     # Test a generic permission error does not trigger OpenShift pip error
     logs = "PermissionError: [Errno 13] Permission denied: '/workspace/data.csv'"
-    hint = _extract_failure_hint(logs)
+    hint = extract_failure_hint(logs)
     assert hint is not None
     assert hint["category"] == "PERMISSION_ERROR"
     assert "Check service account permissions" in hint["suggestion"]
@@ -127,7 +126,7 @@ def test_failure_pattern_matches(test_case):
     log_line = test_case.config["log_line"]
     expected = test_case.config["expected_category"]
     matched = False
-    for pattern, category, hint in _FAILURE_PATTERNS:
+    for pattern, category, hint in FAILURE_PATTERNS:
         if pattern.search(log_line):
             assert category == expected
             assert len(hint) > 0
@@ -138,25 +137,25 @@ def test_failure_pattern_matches(test_case):
 
 def test_normal_log_not_matched():
     normal = "Epoch 1/10: loss=2.34, lr=0.001"
-    for pattern, _category, _hint in _FAILURE_PATTERNS:
+    for pattern, _category, _hint in FAILURE_PATTERNS:
         assert not pattern.search(normal)
-    assert _extract_failure_hint("Training completed successfully. Epoch 5/5 finished.") is None
+    assert extract_failure_hint("Training completed successfully. Epoch 5/5 finished.") is None
 
 
-def test_extract_failure_hint_suggestion_text():
-    cuda = _extract_failure_hint("RuntimeError: CUDA error: device-side assert triggered")
+def testextract_failure_hint_suggestion_text():
+    cuda = extract_failure_hint("RuntimeError: CUDA error: device-side assert triggered")
     assert cuda is not None
     assert "GPU driver compatibility" in cuda["suggestion"]
 
-    import_err = _extract_failure_hint("ImportError: cannot import name 'AutoModel'")
+    import_err = extract_failure_hint("ImportError: cannot import name 'AutoModel'")
     assert import_err is not None
     assert "package versions" in import_err["suggestion"]
 
-    missing = _extract_failure_hint("FileNotFoundError: [Errno 2] No such file")
+    missing = extract_failure_hint("FileNotFoundError: [Errno 2] No such file")
     assert missing is not None
     assert "dataset/model paths" in missing["suggestion"]
 
-    network = _extract_failure_hint("ConnectionRefused: could not connect to master")
+    network = extract_failure_hint("ConnectionRefused: could not connect to master")
     assert network is not None
     assert network["category"] == "NETWORK_ERROR"
     assert "network policies" in network["suggestion"]

--- a/kubeflow_mcp/trainer/api/sdk_contracts_test.py
+++ b/kubeflow_mcp/trainer/api/sdk_contracts_test.py
@@ -1072,29 +1072,29 @@ class TestMCPToolSignatures:
         assert cr_after.env is None, "monkey-patch should be reverted"
 
     def test_extract_failure_hint_hf_cache_patterns(self):
-        """Verify _extract_failure_hint detects HF cache errors before generic PermissionError."""
-        from kubeflow_mcp.trainer.api.monitoring import _extract_failure_hint
+        """Verify extract_failure_hint detects HF cache errors before generic PermissionError."""
+        from kubeflow_mcp.common.failures import extract_failure_hint
 
         # "Permission denied" followed by "huggingface"
-        hint1 = _extract_failure_hint("Permission denied when writing huggingface cache")
+        hint1 = extract_failure_hint("Permission denied when writing huggingface cache")
         assert hint1 is not None and hint1["category"] == "HF_CACHE_WRITE_ERROR"
 
         # "Permission denied" followed by "HF_HOME"
-        hint2 = _extract_failure_hint("Permission denied: cannot write to HF_HOME directory")
+        hint2 = extract_failure_hint("Permission denied: cannot write to HF_HOME directory")
         assert hint2 is not None and hint2["category"] == "HF_CACHE_WRITE_ERROR"
 
         # "HF_HOME" before "Permission denied" (reverse order)
-        hint3 = _extract_failure_hint("HF_HOME=/cache: Permission denied")
+        hint3 = extract_failure_hint("HF_HOME=/cache: Permission denied")
         assert hint3 is not None and hint3["category"] == "HF_CACHE_WRITE_ERROR"
 
         # /.cache/huggingface path must NOT fall through to generic PERMISSION_ERROR
-        hint4 = _extract_failure_hint(
+        hint4 = extract_failure_hint(
             "PermissionError: [Errno 13] Permission denied: '/.cache/huggingface/hub'"
         )
         assert hint4 is not None and hint4["category"] == "HF_CACHE_WRITE_ERROR"
 
         # Generic permission error without HF keywords → PERMISSION_ERROR
-        hint5 = _extract_failure_hint(
+        hint5 = extract_failure_hint(
             "PermissionError: [Errno 13] Permission denied: '/data/output'"
         )
         assert hint5 is not None and hint5["category"] == "PERMISSION_ERROR"


### PR DESCRIPTION
## Description

Moves the training-log failure pattern table and its matcher out of
`trainer/api/monitoring.py` into a new `common/failures.py`.

- Pure code move, no behavior change
- Katib trials run as TrainJobs, so the optimizer client (KEP-34) classifies the same failure signatures
- Leaving the table in the trainer module would force one client module to import another's private helper, breaking module independence
- Existing trainer tests are repointed to the new location; no test logic changed

This is groundwork split out of the optimizer client work so it can be reviewed
and merged on its own.

## Related Issue

Groundwork for KEP-34 (Katib optimizer client). No separate issue.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [ ] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manually tested

Full suite green on this branch (472 passed, 14 deselected). The moved
`FAILURE_PATTERNS` and `extract_failure_hint` keep their existing coverage in
`trainer/api/monitoring_test.py` and `trainer/api/sdk_contracts_test.py`,
including the `HF_CACHE_WRITE_ERROR` ordering case.
