### PR TITLE
chore(ci): ignore kubeflow SDK minor/major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "kubeflow"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
 
   # GitHub Actions in .github/workflows
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Description

Adds a Dependabot `ignore` rule for the `kubeflow` SDK in the `pip` ecosystem block, scoped to minor and major version updates. The SDK version is pinned intentionally and upgraded only with deliberate y-stream releases when new APIs are integrated. Dependabot was repeatedly opening PRs (e.g. #152) that got closed every time.

Note on scope: the issue's suggested snippet ignores all `kubeflow` updates unconditionally. I scoped it to `version-update:semver-minor` and `version-update:semver-major` instead, so patch releases still surface for review. Happy to switch to a blanket ignore if that's preferred, this was a judgment call reading the issue title vs. the snippet.

One trade-off worth flagging: this also suppresses security updates that require a minor/major bump, since the ignore rule doesn't distinguish by update reason.

## Related Issue

Fixes #173

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [ ] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

<!-- Describe how this was tested. Check all that apply. -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

This is a Dependabot config change, not application code, so there's no unit/integration/E2E surface to exercise directly. Validated with:
- `python3 -c "import yaml; yaml.safe_load(...)"` to confirm the YAML parses correctly
- `pre-commit run --files .github/dependabot.yml` (check-yaml, end-of-file-fixer, trailing-whitespace), all passed
- Full test suite via `make test-python`, 500 passed, 1 skipped, no failures
- `make verify` for lint/format, clean

Real end-to-end validation happens once GitHub parses the config on the fork (Insights → Dependabot).