### PR TITLE
fix(trainer): report a missing TrainJob as not found instead of unowned

### DIFF
--- a/kubeflow_mcp/common/utils.py
+++ b/kubeflow_mcp/common/utils.py
@@ -145,13 +145,23 @@ _TRAINJOB_VERSION = "v1alpha1"
 _TRAINJOB_PLURAL = "trainjobs"
 
 
-def is_mcp_managed(name: str, namespace: str) -> bool | None:
-    """Check if a TrainJob was created through MCP (has the ownership label).
+# Outcomes of an ownership check. "missing" is kept distinct from "unmanaged"
+# because the two need opposite responses: a job that does not exist is a
+# not-found, while collapsing it into "unmanaged" tells the caller to go fix
+# permissions that were never the problem.
+OWNERSHIP_MANAGED = "managed"
+OWNERSHIP_UNMANAGED = "unmanaged"
+OWNERSHIP_MISSING = "missing"
+
+
+def get_trainer_ownership(name: str, namespace: str) -> str | None:
+    """Classify a TrainJob for the MCP ownership gate.
 
     Returns:
-        True if the job has the MCP ownership label.
-        False if the job exists but lacks the label.
-        None if the check could not be performed (API error, permissions).
+        ``OWNERSHIP_MANAGED`` if the job carries the MCP ownership label,
+        ``OWNERSHIP_UNMANAGED`` if it exists without the label,
+        ``OWNERSHIP_MISSING`` if no such job exists, or
+        ``None`` if the check could not be performed (API error, permissions).
     """
     try:
         api = get_custom_objects_api()
@@ -164,12 +174,13 @@ def is_mcp_managed(name: str, namespace: str) -> bool | None:
             _request_timeout=K8S_TIMEOUT,
         )
         labels = obj.get("metadata", {}).get("labels", {})
-        return labels.get(MCP_MANAGED_LABEL) == MCP_MANAGED_VALUE
+        managed = labels.get(MCP_MANAGED_LABEL) == MCP_MANAGED_VALUE
+        return OWNERSHIP_MANAGED if managed else OWNERSHIP_UNMANAGED
     except Exception as e:
         from kubeflow_mcp.common.types import is_k8s_not_found
 
         if is_k8s_not_found(e):
-            return False
+            return OWNERSHIP_MISSING
         return None
 
 

--- a/kubeflow_mcp/common/utils_test.py
+++ b/kubeflow_mcp/common/utils_test.py
@@ -22,12 +22,15 @@ from unittest.mock import MagicMock, patch
 from kubeflow_mcp.common.utils import (
     MCP_MANAGED_LABEL,
     MCP_MANAGED_VALUE,
+    OWNERSHIP_MANAGED,
+    OWNERSHIP_MISSING,
+    OWNERSHIP_UNMANAGED,
     _get_api_client,
     get_core_v1_api,
     get_custom_objects_api,
     get_trainer_client_for_namespace,
     get_trainer_effective_namespace,
-    is_mcp_managed,
+    get_trainer_ownership,
     reset_clients,
 )
 
@@ -36,34 +39,36 @@ PATCH_GET_API_CLIENT = "kubeflow_mcp.common.utils._get_api_client"
 PATCH_TRAINER_CLIENT = "kubeflow_mcp.common.utils.get_trainer_client"
 
 
-class TestIsMcpManaged:
+class TestGetTrainerOwnership:
     @patch(PATCH_CUSTOM_API)
-    def test_returns_true_when_label_present(self, mock_api_fn):
+    def test_managed_when_label_present(self, mock_api_fn):
         mock_api = MagicMock()
         mock_api.get_namespaced_custom_object.return_value = {
             "metadata": {"labels": {MCP_MANAGED_LABEL: MCP_MANAGED_VALUE}}
         }
         mock_api_fn.return_value = mock_api
-        assert is_mcp_managed("my-job", "default") is True
+        assert get_trainer_ownership("my-job", "default") == OWNERSHIP_MANAGED
 
     @patch(PATCH_CUSTOM_API)
-    def test_returns_false_when_label_missing(self, mock_api_fn):
+    def test_unmanaged_when_label_missing(self, mock_api_fn):
         mock_api = MagicMock()
         mock_api.get_namespaced_custom_object.return_value = {
             "metadata": {"labels": {"other-label": "value"}}
         }
         mock_api_fn.return_value = mock_api
-        assert is_mcp_managed("my-job", "default") is False
+        assert get_trainer_ownership("my-job", "default") == OWNERSHIP_UNMANAGED
 
     @patch(PATCH_CUSTOM_API)
-    def test_returns_false_when_no_labels(self, mock_api_fn):
+    def test_unmanaged_when_no_labels(self, mock_api_fn):
         mock_api = MagicMock()
         mock_api.get_namespaced_custom_object.return_value = {"metadata": {}}
         mock_api_fn.return_value = mock_api
-        assert is_mcp_managed("my-job", "default") is False
+        assert get_trainer_ownership("my-job", "default") == OWNERSHIP_UNMANAGED
 
     @patch(PATCH_CUSTOM_API)
-    def test_returns_false_on_404(self, mock_api_fn):
+    def test_missing_on_404_is_distinct_from_unmanaged(self, mock_api_fn):
+        """A job that does not exist must not be reported as merely unlabelled:
+        the two need opposite responses from the ownership gate."""
         from kubernetes.client.exceptions import ApiException
 
         mock_api = MagicMock()
@@ -71,14 +76,14 @@ class TestIsMcpManaged:
             status=404, reason="Not Found"
         )
         mock_api_fn.return_value = mock_api
-        assert is_mcp_managed("missing-job", "default") is False
+        assert get_trainer_ownership("missing-job", "default") == OWNERSHIP_MISSING
 
     @patch(PATCH_CUSTOM_API)
     def test_returns_none_on_other_api_error(self, mock_api_fn):
         mock_api = MagicMock()
         mock_api.get_namespaced_custom_object.side_effect = Exception("connection refused")
         mock_api_fn.return_value = mock_api
-        assert is_mcp_managed("my-job", "default") is None
+        assert get_trainer_ownership("my-job", "default") is None
 
 
 class TestResetClients:

--- a/kubeflow_mcp/trainer/api/lifecycle.py
+++ b/kubeflow_mcp/trainer/api/lifecycle.py
@@ -34,6 +34,41 @@ from kubeflow_mcp.core.security import check_namespace_allowed, validate_k8s_nam
 logger = logging.getLogger(__name__)
 
 
+def _require_mcp_ownership(name: str, namespace: str, hint: str) -> ToolError | None:
+    """Block non-admin personas from mutating TrainJobs MCP did not create.
+
+    Returns ``None`` when the operation is allowed (admin persona, or the job
+    carries the MCP ownership label), otherwise the ``ToolError`` to return.
+
+    Shared by both mutating tools so the ownership outcomes cannot drift apart.
+    """
+    if get_effective_persona() == "platform-admin":
+        return None
+
+    ownership = mcp_utils.get_trainer_ownership(name, namespace)
+    if ownership is None:
+        return ToolError(
+            error=f"Cannot verify ownership of training job '{name}' (API error)",
+            error_code=ErrorCode.SDK_ERROR,
+            details={"hint": "Retry, or use platform-admin persona to bypass."},
+        )
+    if ownership == mcp_utils.OWNERSHIP_MISSING:
+        # Report the real problem. Falling through to the ownership message
+        # would blame permissions for what is usually a mistyped name, and
+        # would answer differently than it does for the platform-admin persona.
+        return ToolError(
+            error=f"Training job '{name}' not found",
+            error_code=ErrorCode.RESOURCE_NOT_FOUND,
+        )
+    if ownership == mcp_utils.OWNERSHIP_UNMANAGED:
+        return ToolError(
+            error=f"Training job '{name}' was not created by MCP",
+            error_code=ErrorCode.VALIDATION_ERROR,
+            details={"hint": hint},
+        )
+    return None
+
+
 def delete_training_job(
     name: str,
     namespace: str | None = None,
@@ -65,25 +100,14 @@ def delete_training_job(
             return ns_err.model_dump()
 
         ns = mcp_utils.get_trainer_effective_namespace(namespace)
-        if get_effective_persona() not in ("platform-admin",):
-            managed = mcp_utils.is_mcp_managed(name, ns)
-            if managed is None:
-                return ToolError(
-                    error=f"Cannot verify ownership of training job '{name}' (API error)",
-                    error_code=ErrorCode.SDK_ERROR,
-                    details={"hint": "Retry, or use platform-admin persona to bypass."},
-                ).model_dump()
-            if not managed:
-                return ToolError(
-                    error=f"Training job '{name}' was not created by MCP",
-                    error_code=ErrorCode.VALIDATION_ERROR,
-                    details={
-                        "hint": (
-                            "Data scientists can only delete jobs created through MCP tools. "
-                            "Use platform-admin persona to delete externally created jobs."
-                        ),
-                    },
-                ).model_dump()
+        owner_err = _require_mcp_ownership(
+            name,
+            ns,
+            "Data scientists can only delete jobs created through MCP tools. "
+            "Use platform-admin persona to delete externally created jobs.",
+        )
+        if owner_err is not None:
+            return owner_err.model_dump()
 
         if not confirmed:
             return PreviewResponse(
@@ -156,25 +180,14 @@ def update_training_job(
             return ns_err.model_dump()
 
         ns = mcp_utils.get_trainer_effective_namespace(namespace)
-        if get_effective_persona() not in ("platform-admin",):
-            managed = mcp_utils.is_mcp_managed(name, ns)
-            if managed is None:
-                return ToolError(
-                    error=f"Cannot verify ownership of training job '{name}' (API error)",
-                    error_code=ErrorCode.SDK_ERROR,
-                    details={"hint": "Retry, or use platform-admin persona to bypass."},
-                ).model_dump()
-            if not managed:
-                return ToolError(
-                    error=f"Training job '{name}' was not created by MCP",
-                    error_code=ErrorCode.VALIDATION_ERROR,
-                    details={
-                        "hint": (
-                            "Non-admin personas can only suspend/resume jobs created through MCP tools. "
-                            "Use platform-admin persona for externally created jobs."
-                        ),
-                    },
-                ).model_dump()
+        owner_err = _require_mcp_ownership(
+            name,
+            ns,
+            "Non-admin personas can only suspend/resume jobs created through MCP tools. "
+            "Use platform-admin persona for externally created jobs.",
+        )
+        if owner_err is not None:
+            return owner_err.model_dump()
 
         if not confirmed:
             return PreviewResponse(

--- a/kubeflow_mcp/trainer/api/lifecycle_test.py
+++ b/kubeflow_mcp/trainer/api/lifecycle_test.py
@@ -14,12 +14,13 @@
 
 """Tests for trainer/api/lifecycle.py — delete, suspend, resume.
 
-Covers input validation. K8s API interaction tests require mocking and are
-marked as TODOs.
+Covers input validation and the MCP ownership gate. The remaining K8s API
+interaction tests are marked as TODOs.
 """
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -29,6 +30,7 @@ from tests.common import (
     FAILED,
     PERMISSION_DENIED,
     RESOURCE_NOT_FOUND,
+    SDK_ERROR,
     VALIDATION_ERROR,
     TestCase,
     assert_test_case,
@@ -38,6 +40,25 @@ from kubeflow_mcp.common import utils as mcp_utils
 from kubeflow_mcp.common.constants import ErrorCode
 from kubeflow_mcp.common.types import ToolError
 from kubeflow_mcp.trainer.api.lifecycle import delete_training_job, update_training_job
+
+_UTILS = "kubeflow_mcp.common.utils"
+_LIFECYCLE = "kubeflow_mcp.trainer.api.lifecycle"
+
+
+@contextmanager
+def cluster(ownership=mcp_utils.OWNERSHIP_MANAGED, persona="data-scientist"):
+    """Patch namespace resolution, the ownership lookup and the K8s APIs."""
+    api = MagicMock()
+    client = MagicMock()
+    with (
+        patch(f"{_UTILS}.get_trainer_effective_namespace", return_value="default"),
+        patch(f"{_UTILS}.get_trainer_custom_objects_api", return_value=api),
+        patch(f"{_UTILS}.get_trainer_client_for_namespace", return_value=client),
+        patch(f"{_UTILS}.get_trainer_ownership", return_value=ownership) as lookup,
+        patch(f"{_LIFECYCLE}.get_effective_persona", return_value=persona),
+        patch(f"{_LIFECYCLE}.check_namespace_allowed", return_value=None),
+    ):
+        yield api, client, lookup
 
 
 @pytest.mark.parametrize(
@@ -94,12 +115,15 @@ class TestDeleteTrainingJob:
     @patch(
         "kubeflow_mcp.trainer.api.lifecycle.get_effective_persona", return_value="data-scientist"
     )
-    @patch("kubeflow_mcp.trainer.api.lifecycle.mcp_utils.is_mcp_managed", return_value=False)
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_ownership",
+        return_value=mcp_utils.OWNERSHIP_UNMANAGED,
+    )
     @patch(
         "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_effective_namespace",
         return_value="default",
     )
-    def test_non_admin_cannot_delete_non_mcp_job(self, _ns, _managed, _persona):
+    def test_non_admin_cannot_delete_non_mcp_job(self, _ns, _ownership, _persona):
         result = delete_training_job(name="external-job", confirmed=False)
         assert result["success"] is False
         assert result["error_code"] == VALIDATION_ERROR
@@ -130,6 +154,116 @@ class TestDeleteTrainingJob:
         result = delete_training_job(name="test-job", namespace="restricted-ns", confirmed=True)
         assert result["success"] is False
         assert result["error_code"] == PERMISSION_DENIED
+
+
+# ─── MCP ownership enforcement ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("persona", ["data-scientist", "ml-engineer", "platform-admin"])
+@pytest.mark.parametrize(
+    ("tool", "call"),
+    [
+        ("delete", lambda: delete_training_job("ghost-job", confirmed=True)),
+        ("update", lambda: update_training_job("ghost-job", "suspend", confirmed=True)),
+    ],
+)
+def test_missing_job_reports_not_found_for_every_persona(persona, tool, call):
+    """A name that does not exist is a not-found, whoever asks.
+
+    The ownership gate used to collapse "missing" into "not created by MCP",
+    so a typo sent non-admins after RBAC that was never the problem, and the
+    same job answered differently depending on the caller's persona.
+    """
+    with cluster(ownership=mcp_utils.OWNERSHIP_MISSING, persona=persona) as (api, client, _):
+        # platform-admin skips the ownership lookup and reaches the cluster,
+        # which returns its own 404.
+        client.delete_job.side_effect = ApiException(status=404, reason="Not Found")
+        api.patch_namespaced_custom_object.side_effect = ApiException(
+            status=404, reason="Not Found"
+        )
+        result = call()
+
+    assert result["success"] is False
+    assert result["error_code"] == RESOURCE_NOT_FOUND
+    assert "not created by MCP" not in result["error"]
+
+
+@pytest.mark.parametrize(
+    ("tool", "call"),
+    [
+        ("delete", lambda: delete_training_job("external", confirmed=True)),
+        ("update", lambda: update_training_job("external", "suspend", confirmed=True)),
+    ],
+)
+def test_non_admin_blocked_from_mutating_external_job(tool, call):
+    with cluster(ownership=mcp_utils.OWNERSHIP_UNMANAGED) as (api, client, _):
+        result = call()
+    assert result["success"] is False
+    assert result["error_code"] == VALIDATION_ERROR
+    assert "was not created by MCP" in result["error"]
+    client.delete_job.assert_not_called()
+    api.patch_namespaced_custom_object.assert_not_called()
+
+
+def test_non_admin_allowed_for_mcp_created_job():
+    with cluster(ownership=mcp_utils.OWNERSHIP_MANAGED) as (_, client, _lookup):
+        result = delete_training_job("ours", confirmed=True)
+    assert result["success"] is True
+    client.delete_job.assert_called_once()
+
+
+def test_admin_bypasses_ownership_check_entirely():
+    """platform-admin must not even perform the lookup."""
+    with cluster(ownership=mcp_utils.OWNERSHIP_UNMANAGED, persona="platform-admin") as (
+        _,
+        client,
+        lookup,
+    ):
+        result = delete_training_job("external", confirmed=True)
+    assert result["success"] is True
+    client.delete_job.assert_called_once()
+    lookup.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("tool", "call"),
+    [
+        ("delete", lambda: delete_training_job("ghost-job", confirmed=True)),
+        ("update", lambda: update_training_job("ghost-job", "suspend", confirmed=True)),
+    ],
+)
+def test_missing_job_end_to_end_from_a_real_404(tool, call):
+    """End to end through the real ownership helper, mocking only Kubernetes.
+
+    The tests above stub ``get_trainer_ownership``, so they pin the gate's
+    branching but cannot see how a genuine 404 is classified. This one closes
+    that gap: it is the test that fails if the 404 is ever folded back into
+    "unmanaged".
+    """
+    k8s = MagicMock()
+    k8s.get_namespaced_custom_object.side_effect = ApiException(status=404, reason="Not Found")
+    client = MagicMock()
+
+    with (
+        patch(f"{_UTILS}.get_trainer_effective_namespace", return_value="default"),
+        patch(f"{_UTILS}.get_custom_objects_api", return_value=k8s),
+        patch(f"{_UTILS}.get_trainer_custom_objects_api", return_value=k8s),
+        patch(f"{_UTILS}.get_trainer_client_for_namespace", return_value=client),
+        patch(f"{_LIFECYCLE}.get_effective_persona", return_value="data-scientist"),
+        patch(f"{_LIFECYCLE}.check_namespace_allowed", return_value=None),
+    ):
+        result = call()
+
+    assert result["error_code"] == RESOURCE_NOT_FOUND
+    assert "not created by MCP" not in result["error"]
+    client.delete_job.assert_not_called()
+
+
+def test_ownership_lookup_failure_does_not_mutate():
+    with cluster(ownership=None) as (_, client, _lookup):
+        result = delete_training_job("unknown", confirmed=True)
+    assert result["error_code"] == SDK_ERROR
+    client.delete_job.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -189,12 +323,15 @@ class TestUpdateTrainingJob:
     @patch(
         "kubeflow_mcp.trainer.api.lifecycle.get_effective_persona", return_value="data-scientist"
     )
-    @patch("kubeflow_mcp.trainer.api.lifecycle.mcp_utils.is_mcp_managed", return_value=False)
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_ownership",
+        return_value=mcp_utils.OWNERSHIP_UNMANAGED,
+    )
     @patch(
         "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_effective_namespace",
         return_value="default",
     )
-    def test_non_admin_cannot_preview_non_mcp_job(self, _ns, _managed, _persona):
+    def test_non_admin_cannot_preview_non_mcp_job(self, _ns, _ownership, _persona):
         result = update_training_job(name="external-job", action="suspend", confirmed=False)
         assert result["success"] is False
         assert result["error_code"] == VALIDATION_ERROR


### PR DESCRIPTION
## Description

- `is_mcp_managed` returned `False` for a TrainJob that does not exist, the same value it returns for one that exists without the MCP ownership label.
- `delete_training_job` and `update_training_job` gate on ownership before existence, so a mistyped name was reported as `VALIDATION_ERROR: "was not created by MCP"` with a permissions hint, instead of not found.
- The same missing job answered differently depending on the caller: `platform-admin` skips the gate and correctly got `RESOURCE_NOT_FOUND`, while every other persona got the misleading error.
- Replaced with `get_trainer_ownership`, returning `managed`, `unmanaged` or `missing`. Missing now maps to `RESOURCE_NOT_FOUND`, and the ownership message is reserved for jobs that actually exist.
- Both call sites now share one `_require_mcp_ownership` helper, removing duplicated error construction that had already drifted between the two tools.

No behaviour change for `managed`, `unmanaged` or API-failure outcomes.

## Related Issue

No existing issue. Found while exercising the Katib optimizer client against a live cluster.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [ ] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

- Added `test_missing_job_end_to_end_from_a_real_404`, which mocks only the Kubernetes API so the real ownership helper runs. The other ownership tests stub the helper, so they pin the gate's branching but cannot catch this class of regression.
- Verified the coverage actually bites: reintroducing the bug fails 3 tests, and all pass with the fix.
- Reproduced the original behaviour first by driving both tools with a mocked 404 across all three personas.
- Fills two existing `TODO(test)` markers in `trainer/api/lifecycle_test.py`.
- `make test-python`: 485 passed. `make verify`: all checks passed.

/kind bug
/area trainer
