### PR TITLE
fix: validate discovery resource names

### DIFF
--- a/kubeflow_mcp/trainer/api/discovery.py
+++ b/kubeflow_mcp/trainer/api/discovery.py
@@ -28,7 +28,7 @@ from kubeflow_mcp.common.utils import (
     get_trainer_client_for_namespace,
     get_trainer_effective_namespace,
 )
-from kubeflow_mcp.core.security import check_namespace_allowed
+from kubeflow_mcp.core.security import check_namespace_allowed, validate_k8s_name
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +79,11 @@ def list_training_jobs(
         >>> list_training_jobs(status="Running")
         {"data": {"jobs": [{"name": "fine-tune-abc", "status": "Running"}], "total": 1}}
     """
+    if runtime:
+        runtime_err = validate_k8s_name(runtime, "runtime")
+        if runtime_err is not None:
+            return runtime_err.model_dump()
+
     ns_err = check_namespace_allowed(namespace)
     if ns_err is not None:
         return ns_err.model_dump()
@@ -134,6 +139,10 @@ def get_training_job(name: str, namespace: str | None = None) -> dict[str, Any]:
     Raises:
         ToolError: If job not found (``RESOURCE_NOT_FOUND``).
     """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
     ns_err = check_namespace_allowed(namespace)
     if ns_err is not None:
         return ns_err.model_dump()
@@ -366,6 +375,10 @@ def get_runtime(name: str, include_packages: bool = False) -> dict[str, Any]:
     Raises:
         ToolError: If runtime not found (``RESOURCE_NOT_FOUND``).
     """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
     try:
         client = get_trainer_client()
         rt = client.get_runtime(name=name)

--- a/kubeflow_mcp/trainer/api/discovery_test.py
+++ b/kubeflow_mcp/trainer/api/discovery_test.py
@@ -12,16 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for trainer/api/discovery.py — list/get training jobs and runtimes.
+"""Tests for trainer/api/discovery.py.
 
-Covers input validation and status filter aliasing.
+Covers discovery behavior, input validation, and status filter aliasing.
 K8s API interaction tests require mocking the SDK and are marked as TODOs.
 """
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import pytest
 from tests.common import RESOURCE_NOT_FOUND
 
+from kubeflow_mcp.common.constants import ErrorCode
 from kubeflow_mcp.conftest import (
     NOT_FOUND_NAME,
     VALID_JOB_NAME,
@@ -31,7 +35,9 @@ from kubeflow_mcp.conftest import (
 from kubeflow_mcp.trainer.api.discovery import (
     _JOB_STATUS_FILTER_ALIASES,
     _trainjob_runtime_to_mcp,
+    get_runtime,
     get_training_job,
+    list_training_jobs,
 )
 
 
@@ -69,13 +75,41 @@ def test_get_training_job_not_found(mock_trainer_client):
     verify_tool_error(result, error_code=RESOURCE_NOT_FOUND)
 
 
-# TODO(test): list_training_jobs — returns formatted job list with mock SDK
-# TODO(test): list_training_jobs — status filter applies alias
-# TODO(test): list_training_jobs — runtime filter
-# TODO(test): list_training_jobs — namespace policy enforcement
-# TODO(test): get_training_job — returns job details with mock SDK
-# TODO(test): get_training_job — invalid name rejected
-# TODO(test): list_runtimes — returns runtime list
-# TODO(test): get_runtime — returns runtime details
-# TODO(test): get_runtime — include_packages=True spawns pod
-# TODO(test): get_runtime — not found returns RESOURCE_NOT_FOUND
+@pytest.mark.parametrize(
+    ("tool", "kwargs", "client_path"),
+    [
+        (
+            get_training_job,
+            {"name": "INVALID_NAME"},
+            "kubeflow_mcp.trainer.api.discovery.get_trainer_client_for_namespace",
+        ),
+        (
+            get_runtime,
+            {"name": "INVALID_NAME"},
+            "kubeflow_mcp.trainer.api.discovery.get_trainer_client",
+        ),
+        (
+            list_training_jobs,
+            {"runtime": "INVALID_NAME"},
+            "kubeflow_mcp.trainer.api.discovery.get_trainer_client_for_namespace",
+        ),
+    ],
+)
+def test_rejects_invalid_resource_name_before_calling_sdk(tool, kwargs, client_path):
+    with patch(client_path) as mock_client:
+        result = tool(**kwargs)
+
+    assert result["success"] is False
+    assert result["error_code"] == ErrorCode.VALIDATION_ERROR
+    mock_client.assert_not_called()
+
+
+# TODO(test): list_training_jobs - returns formatted job list with mock SDK
+# TODO(test): list_training_jobs - status filter applies alias
+# TODO(test): list_training_jobs - runtime filter
+# TODO(test): list_training_jobs - namespace policy enforcement
+# TODO(test): get_training_job - returns job details with mock SDK
+# TODO(test): list_runtimes - returns runtime list
+# TODO(test): get_runtime - returns runtime details
+# TODO(test): get_runtime - include_packages=True spawns pod
+# TODO(test): get_runtime - not found returns RESOURCE_NOT_FOUND


### PR DESCRIPTION
## Description

Validates Kubernetes resource names in Trainer discovery tools before SDK calls.

This adds validation for:

- `get_training_job(name=...)`
- `get_runtime(name=...)`
- `list_training_jobs(runtime=...)`

Invalid names now return the standard `VALIDATION_ERROR` response instead of reaching the Trainer/Kubernetes SDK and producing a less clear SDK error.

Focused unit tests also verify that the SDK client is not called when validation fails.

## Related Issue

Fixes #162

## Testing

- [x] Focused discovery validation tests
- [x] Full Python test suite (`221 passed`)
- [x] Ruff lint and formatting checks
- [x] Pre-commit checks

## Checklist

- [x] My commit is signed off
- [x] Tests pass locally
- [x] Linting and formatting pass