### PR TITLE
fix(core): redact sensitive structured fields

### DIFF
--- a/kubeflow_mcp/core/logging.py
+++ b/kubeflow_mcp/core/logging.py
@@ -24,6 +24,8 @@ from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Any
 
+from kubeflow_mcp.core.security import mask_sensitive_data
+
 correlation_id: ContextVar[str] = ContextVar("correlation_id", default="")
 request_context: ContextVar[dict[str, Any] | None] = ContextVar("request_context", default=None)
 
@@ -31,24 +33,24 @@ _log_buffer: deque[dict[str, Any]] = deque(maxlen=1000)
 
 
 def _redact_dict(d: Any) -> Any:
-    """Recursively redact sensitive keys in a dict (and any nested lists)."""
-    sensitive_keys = {"password", "token", "secret", "authorization", "credential", "api_key"}
+    """Recursively redact sensitive data for logging."""
 
     if isinstance(d, dict):
-        redacted = {}
-        for k, v in d.items():
-            if isinstance(k, str) and any(s in k.lower() for s in sensitive_keys):
-                redacted[k] = "***"
-            elif isinstance(v, (dict, list)):
-                redacted[k] = _redact_dict(v)
-            elif isinstance(v, str):
-                redacted[k] = _REDACT_PATTERNS.sub("***", v)
-            else:
-                redacted[k] = v
-        return redacted
-
+        return _apply_pattern(mask_sensitive_data(d))
     if isinstance(d, list):
         return [_redact_dict(item) for item in d]
+
+    return d
+
+
+def _apply_pattern(d: Any) -> Any:
+    """Apply _REDACT_PATTERNS to string leaves in an already key-masked structure."""
+    if isinstance(d, dict):
+        return {k: _apply_pattern(v) for k, v in d.items()}
+    if isinstance(d, list):
+        return [_apply_pattern(v) for v in d]
+    if isinstance(d, str):
+        return _REDACT_PATTERNS.sub("***", d)
 
     return d
 

--- a/kubeflow_mcp/core/logging.py
+++ b/kubeflow_mcp/core/logging.py
@@ -30,6 +30,29 @@ request_context: ContextVar[dict[str, Any] | None] = ContextVar("request_context
 _log_buffer: deque[dict[str, Any]] = deque(maxlen=1000)
 
 
+def _redact_dict(d: Any) -> Any:
+    """Recursively redact sensitive keys in a dict (and any nested lists)."""
+    sensitive_keys = {"password", "token", "secret", "authorization", "credential", "api_key"}
+
+    if isinstance(d, dict):
+        redacted = {}
+        for k, v in d.items():
+            if isinstance(k, str) and any(s in k.lower() for s in sensitive_keys):
+                redacted[k] = "***"
+            elif isinstance(v, (dict, list)):
+                redacted[k] = _redact_dict(v)
+            elif isinstance(v, str):
+                redacted[k] = _REDACT_PATTERNS.sub("***", v)
+            else:
+                redacted[k] = v
+        return redacted
+
+    if isinstance(d, list):
+        return [_redact_dict(item) for item in d]
+
+    return d
+
+
 class StructuredFormatter(logging.Formatter):
     """JSON formatter for production."""
 
@@ -47,12 +70,13 @@ class StructuredFormatter(logging.Formatter):
 
         ctx = request_context.get()
         if ctx is not None:
-            log_dict["context"] = ctx
+            log_dict["context"] = _redact_dict(ctx)
 
         extra_keys = {"audit", "tool", "parameters", "success", "duration_ms", "tracing_enabled"}
         for key in extra_keys:
             if hasattr(record, key):
-                log_dict[key] = getattr(record, key)
+                value = getattr(record, key)
+                log_dict[key] = _redact_dict(value) if isinstance(value, (dict, list)) else value
 
         return json.dumps(log_dict, default=str)
 

--- a/kubeflow_mcp/core/logging_test.py
+++ b/kubeflow_mcp/core/logging_test.py
@@ -59,10 +59,26 @@ class TestRedactDict:
         assert result == {"Password": "***", "API_KEY": "***"}
 
     def test_substring_key_match(self):
-        # Matching is substring-based, so keys like "auth_token" or
-        # "client_secret" should also be redacted.
+        # auth_token matches via the "_token" suffix rule; client_secret
+        # matches via the "secret" substring rule in mask_sensitive_data.
         result = _redact_dict({"auth_token": "abc", "client_secret": "xyz"})
         assert result == {"auth_token": "***", "client_secret": "***"}
+
+    def test_tokenizer_key_not_falsely_redacted(self):
+        # mask_sensitive_data deliberately does not treat "tokenizer" as
+        # sensitive despite containing "token" as a substring — this was
+        # the false positive with the old local key-matching logic.
+        result = _redact_dict({"tokenizer": "bert-base-uncased"})
+        assert result == {"tokenizer": "bert-base-uncased"}
+
+    def test_safe_keys_not_redacted(self):
+        result = _redact_dict({"public_key": "ssh-rsa AAAA...", "key_name": "prod"})
+        assert result["public_key"] == "ssh-rsa AAAA..."
+        assert result["key_name"] == "prod"
+
+    def test_exact_sensitive_key_redacted(self):
+        result = _redact_dict({"access_token": "abc", "secret_access_key": "xyz"})
+        assert result == {"access_token": "***", "secret_access_key": "***"}
 
     def test_non_dict_non_list_input_returned_unchanged(self):
         assert _redact_dict("just a string") == "just a string"

--- a/kubeflow_mcp/core/logging_test.py
+++ b/kubeflow_mcp/core/logging_test.py
@@ -1,0 +1,149 @@
+# Copyright The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for structured logging redaction."""
+
+import json
+import logging
+
+import pytest
+
+from kubeflow_mcp.core.logging import StructuredFormatter, _redact_dict, request_context
+
+
+class TestRedactDict:
+    """Tests for the _redact_dict helper."""
+
+    def test_redacts_top_level_sensitive_key(self):
+        result = _redact_dict({"password": "hunter2"})
+        assert result == {"password": "***"}
+
+    def test_redacts_nested_dict(self):
+        result = _redact_dict({"user": {"token": "abc123"}})
+        assert result == {"user": {"token": "***"}}
+
+    def test_redacts_dict_inside_list(self):
+        result = _redact_dict({"steps": [{"password": "hunter2"}, {"name": "ok"}]})
+        assert result == {"steps": [{"password": "***"}, {"name": "ok"}]}
+
+    def test_redacts_non_string_sensitive_values(self):
+        # Sensitive keys should be redacted regardless of value type.
+        result = _redact_dict({"token": 12345, "secret": None})
+        assert result == {"token": "***", "secret": "***"}
+
+    def test_redacts_pattern_inside_non_sensitive_key_value(self):
+        # A sensitive-looking substring embedded in an otherwise ordinary
+        # string value should still be caught by the regex pass. Only the
+        # matched portion is replaced; surrounding text is preserved.
+        result = _redact_dict({"note": "password=hunter2 was used"})
+        assert result["note"] == "*** was used"
+        assert "hunter2" not in result["note"]
+
+    def test_leaves_non_sensitive_values_untouched(self):
+        result = _redact_dict({"user_id": "abc-123", "count": 5, "ok": True})
+        assert result == {"user_id": "abc-123", "count": 5, "ok": True}
+
+    def test_case_insensitive_key_match(self):
+        result = _redact_dict({"Password": "hunter2", "API_KEY": "xyz"})
+        assert result == {"Password": "***", "API_KEY": "***"}
+
+    def test_substring_key_match(self):
+        # Matching is substring-based, so keys like "auth_token" or
+        # "client_secret" should also be redacted.
+        result = _redact_dict({"auth_token": "abc", "client_secret": "xyz"})
+        assert result == {"auth_token": "***", "client_secret": "***"}
+
+    def test_non_dict_non_list_input_returned_unchanged(self):
+        assert _redact_dict("just a string") == "just a string"
+        assert _redact_dict(42) == 42
+        assert _redact_dict(None) is None
+
+    def test_empty_dict_and_list(self):
+        assert _redact_dict({}) == {}
+        assert _redact_dict([]) == []
+
+    def test_deeply_nested_mixed_structure(self):
+        payload = {
+            "request": {
+                "headers": {"authorization": "Bearer abc.def.ghi"},
+                "items": [
+                    {"credential": "xyz"},
+                    {"safe": "value"},
+                ],
+            }
+        }
+        result = _redact_dict(payload)
+        assert result["request"]["headers"]["authorization"] == "***"
+        assert result["request"]["items"][0]["credential"] == "***"
+        assert result["request"]["items"][1]["safe"] == "value"
+
+
+class TestStructuredFormatterRedaction:
+    """Integration-style tests: redaction applied via the actual formatter."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_context(self):
+        token = request_context.set(None)
+        yield
+        request_context.reset(token)
+
+    def _make_record(self, **extra):
+        record = logging.LogRecord(
+            name="kubeflow_mcp.test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="test message",
+            args=(),
+            exc_info=None,
+        )
+        for key, value in extra.items():
+            setattr(record, key, value)
+        return record
+
+    def test_context_is_redacted_in_output(self):
+        request_context.set({"password": "hunter2", "user": "alice"})
+        formatter = StructuredFormatter()
+        record = self._make_record()
+
+        output = json.loads(formatter.format(record))
+
+        assert output["context"]["password"] == "***"
+        assert output["context"]["user"] == "alice"
+
+    def test_parameters_extra_is_redacted_in_output(self):
+        formatter = StructuredFormatter()
+        record = self._make_record(parameters={"api_key": "sk-abc123", "limit": 10})
+
+        output = json.loads(formatter.format(record))
+
+        assert output["parameters"]["api_key"] == "***"
+        assert output["parameters"]["limit"] == 10
+
+    def test_non_dict_extra_passes_through_unmodified(self):
+        formatter = StructuredFormatter()
+        record = self._make_record(success=True, duration_ms=42)
+
+        output = json.loads(formatter.format(record))
+
+        assert output["success"] is True
+        assert output["duration_ms"] == 42
+
+    def test_no_context_omits_context_key(self):
+        formatter = StructuredFormatter()
+        record = self._make_record()
+
+        output = json.loads(formatter.format(record))
+
+        assert "context" not in output


### PR DESCRIPTION
Fix : 

- Add recursive _redact_dict() that replaces sensitive key values (password, token, secret, authorization, credential, api_key) with "***" in dictionaries and lists.
- Apply to request_context and all extra structured fields (parameters, audit, tool, etc.) in StructuredFormatter.
- Add missing unit test kubeflow_mcp/core/logging_test.py to validate redaction.

Issue:

- StructuredFormatter currently logs context and extra fields without redaction, leaking credentials/tokens to production log aggregators. This closes that gap.

Testing

- New unit test covers nested dicts, lists, and mixed sensitive/non‑sensitive fields.

All existing tests pass (make test-python & make verify).



