### PR TITLE
fix: validate monitoring job names

### DIFF
--- a/kubeflow_mcp/trainer/api/monitoring.py
+++ b/kubeflow_mcp/trainer/api/monitoring.py
@@ -152,6 +152,10 @@ def get_training_logs(
     Raises:
         ToolError: If job not found (``RESOURCE_NOT_FOUND``).
     """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
     ns_err = check_namespace_allowed(namespace)
     if ns_err is not None:
         return ns_err.model_dump()
@@ -172,9 +176,6 @@ def get_training_logs(
         if not log_lines:
             try:
                 eff_ns = get_trainer_effective_namespace(namespace)
-                name_err = validate_k8s_name(name)
-                if name_err is not None:
-                    return name_err.model_dump()
                 v1 = get_core_v1_api()
                 pods = v1.list_namespaced_pod(
                     namespace=eff_ns,
@@ -268,6 +269,10 @@ def get_training_events(
           ``involved_object_name``, ``reason``, ``message``, ``event_time``
         - ``total`` (int): Total event count
     """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
     ns_err = check_namespace_allowed(namespace)
     if ns_err is not None:
         return ns_err.model_dump()
@@ -341,6 +346,10 @@ def wait_for_training(
         - ``reached`` (bool): Whether a target status was reached
         - ``message`` (str): Status message or timeout notice
     """
+    name_err = validate_k8s_name(name)
+    if name_err is not None:
+        return name_err.model_dump()
+
     ns_err = check_namespace_allowed(namespace)
     if ns_err is not None:
         return ns_err.model_dump()

--- a/kubeflow_mcp/trainer/api/monitoring_test.py
+++ b/kubeflow_mcp/trainer/api/monitoring_test.py
@@ -330,20 +330,12 @@ class TestGetTrainingLogs:
         assert result["success"] is True
         assert result["data"]["logs"] == ""
 
-    @patch(PATCH_VALIDATE_NAME)
-    @patch(PATCH_EFF_NS, return_value="default")
-    @patch(PATCH_NS_CHECK, return_value=None)
     @patch(PATCH_CLIENT)
-    def test_fallback_invalid_name_returns_error(self, mock_client_fn, _ns, _eff_ns, mock_validate):
-        from kubeflow_mcp.common.types import ToolError as ToolErrorModel
-
-        mock_client_fn.return_value = _make_mock_client(get_job_logs=[])
-        mock_validate.return_value = ToolErrorModel(
-            error="invalid name", error_code="VALIDATION_ERROR"
-        )
+    def test_invalid_name_rejected_before_sdk_call(self, mock_client_fn):
         result = get_training_logs("bad..name", step="node-0")
         assert result["success"] is False
         assert result["error_code"] == "VALIDATION_ERROR"
+        mock_client_fn.assert_not_called()
 
     @patch(PATCH_VALIDATE_NAME, return_value=None)
     @patch(PATCH_CORE_V1)
@@ -466,6 +458,13 @@ class TestGetTrainingEvents:
         assert result["success"] is False
         assert result["error_code"] == "PERMISSION_DENIED"
 
+    @patch(PATCH_CLIENT)
+    def test_invalid_name_rejected_before_sdk_call(self, mock_client_fn):
+        result = get_training_events("bad..name")
+        assert result["success"] is False
+        assert result["error_code"] == "VALIDATION_ERROR"
+        mock_client_fn.assert_not_called()
+
 
 # ─── wait_for_training (tool-level) ──────────────────────────────────────
 
@@ -555,3 +554,10 @@ class TestWaitForTraining:
         result = wait_for_training("my-job", namespace="forbidden-ns")
         assert result["success"] is False
         assert result["error_code"] == "PERMISSION_DENIED"
+
+    @patch(PATCH_CLIENT)
+    def test_invalid_name_rejected_before_sdk_call(self, mock_client_fn):
+        result = wait_for_training("bad..name")
+        assert result["success"] is False
+        assert result["error_code"] == "VALIDATION_ERROR"
+        mock_client_fn.assert_not_called()


### PR DESCRIPTION
## Description

Validates training job names at the start of all monitoring tools before calling the Trainer/Kubernetes SDK.

Updated:

- `get_training_logs()`
- `get_training_events()`
- `wait_for_training()`

The previous validation inside the `get_training_logs()` fallback path was removed because validation now happens once at the tool boundary.

Focused tests verify that invalid names return `VALIDATION_ERROR` and do not call the SDK.

## Related Issue

Fixes #164

## Testing

- [x] Focused monitoring tests
- [x] Full Python test suite (`221 passed`)
- [x] Ruff lint and formatting checks
- [x] Pre-commit checks

## Checklist

- [x] My commit is signed off
- [x] Tests pass locally
- [x] Linting and formatting pass