### PR TITLE
feat(examples): add manifests for in-cluster deployment

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,161 @@
+# Deploying Kubeflow MCP Server in a cluster
+
+A minimal, self-contained example for running the MCP Server inside Kubernetes so
+that agents can reach it over HTTP and drive
+[Kubeflow Trainer](https://github.com/kubeflow/trainer) in your own namespace.
+
+It is intentionally small: one Deployment, one ClusterIP Service, a ServiceAccount
+and least-privilege RBAC. No Ingress, no OIDC, no Helm chart.
+
+## Prerequisites
+
+- A Kubernetes cluster with Kubeflow Trainer installed
+- A namespace to run in. The example uses `kubeflow-user-example-com`, the Profile
+  namespace created by a standard Kubeflow installation
+- `kubectl` pointed at that cluster
+
+## Quick start
+
+```bash
+NAMESPACE=kubeflow-user-example-com
+
+# Generate the bearer token and deploy everything in one step. Piping keeps the
+# token out of manifests.yaml, so no credential is ever written to disk.
+sed "s/REPLACE_ME/$(openssl rand -hex 32)/" manifests.yaml | kubectl apply -f -
+
+kubectl rollout status deploy/kubeflow-mcp -n "$NAMESPACE"
+```
+
+Read the token back when configuring a client:
+
+```bash
+kubectl get secret kubeflow-mcp-auth -n "$NAMESPACE" -o jsonpath='{.data.token}' | base64 -d
+```
+
+To rotate it later, re-run the command above and restart the pod so the new value
+is picked up:
+
+```bash
+kubectl rollout restart deploy/kubeflow-mcp -n "$NAMESPACE"
+```
+
+If you prefer to manage the Secret separately — for example with an external secret
+store — delete the `Secret` document from `manifests.yaml` and create it
+imperatively instead. Leaving the document in place while doing this would reset
+the token to `REPLACE_ME` on the next apply:
+
+```bash
+kubectl create secret generic kubeflow-mcp-auth -n "$NAMESPACE" \
+  --from-literal=token="$(openssl rand -hex 32)"
+```
+
+## What gets created
+
+| Resource | Purpose |
+|---|---|
+| `Namespace/kubeflow-user-example-com` | Already present on a standard Kubeflow install, where the Profile controller owns it — applying is then a no-op |
+| `ServiceAccount/kubeflow-mcp` | Identity the server uses against the Kubernetes API |
+| `ClusterRole/kubeflow-mcp-read` | Read-only: `ClusterTrainingRuntime`, nodes, namespaces, CRDs |
+| `Role/kubeflow-mcp-trainjobs` | Full TrainJob lifecycle, in this namespace only |
+| `Role/kubeflow-mcp-trainer-version` | Read of the single `kubeflow-trainer-public` ConfigMap in `kubeflow-system`, so the SDK can report the Trainer control-plane version |
+| `Secret/kubeflow-mcp-auth` | Bearer token for the HTTP transport |
+| `Deployment/kubeflow-mcp` | The server, HTTP transport on port 8000 |
+| `Service/kubeflow-mcp` | ClusterIP, reachable at `kubeflow-mcp:8000` in-namespace |
+
+The server can create and delete TrainJobs in its own namespace, and can only read
+anything outside it.
+
+## Verify
+
+From inside the cluster:
+
+```bash
+kubectl run mcp-check -n "$NAMESPACE" --rm -it --restart=Never --image=curlimages/curl -- \
+  curl -s http://kubeflow-mcp:8000/ready
+```
+
+`/health` and `/ready` are served without authentication so the kubelet can probe
+them; every other endpoint requires the bearer token.
+
+To reach it from your workstation:
+
+```bash
+kubectl port-forward -n "$NAMESPACE" svc/kubeflow-mcp 8000:8000
+```
+
+Then point an MCP client at `http://localhost:8000/mcp` with
+`Authorization: Bearer <token>`.
+
+`KUBEFLOW_MCP_ALLOWED_HOSTS` lists `localhost` and `127.0.0.1` alongside the Service
+names for this reason. Setting the variable replaces the built-in loopback defaults
+rather than adding to them, so dropping those two entries makes port-forwarded
+clients fail with HTTP 421 while `/health` and `/ready` keep working.
+
+## Deploying into a different namespace
+
+The server is deployed into the user's Profile namespace on purpose: in-cluster the
+Kubeflow SDK derives its default namespace from the pod's ServiceAccount namespace.
+Running it elsewhere makes every tool default to a namespace that has no TrainJobs
+in it.
+
+To use another namespace, replace `kubeflow-user-example-com` everywhere in
+`manifests.yaml` — including inside `KUBEFLOW_MCP_ALLOWED_HOSTS`, which spells out
+the Service DNS names:
+
+```bash
+sed -i 's/kubeflow-user-example-com/my-namespace/g' manifests.yaml
+```
+
+## Choosing what the agent can do
+
+Tool exposure is controlled by the persona, which is separate from RBAC — RBAC
+decides what the ServiceAccount may touch in the Kubernetes API, the persona
+decides which MCP tools exist at all.
+
+| `KUBEFLOW_MCP_PERSONA` | Tools |
+|---|---|
+| `readonly` (default) | Inspection and monitoring only — cannot submit a TrainJob |
+| `data-scientist` (used here) | `readonly` plus `fine_tune`, `run_custom_training`, `wait_for_training`, `delete_training_job` |
+| `ml-engineer` | `data-scientist` plus `run_container_training`, `update_training_job`, `inspect_crd`, `inspect_controller` |
+| `platform-admin` | Everything |
+
+The example uses `data-scientist` because the default `readonly` persona cannot
+submit training jobs, which is the first thing most people want to try. Switch the
+`KUBEFLOW_MCP_PERSONA` env var to change it.
+
+`ml-engineer` additionally reads the Trainer controller's pods and logs, which the
+RBAC in this example does not grant. If you use it, add a read-only Role for the
+controller namespace and set `KUBEFLOW_MCP_CONTROLLER_NAMESPACE`.
+
+For finer control than the built-in personas, mount a policy file at
+`$HOME/.kf-mcp-policy.yaml` in the pod — see the main
+[README](../../README.md) for the format.
+
+## Troubleshooting
+
+**Requests return HTTP 421** — DNS rebinding protection allows loopback `Host`
+headers by default, so anything arriving via the Service is rejected.
+`KUBEFLOW_MCP_ALLOWED_HOSTS` must list the exact hostname clients use; only the
+`:*` port wildcard is supported, not a host wildcard. Note that `port-forward`
+does *not* reproduce this, because it sends a loopback `Host` header.
+
+**Tools report an empty namespace, or a 403 listing runtimes** — the pod is running
+outside the namespace whose TrainJobs you expect. See the section above.
+
+**The agent has no tool for submitting a TrainJob** — the persona is `readonly`.
+Set `KUBEFLOW_MCP_PERSONA` to `data-scientist` or higher.
+
+**Log line: `Trainer control-plane version info is not available ... (404)`** — the
+SDK reads the Trainer version from the `kubeflow-trainer-public` ConfigMap in
+`kubeflow-system`, which older Trainer releases do not create. Harmless: every
+`check_compatibility` check still passes, including the CRD and API version. If the
+same message shows `(403)` instead, the `kubeflow-mcp-trainer-version` Role is
+missing or Trainer runs in a different namespace than `kubeflow-system`.
+
+**Every authenticated request returns 401** — the token still reads `REPLACE_ME`,
+or the client is sending a different one. Compare against the value stored in the
+Secret.
+
+**Pod stuck in `CreateContainerConfigError`** — the `kubeflow-mcp-auth` Secret is
+missing, which happens if you removed it from `manifests.yaml` without creating it
+imperatively.

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -7,22 +7,20 @@ that agents can reach it over HTTP and drive
 It is intentionally small: one Deployment, one ClusterIP Service, a ServiceAccount
 and least-privilege RBAC. No Ingress, no OIDC, no Helm chart.
 
-## Prerequisites
-
-- A Kubernetes cluster with Kubeflow Trainer installed
-- A namespace to run in. The example uses `kubeflow-user-example-com`, the Profile
-  namespace created by a standard Kubeflow installation
-- `kubectl` pointed at that cluster
-
 ## Quick start
+
+Requires a cluster with Kubeflow Trainer installed, `kubectl`, and an existing
+namespace — the example uses `kubeflow-user-example-com`, the Profile namespace a
+standard Kubeflow install creates. The bearer token is not part of `manifests.yaml`,
+so create it first:
 
 ```bash
 NAMESPACE=kubeflow-user-example-com
 
-# Generate the bearer token and deploy everything in one step. Piping keeps the
-# token out of manifests.yaml, so no credential is ever written to disk.
-sed "s/REPLACE_ME/$(openssl rand -hex 32)/" manifests.yaml | kubectl apply -f -
+kubectl create secret generic kubeflow-mcp-auth -n "$NAMESPACE" \
+  --from-literal=token="$(openssl rand -hex 32)"
 
+kubectl apply -f manifests.yaml
 kubectl rollout status deploy/kubeflow-mcp -n "$NAMESPACE"
 ```
 
@@ -32,33 +30,25 @@ Read the token back when configuring a client:
 kubectl get secret kubeflow-mcp-auth -n "$NAMESPACE" -o jsonpath='{.data.token}' | base64 -d
 ```
 
-To rotate it later, re-run the command above and restart the pod so the new value
-is picked up:
-
-```bash
-kubectl rollout restart deploy/kubeflow-mcp -n "$NAMESPACE"
-```
-
-If you prefer to manage the Secret separately — for example with an external secret
-store — delete the `Secret` document from `manifests.yaml` and create it
-imperatively instead. Leaving the document in place while doing this would reset
-the token to `REPLACE_ME` on the next apply:
+To rotate it, replace the Secret and restart the pod so the new value is picked up.
+`replace` rather than `apply` keeps the new token out of the
+`last-applied-configuration` annotation:
 
 ```bash
 kubectl create secret generic kubeflow-mcp-auth -n "$NAMESPACE" \
-  --from-literal=token="$(openssl rand -hex 32)"
+  --from-literal=token="$(openssl rand -hex 32)" --dry-run=client -o yaml \
+  | kubectl replace -f -
+kubectl rollout restart deploy/kubeflow-mcp -n "$NAMESPACE"
 ```
 
 ## What gets created
 
 | Resource | Purpose |
 |---|---|
-| `Namespace/kubeflow-user-example-com` | Already present on a standard Kubeflow install, where the Profile controller owns it — applying is then a no-op |
 | `ServiceAccount/kubeflow-mcp` | Identity the server uses against the Kubernetes API |
 | `ClusterRole/kubeflow-mcp-read` | Read-only: `ClusterTrainingRuntime`, nodes, namespaces, CRDs |
 | `Role/kubeflow-mcp-trainjobs` | Full TrainJob lifecycle, in this namespace only |
 | `Role/kubeflow-mcp-trainer-version` | Read of the single `kubeflow-trainer-public` ConfigMap in `kubeflow-system`, so the SDK can report the Trainer control-plane version |
-| `Secret/kubeflow-mcp-auth` | Bearer token for the HTTP transport |
 | `Deployment/kubeflow-mcp` | The server, HTTP transport on port 8000 |
 | `Service/kubeflow-mcp` | ClusterIP, reachable at `kubeflow-mcp:8000` in-namespace |
 
@@ -100,36 +90,15 @@ in it.
 
 To use another namespace, replace `kubeflow-user-example-com` everywhere in
 `manifests.yaml` — including inside `KUBEFLOW_MCP_ALLOWED_HOSTS`, which spells out
-the Service DNS names:
+the Service DNS names, and the namespace suffix on both binding names. It leaves
+`kubeflow-system` untouched:
 
 ```bash
-sed -i 's/kubeflow-user-example-com/my-namespace/g' manifests.yaml
+sed -i.bak 's/kubeflow-user-example-com/my-namespace/g' manifests.yaml
 ```
 
-## Choosing what the agent can do
-
-Tool exposure is controlled by the persona, which is separate from RBAC — RBAC
-decides what the ServiceAccount may touch in the Kubernetes API, the persona
-decides which MCP tools exist at all.
-
-| `KUBEFLOW_MCP_PERSONA` | Tools |
-|---|---|
-| `readonly` (default) | Inspection and monitoring only — cannot submit a TrainJob |
-| `data-scientist` (used here) | `readonly` plus `fine_tune`, `run_custom_training`, `wait_for_training`, `delete_training_job` |
-| `ml-engineer` | `data-scientist` plus `run_container_training`, `update_training_job`, `inspect_crd`, `inspect_controller` |
-| `platform-admin` | Everything |
-
-The example uses `data-scientist` because the default `readonly` persona cannot
-submit training jobs, which is the first thing most people want to try. Switch the
-`KUBEFLOW_MCP_PERSONA` env var to change it.
-
-`ml-engineer` additionally reads the Trainer controller's pods and logs, which the
-RBAC in this example does not grant. If you use it, add a read-only Role for the
-controller namespace and set `KUBEFLOW_MCP_CONTROLLER_NAMESPACE`.
-
-For finer control than the built-in personas, mount a policy file at
-`$HOME/.kf-mcp-policy.yaml` in the pod — see the main
-[README](../../README.md) for the format.
+`-i.bak` rather than a bare `-i`: BSD `sed` on macOS reads the next argument as the
+backup suffix and fails without one.
 
 ## Troubleshooting
 
@@ -138,6 +107,10 @@ headers by default, so anything arriving via the Service is rejected.
 `KUBEFLOW_MCP_ALLOWED_HOSTS` must list the exact hostname clients use; only the
 `:*` port wildcard is supported, not a host wildcard. Note that `port-forward`
 does *not* reproduce this, because it sends a loopback `Host` header.
+
+**A browser-based client returns 403** — the `Origin` header is not allowed. Add it
+to `KUBEFLOW_MCP_ALLOWED_ORIGINS`; setting hosts alone leaves origins at their
+loopback-only defaults. Non-browser MCP clients send no `Origin` and are unaffected.
 
 **Tools report an empty namespace, or a 403 listing runtimes** — the pod is running
 outside the namespace whose TrainJobs you expect. See the section above.
@@ -152,10 +125,22 @@ SDK reads the Trainer version from the `kubeflow-trainer-public` ConfigMap in
 same message shows `(403)` instead, the `kubeflow-mcp-trainer-version` Role is
 missing or Trainer runs in a different namespace than `kubeflow-system`.
 
-**Every authenticated request returns 401** — the token still reads `REPLACE_ME`,
-or the client is sending a different one. Compare against the value stored in the
-Secret.
+**Every authenticated request returns 401** — the client is sending a different
+token than the one stored in the Secret.
 
-**Pod stuck in `CreateContainerConfigError`** — the `kubeflow-mcp-auth` Secret is
-missing, which happens if you removed it from `manifests.yaml` without creating it
-imperatively.
+**Pod stuck in `CreateContainerConfigError`** — the `kubeflow-mcp-auth` Secret does
+not exist yet. Create it as shown in the quick start.
+
+**`kubectl apply` fails with `namespaces "kubeflow-system" not found`** — Trainer
+runs somewhere else, so the two `kubeflow-mcp-trainer-version` documents have
+nowhere to go while the Deployment and Service are still created. Point those two
+documents at the Trainer namespace and set `KUBEFLOW_SYSTEM_NAMESPACE` to match.
+
+**The pod is `Ready` but calls still fail** — `/ready` is evaluated once when routes
+are registered and never re-checked, so it carries no more signal than `/health`. If
+the Kubernetes API becomes unreachable the pod stays `Ready` and keeps taking
+traffic from the Service.
+
+**A service mesh blocks traffic to the pod** — the Deployment sets
+`sidecar.istio.io/inject: "false"`. If your mesh enforces strict mTLS, remove that
+annotation and allow the traffic with a `PeerAuthentication`/`DestinationRule`.

--- a/examples/kubernetes/manifests.yaml
+++ b/examples/kubernetes/manifests.yaml
@@ -1,10 +1,5 @@
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: kubeflow-user-example-com
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubeflow-mcp
@@ -30,7 +25,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kubeflow-mcp-read
+  name: kubeflow-mcp-read-kubeflow-user-example-com
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -47,7 +42,7 @@ metadata:
   namespace: kubeflow-user-example-com
 rules:
   - apiGroups: ["trainer.kubeflow.org"]
-    resources: ["trainjobs", "trainjobs/status"]
+    resources: ["trainjobs"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["trainer.kubeflow.org"]
     resources: ["trainingruntimes"]
@@ -61,6 +56,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "events", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -90,7 +88,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: kubeflow-mcp-trainer-version
+  name: kubeflow-mcp-trainer-version-kubeflow-user-example-com
   namespace: kubeflow-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -100,17 +98,6 @@ subjects:
   - kind: ServiceAccount
     name: kubeflow-mcp
     namespace: kubeflow-user-example-com
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kubeflow-mcp-auth
-  namespace: kubeflow-user-example-com
-  labels:
-    app.kubernetes.io/name: kubeflow-mcp
-type: Opaque
-stringData:
-  token: REPLACE_ME
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -139,7 +126,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: server
-          image: ghcr.io/kubeflow/mcp-server:latest
+          image: ghcr.io/kubeflow/mcp-server:0.1.1
           ports:
             - name: http
               containerPort: 8000
@@ -149,7 +136,9 @@ spec:
             - name: FASTMCP_HOST
               value: "0.0.0.0"
             - name: KUBEFLOW_MCP_ALLOWED_HOSTS
-              value: "kubeflow-mcp:*,kubeflow-mcp.kubeflow-user-example-com.svc:*,kubeflow-mcp.kubeflow-user-example-com.svc.cluster.local:*,localhost:*,127.0.0.1:*"
+              value: "kubeflow-mcp:*,kubeflow-mcp.kubeflow-user-example-com.svc:*,kubeflow-mcp.kubeflow-user-example-com.svc.cluster.local:*,localhost:*,127.0.0.1:*,[::1]:*"
+            - name: KUBEFLOW_MCP_ALLOWED_ORIGINS
+              value: "http://kubeflow-mcp:*,http://kubeflow-mcp.kubeflow-user-example-com.svc:*,http://kubeflow-mcp.kubeflow-user-example-com.svc.cluster.local:*,http://localhost:*,http://127.0.0.1:*,http://[::1]:*"
             - name: KUBEFLOW_MCP_PERSONA
               value: data-scientist
             - name: KUBEFLOW_MCP_AUTH_TOKEN
@@ -157,17 +146,33 @@ spec:
                 secretKeyRef:
                   name: kubeflow-mcp-auth
                   key: token
+            - name: HOME
+              value: /home/kubeflow-mcp
+            - name: HF_HOME
+              value: /home/kubeflow-mcp/.cache/huggingface
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 2
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /health
               port: http
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /ready
               port: http
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
+              cpu: 100m
               memory: 128Mi
             limits:
               memory: 512Mi
@@ -179,8 +184,12 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: home
+              mountPath: /home/kubeflow-mcp
       volumes:
         - name: tmp
+          emptyDir: {}
+        - name: home
           emptyDir: {}
 ---
 apiVersion: v1

--- a/examples/kubernetes/manifests.yaml
+++ b/examples/kubernetes/manifests.yaml
@@ -59,7 +59,13 @@ rules:
     resources: ["jobs"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
+  - apiGroups: [""]
     resources: ["pods", "pods/log", "events", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  # get_runtime(include_packages=True) creates and deletes a probe Pod
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "delete"]
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/examples/kubernetes/manifests.yaml
+++ b/examples/kubernetes/manifests.yaml
@@ -1,0 +1,199 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow-user-example-com
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeflow-mcp
+  namespace: kubeflow-user-example-com
+  labels:
+    app.kubernetes.io/name: kubeflow-mcp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-mcp-read
+rules:
+  - apiGroups: ["trainer.kubeflow.org"]
+    resources: ["clustertrainingruntimes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes", "namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeflow-mcp-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeflow-mcp-read
+subjects:
+  - kind: ServiceAccount
+    name: kubeflow-mcp
+    namespace: kubeflow-user-example-com
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubeflow-mcp-trainjobs
+  namespace: kubeflow-user-example-com
+rules:
+  - apiGroups: ["trainer.kubeflow.org"]
+    resources: ["trainjobs", "trainjobs/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["trainer.kubeflow.org"]
+    resources: ["trainingruntimes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["jobset.x-k8s.io"]
+    resources: ["jobsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubeflow-mcp-trainjobs
+  namespace: kubeflow-user-example-com
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubeflow-mcp-trainjobs
+subjects:
+  - kind: ServiceAccount
+    name: kubeflow-mcp
+    namespace: kubeflow-user-example-com
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubeflow-mcp-trainer-version
+  namespace: kubeflow-system
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["kubeflow-trainer-public"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubeflow-mcp-trainer-version
+  namespace: kubeflow-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubeflow-mcp-trainer-version
+subjects:
+  - kind: ServiceAccount
+    name: kubeflow-mcp
+    namespace: kubeflow-user-example-com
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubeflow-mcp-auth
+  namespace: kubeflow-user-example-com
+  labels:
+    app.kubernetes.io/name: kubeflow-mcp
+type: Opaque
+stringData:
+  token: REPLACE_ME
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubeflow-mcp
+  namespace: kubeflow-user-example-com
+  labels:
+    app.kubernetes.io/name: kubeflow-mcp
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubeflow-mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kubeflow-mcp
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: kubeflow-mcp
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: server
+          image: ghcr.io/kubeflow/mcp-server:latest
+          ports:
+            - name: http
+              containerPort: 8000
+          env:
+            - name: MCP_TRANSPORT
+              value: http
+            - name: FASTMCP_HOST
+              value: "0.0.0.0"
+            - name: KUBEFLOW_MCP_ALLOWED_HOSTS
+              value: "kubeflow-mcp:*,kubeflow-mcp.kubeflow-user-example-com.svc:*,kubeflow-mcp.kubeflow-user-example-com.svc.cluster.local:*,localhost:*,127.0.0.1:*"
+            - name: KUBEFLOW_MCP_PERSONA
+              value: data-scientist
+            - name: KUBEFLOW_MCP_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: kubeflow-mcp-auth
+                  key: token
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubeflow-mcp
+  namespace: kubeflow-user-example-com
+  labels:
+    app.kubernetes.io/name: kubeflow-mcp
+spec:
+  selector:
+    app.kubernetes.io/name: kubeflow-mcp
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http


### PR DESCRIPTION
## Description

Adds a self-contained Kubernetes example so the MCP Server can be deployed in a
cluster and reached over HTTP by an MCP client. A single `kubectl apply` creates the
namespace, ServiceAccount, least-privilege RBAC, auth Secret, Deployment and Service,
with liveness and readiness probes wired to `/health` and `/ready`.

## Related Issue

Related to kubeflow/mcp-server#161

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`) (failing for current main)
- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [x] Manually tested (describe below)

Deployed to a kind cluster running Kubeflow Trainer v2.1.0, then driven end to end from
an MCP client (Claude Code) connected over `kubectl port-forward`.

**`pre_flight`** — environment compatible:

**`run_custom_training`** — the two-phase confirmation gate behaved as designed: the
first call with `confirmed=False` returned a clean preview with no safety warnings, and
the job was only submitted on the follow-up call with `confirmed=True`.

**Result** — TrainJob `two-moons-mlp` reached `Complete`, with logs retrieved through
the server:

