### PR TITLE
fix(trainer): bound memory when reading training job logs

### DIFF
--- a/kubeflow_mcp/trainer/api/monitoring.py
+++ b/kubeflow_mcp/trainer/api/monitoring.py
@@ -16,6 +16,7 @@
 
 import logging
 import re
+from collections import deque
 from typing import Any
 
 from kubeflow_mcp.common.constants import ErrorCode
@@ -168,7 +169,9 @@ def get_training_logs(
             ).model_dump()
 
         client = get_trainer_client_for_namespace(namespace)
-        log_lines = list(client.get_job_logs(name=name, step=step, follow=False))
+        log_lines = list(
+            deque(client.get_job_logs(name=name, step=step, follow=False), maxlen=MAX_LOG_LINES)
+        )
         if not log_lines:
             try:
                 eff_ns = get_trainer_effective_namespace(namespace)

--- a/kubeflow_mcp/trainer/api/monitoring_test.py
+++ b/kubeflow_mcp/trainer/api/monitoring_test.py
@@ -251,6 +251,21 @@ class TestGetTrainingLogs:
         assert result["success"] is True
         assert "line 499" not in result["data"]["logs"]
         assert f"line {MAX_LOG_LINES + 499}" in result["data"]["logs"]
+        assert result["data"]["lines"] == MAX_LOG_LINES
+
+    @patch(PATCH_NS_CHECK, return_value=None)
+    @patch(PATCH_CLIENT)
+    def test_log_truncation_with_generator(self, mock_client_fn, _ns):
+        def _log_generator():
+            for i in range(MAX_LOG_LINES + 500):
+                yield f"g{i}"
+
+        mock_client_fn.return_value = _make_mock_client(get_job_logs=_log_generator())
+        result = get_training_logs("big-generator-job")
+        assert result["success"] is True
+        assert "g499\n" not in result["data"]["logs"]
+        assert f"g{MAX_LOG_LINES + 499}" in result["data"]["logs"]
+        assert result["data"]["lines"] == MAX_LOG_LINES
 
     @patch(PATCH_NS_CHECK, return_value=None)
     @patch(PATCH_CLIENT)


### PR DESCRIPTION
### What this PR does

- Consumes `client.get_job_logs()` using `collections.deque(..., maxlen=MAX_LOG_LINES)` instead of an unbounded `list()`.
- Keeps log memory in the MCP server bounded to `MAX_LOG_LINES` during stream iteration, avoiding large intermediate list allocations on high-output training jobs.
- Adds `test_log_truncation_with_generator` in `kubeflow_mcp/trainer/api/monitoring_test.py` with boundary line count assertions.

Fixes #166

### How it was tested

- `uv run pytest kubeflow_mcp/trainer/api/monitoring_test.py` (45 passed)
- `uv run pytest` (480 passed)
- `make verify` (clean)
