### PR TITLE
fix(ci): gate E2E workflow behind path filter and ok-to-test-e2e label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -144,6 +144,10 @@
   color: "74bb61"
   description: "Approve CI for external contributors"
 
+- name: ok-to-test-e2e
+  color: "74bb61"
+  description: "Run the Kubernetes E2E workflow on this PR"
+
 - name: good first issue
   color: "7057ff"
   description: "Good for newcomers"

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -1,6 +1,23 @@
 name: E2E Test - Kubernetes
 
-on: pull_request
+# E2E provisions a large runner + Kind cluster, so it is gated to avoid
+# unnecessary compute (see #174):
+#   - PRs: only when E2E-relevant paths change AND the `ok-to-test-e2e`
+#     label is present (add the label to (re-)trigger the run)
+#   - push to main: always, for post-merge validation
+#   - workflow_dispatch: manual runs
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - "kubeflow_mcp/**"
+      - "tests/e2e/**"
+      - "pyproject.toml"
+      - "Makefile"
+      - ".github/workflows/e2e-k8s.yaml"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,7 +29,13 @@ permissions:
 jobs:
   e2e:
     name: E2E Test (Kind Cluster)
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test-e2e')
     runs-on: oracle-vm-16cpu-64gb-x86-64
+    # Successful runs take ~35-40 min (cluster setup + tests); cap well
+    # above that so hung runs cannot hold the large runner indefinitely.
+    timeout-minutes: 50
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What this PR does

Gates the Kubernetes E2E workflow so it no longer provisions a 16-CPU/64GB runner + Kind cluster on every PR.

- **Path filter** on `pull_request`: `kubeflow_mcp/**`, `tests/e2e/**`, `pyproject.toml`, `Makefile`, plus `.github/workflows/e2e-k8s.yaml` itself so changes to the workflow are still exercised
- **Label gate**: the job only runs on PRs carrying the `ok-to-test-e2e` label; `labeled` is included in the trigger types, so adding the label (re-)triggers the run. The label is added to `.github/labels.yml` (auto-synced by `sync-labels.yaml` on merge)
- **`workflow_dispatch`** for manual runs
- **`push` to `main`** stays unconditional for post-merge validation
- **`timeout-minutes: 50`** so hung runs cannot hold the runner indefinitely

### Note: timeout is 50, not 15

The issue proposed `timeout-minutes: 15`, but recent **successful** runs of this workflow take ~35–40 min (cluster setup + tests), so a 15-minute cap would kill every legitimate run, including post-merge validation on `main`. 50 keeps a hard ceiling well below the 360-min default while leaving headroom for real runs.

E2E is not a required status check on `main`, so path-filtered PRs are not blocked waiting on a skipped run.

Fixes #174