### PR TITLE
fix(ci): stop welcoming returning contributors as first-timers

### DIFF
--- a/.github/workflows/welcome-new-contributors.yaml
+++ b/.github/workflows/welcome-new-contributors.yaml
@@ -9,7 +9,6 @@ on:
       - opened
 
 permissions:
-  contents: write
   issues: write
   pull-requests: write
 
@@ -17,10 +16,14 @@ jobs:
   welcome:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/first-interaction@v3
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          issue_message: |
+      # actions/first-interaction@v3 greets returning contributors on every
+      # PR (its PR check ignores the author, and its skip guard lets any PR
+      # author who has never filed an issue through — see issue #171 and
+      # https://github.com/actions/first-interaction/issues/369). Check the
+      # author's own history via the search API instead.
+      - uses: actions/github-script@v8
+        env:
+          ISSUE_MESSAGE: |
             🎉 **Welcome to the Kubeflow MCP Server!** 🎉
 
             Thanks for opening your first issue! We're happy to have you as part of our community 🚀
@@ -37,7 +40,7 @@ jobs:
             Feel free to ask questions in the comments if you need any help or clarification!
             Thanks again for contributing to Kubeflow! 🙏
 
-          pr_message: |
+          PR_MESSAGE: |
             🎉 **Welcome to the Kubeflow MCP Server!** 🎉
 
             Thanks for opening your first PR! We're happy to have you as part of our community 🚀
@@ -53,3 +56,33 @@ jobs:
 
             Feel free to ask questions in the comments if you need any help or clarification!
             Thanks again for contributing to Kubeflow! 🙏
+        with:
+          script: |
+            const sender = context.payload.sender
+            if (!sender || sender.type === 'Bot') {
+              return core.info('Skipping: bot or missing sender')
+            }
+
+            const isIssue = context.payload.issue !== undefined
+            const number = context.issue.number
+            const type = isIssue ? 'issue' : 'pr'
+
+            // Count the author's earlier issues or PRs in this repo.
+            const query = `repo:${context.repo.owner}/${context.repo.repo} type:${type} author:${sender.login}`
+            const { data } = await github.rest.search.issuesAndPullRequests({
+              q: query,
+              advanced_search: true,
+              per_page: 100,
+            })
+
+            if (data.items.some((item) => item.number < number)) {
+              return core.info(`Skipping: not ${sender.login}'s first ${type}`)
+            }
+
+            core.info(`Welcoming ${sender.login} on their first ${type} (#${number})`)
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: isIssue ? process.env.ISSUE_MESSAGE : process.env.PR_MESSAGE,
+            })


### PR DESCRIPTION
## What this PR does

Fixes the `Welcome new contributors` workflow greeting returning contributors with *"Thanks for opening your first PR!"* on **every** PR they open (happened on #90, #147, and #170 — all mine, well after #30 was merged).

## Root cause

`actions/first-interaction@v3` is broken (see #171 for the full analysis, and upstream actions/first-interaction#369):

1. Its `isFirstPullRequest()` lists **all** repo PRs with no author filter, so it can only be true for the repo's literal first PR.
2. Its skip guard is `if (!isFirstIssue && !isFirstPullRequest) skip` — on a PR event it still consults `isFirstIssue`, which **is** author-filtered. Any PR author who has never filed an issue in this repo makes that check true, bypassing the skip, so the `pr_message` posts on every PR they open.

## The fix

Replace `actions/first-interaction` with a small `actions/github-script` step that:

- searches the **author's own history** in this repo (`type:pr author:X` / `type:issue author:X`) and only comments when no earlier item by them exists
- keeps the exact same welcome messages (moved to `env` so no script injection surface)
- skips bot senders (e.g. google-oss-prow, dependabot), which the old action greeted too
- drops the unneeded `contents: write` permission (least privilege — the job only comments)

The workflow keeps running on `pull_request_target` so it can comment on fork PRs; the script never checks out or executes PR code, so that trigger remains safe.

Fixes #171