### PR TITLE
fix(trainer): extract runtime metadata from SDK Runtime in get_runtime

### DIFF
--- a/kubeflow_mcp/trainer/api/discovery.py
+++ b/kubeflow_mcp/trainer/api/discovery.py
@@ -192,7 +192,7 @@ def get_training_job(name: str, namespace: str | None = None) -> dict[str, Any]:
 
 
 def list_runtimes() -> dict[str, Any]:
-    """List available ClusterTrainingRuntimes.
+    """List available TrainingRuntimes and ClusterTrainingRuntimes.
 
     Call this if ``fine_tune()`` fails with "runtime not found" to see
     what runtimes are installed in the cluster.
@@ -231,17 +231,23 @@ def list_runtimes() -> dict[str, Any]:
         ).model_dump()
 
 
-def _get_runtime_image(name: str) -> str | None:
-    """Extract container image from a ClusterTrainingRuntime CRD or SDK Runtime."""
-    try:
-        client = get_trainer_client()
-        rt = client.get_runtime(name=name)
-        trainer = getattr(rt, "trainer", None)
+def _get_runtime_image(name: str, runtime_obj: Any = None) -> str | None:
+    """Extract container image from an SDK Runtime or ClusterTrainingRuntime CRD."""
+    if runtime_obj is not None:
+        trainer = getattr(runtime_obj, "trainer", None)
         image = getattr(trainer, "image", None) if trainer is not None else None
         if image:
             return str(image)
-    except Exception:
-        pass
+    else:
+        try:
+            client = get_trainer_client()
+            rt = client.get_runtime(name=name)
+            trainer = getattr(rt, "trainer", None)
+            image = getattr(trainer, "image", None) if trainer is not None else None
+            if image:
+                return str(image)
+        except Exception:
+            pass
 
     try:
         api = get_custom_objects_api()
@@ -268,7 +274,7 @@ def _get_runtime_image(name: str) -> str | None:
     return None
 
 
-def _fetch_packages_via_pod(runtime_name: str) -> dict[str, Any]:
+def _fetch_packages_via_pod(runtime_name: str, runtime_obj: Any = None) -> dict[str, Any]:
     """Create a lightweight Pod to run ``pip list`` using the runtime's image.
 
     Creates a temporary Pod from the runtime's container image to list packages.
@@ -277,7 +283,7 @@ def _fetch_packages_via_pod(runtime_name: str) -> dict[str, Any]:
     The pod includes emptyDir volumes for writable directories so it works
     on platforms with read-only root filesystems.
     """
-    image = _get_runtime_image(runtime_name)
+    image = _get_runtime_image(runtime_name, runtime_obj=runtime_obj)
     if not image:
         return {
             "packages_error": f"Could not extract container image from runtime '{runtime_name}'"
@@ -430,7 +436,7 @@ def _extract_runtime_metadata(rt: Any) -> dict[str, Any]:
 
 
 def get_runtime(name: str, include_packages: bool = False) -> dict[str, Any]:
-    """Get ClusterTrainingRuntime configuration.
+    """Get TrainingRuntime or ClusterTrainingRuntime configuration.
 
     Args:
         name: Runtime name (e.g., ``torch-distributed``).
@@ -454,7 +460,7 @@ def get_runtime(name: str, include_packages: bool = False) -> dict[str, Any]:
         data = _extract_runtime_metadata(rt)
 
         if include_packages:
-            data.update(_fetch_packages_via_pod(name))
+            data.update(_fetch_packages_via_pod(name, runtime_obj=rt))
 
         return ToolResponse(data=data).model_dump()
 

--- a/kubeflow_mcp/trainer/api/discovery.py
+++ b/kubeflow_mcp/trainer/api/discovery.py
@@ -393,7 +393,7 @@ def _extract_runtime_metadata(rt: Any) -> dict[str, Any]:
         if image:
             data["image"] = str(image)
         num_nodes = getattr(trainer, "num_nodes", None)
-        if num_nodes:
+        if num_nodes is not None:
             data["num_nodes"] = num_nodes
         device = getattr(trainer, "device", None)
         if device and device != "UNKNOWN":

--- a/kubeflow_mcp/trainer/api/discovery.py
+++ b/kubeflow_mcp/trainer/api/discovery.py
@@ -232,26 +232,39 @@ def list_runtimes() -> dict[str, Any]:
 
 
 def _get_runtime_image(name: str) -> str | None:
-    """Extract container image from a ClusterTrainingRuntime CRD."""
-    api = get_custom_objects_api()
-    rt = api.get_cluster_custom_object(
-        group="trainer.kubeflow.org",
-        version="v1alpha1",
-        plural="clustertrainingruntimes",
-        name=name,
-    )
-    for rj in rt.get("spec", {}).get("template", {}).get("spec", {}).get("replicatedJobs", []):
-        containers = (
-            rj.get("template", {})
-            .get("spec", {})
-            .get("template", {})
-            .get("spec", {})
-            .get("containers", [])
+    """Extract container image from a ClusterTrainingRuntime CRD or SDK Runtime."""
+    try:
+        client = get_trainer_client()
+        rt = client.get_runtime(name=name)
+        trainer = getattr(rt, "trainer", None)
+        image = getattr(trainer, "image", None) if trainer is not None else None
+        if image:
+            return str(image)
+    except Exception:
+        pass
+
+    try:
+        api = get_custom_objects_api()
+        rt = api.get_cluster_custom_object(
+            group="trainer.kubeflow.org",
+            version="v1alpha1",
+            plural="clustertrainingruntimes",
+            name=name,
         )
-        for c in containers:
-            img = c.get("image")
-            if img:
-                return img
+        for rj in rt.get("spec", {}).get("template", {}).get("spec", {}).get("replicatedJobs", []):
+            containers = (
+                rj.get("template", {})
+                .get("spec", {})
+                .get("template", {})
+                .get("spec", {})
+                .get("containers", [])
+            )
+            for c in containers:
+                img = c.get("image")
+                if img:
+                    return str(img)
+    except Exception:
+        pass
     return None
 
 
@@ -360,6 +373,62 @@ def _fetch_packages_via_pod(runtime_name: str) -> dict[str, Any]:
             logger.warning("Failed to delete pip-list pod %s/%s", ns, pod_name)
 
 
+def _extract_runtime_metadata(rt: Any) -> dict[str, Any]:
+    """Extract runtime details from SDK Runtime object or CRD spec."""
+    rt_name = rt.name if hasattr(rt, "name") else str(rt)
+    data: dict[str, Any] = {"name": rt_name}
+
+    trainer = getattr(rt, "trainer", None)
+    if trainer is not None:
+        framework = getattr(trainer, "framework", None)
+        if framework:
+            data["framework"] = framework
+        image = getattr(trainer, "image", None)
+        if image:
+            data["image"] = str(image)
+        num_nodes = getattr(trainer, "num_nodes", None)
+        if num_nodes:
+            data["num_nodes"] = num_nodes
+        device = getattr(trainer, "device", None)
+        if device and device != "UNKNOWN":
+            data["device"] = device
+        device_count = getattr(trainer, "device_count", None)
+        if device_count and device_count != "UNKNOWN":
+            data["device_count"] = device_count
+        tt = getattr(trainer, "trainer_type", None)
+        if tt is not None:
+            data["trainer_type"] = getattr(tt, "value", str(tt))
+
+    pretrained_model = getattr(rt, "pretrained_model", None)
+    if pretrained_model:
+        data["pretrained_model"] = pretrained_model
+
+    spec = getattr(rt, "spec", None)
+    if spec is not None:
+        ml_policy = getattr(spec, "ml_policy", None)
+        if "framework" not in data:
+            framework = getattr(ml_policy, "torch", None) or getattr(ml_policy, "mpi", None)
+            if framework:
+                data["framework"] = framework
+        template = getattr(spec, "template", None)
+        if template is not None:
+            replicated_jobs = getattr(getattr(template, "spec", None), "replicated_jobs", None)
+            if replicated_jobs:
+                data["replicated_jobs"] = [
+                    {
+                        "name": getattr(rj, "name", None),
+                        "replicas": getattr(
+                            getattr(getattr(rj, "template", None), "spec", None),
+                            "completions",
+                            None,
+                        ),
+                    }
+                    for rj in replicated_jobs
+                ]
+
+    return data
+
+
 def get_runtime(name: str, include_packages: bool = False) -> dict[str, Any]:
     """Get ClusterTrainingRuntime configuration.
 
@@ -382,30 +451,7 @@ def get_runtime(name: str, include_packages: bool = False) -> dict[str, Any]:
     try:
         client = get_trainer_client()
         rt = client.get_runtime(name=name)
-
-        rt_name = rt.name if hasattr(rt, "name") else name
-
-        data: dict[str, Any] = {"name": rt_name}
-
-        spec = getattr(rt, "spec", None)
-        if spec is not None:
-            ml_policy = getattr(spec, "ml_policy", None)
-            data["framework"] = getattr(ml_policy, "torch", None) or getattr(ml_policy, "mpi", None)
-            template = getattr(spec, "template", None)
-            if template is not None:
-                replicated_jobs = getattr(getattr(template, "spec", None), "replicated_jobs", None)
-                if replicated_jobs:
-                    data["replicated_jobs"] = [
-                        {
-                            "name": getattr(rj, "name", None),
-                            "replicas": getattr(
-                                getattr(getattr(rj, "template", None), "spec", None),
-                                "completions",
-                                None,
-                            ),
-                        }
-                        for rj in replicated_jobs
-                    ]
+        data = _extract_runtime_metadata(rt)
 
         if include_packages:
             data.update(_fetch_packages_via_pod(name))

--- a/kubeflow_mcp/trainer/api/discovery_test.py
+++ b/kubeflow_mcp/trainer/api/discovery_test.py
@@ -181,8 +181,35 @@ class TestGetRuntime:
         assert result["success"] is False
         assert result["error_code"] == ErrorCode.RESOURCE_NOT_FOUND
 
+    @patch("kubeflow_mcp.trainer.api.discovery._fetch_packages_via_pod")
+    @patch("kubeflow_mcp.trainer.api.discovery.get_trainer_client")
+    def test_get_runtime_include_packages_passes_runtime_obj(
+        self, mock_client_fn, mock_fetch_packages
+    ):
+        mock_rt = MagicMock()
+        mock_rt.name = "torch-distributed"
+        mock_rt.trainer.image = "pytorch/pytorch:2.0"
+        mock_client = MagicMock()
+        mock_client.get_runtime.return_value = mock_rt
+        mock_client_fn.return_value = mock_client
+        mock_fetch_packages.return_value = {"packages": [{"name": "torch", "version": "2.0"}]}
+
+        result = get_runtime("torch-distributed", include_packages=True)
+        assert result["success"] is True
+        mock_fetch_packages.assert_called_once_with("torch-distributed", runtime_obj=mock_rt)
+        assert result["data"]["packages"] == [{"name": "torch", "version": "2.0"}]
+
 
 class TestGetRuntimeImage:
+    @patch("kubeflow_mcp.trainer.api.discovery.get_trainer_client")
+    def test_extracts_image_from_passed_runtime_obj(self, mock_client_fn):
+        mock_rt = MagicMock()
+        mock_rt.trainer.image = "docker.io/kubeflow/passed:v1"
+
+        image = _get_runtime_image("torchtune-llama", runtime_obj=mock_rt)
+        assert image == "docker.io/kubeflow/passed:v1"
+        mock_client_fn.assert_not_called()
+
     @patch("kubeflow_mcp.trainer.api.discovery.get_trainer_client")
     def test_extracts_image_from_sdk_runtime(self, mock_client_fn):
         mock_rt = MagicMock()

--- a/kubeflow_mcp/trainer/api/discovery_test.py
+++ b/kubeflow_mcp/trainer/api/discovery_test.py
@@ -20,7 +20,7 @@ K8s API interaction tests require mocking the SDK and are marked as TODOs.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from tests.common import RESOURCE_NOT_FOUND
@@ -34,6 +34,7 @@ from kubeflow_mcp.conftest import (
 )
 from kubeflow_mcp.trainer.api.discovery import (
     _JOB_STATUS_FILTER_ALIASES,
+    _get_runtime_image,
     _trainjob_runtime_to_mcp,
     get_runtime,
     get_training_job,
@@ -104,12 +105,125 @@ def test_rejects_invalid_resource_name_before_calling_sdk(tool, kwargs, client_p
     mock_client.assert_not_called()
 
 
-# TODO(test): list_training_jobs - returns formatted job list with mock SDK
-# TODO(test): list_training_jobs - status filter applies alias
-# TODO(test): list_training_jobs - runtime filter
-# TODO(test): list_training_jobs - namespace policy enforcement
-# TODO(test): get_training_job - returns job details with mock SDK
-# TODO(test): list_runtimes - returns runtime list
-# TODO(test): get_runtime - returns runtime details
-# TODO(test): get_runtime - include_packages=True spawns pod
-# TODO(test): get_runtime - not found returns RESOURCE_NOT_FOUND
+class TestGetRuntime:
+    @patch("kubeflow_mcp.trainer.api.discovery.get_trainer_client")
+    def test_get_runtime_extracts_sdk_trainer_metadata(self, mock_client_fn):
+        mock_trainer = MagicMock()
+        mock_trainer.framework = "torch"
+        mock_trainer.image = "pytorch/pytorch:2.0"
+        mock_trainer.num_nodes = 2
+        mock_trainer.device = "gpu"
+        mock_trainer.device_count = "4"
+        mock_trainer.trainer_type.value = "CustomTrainer"
+
+        mock_rt = MagicMock()
+        mock_rt.name = "torch-distributed"
+        mock_rt.trainer = mock_trainer
+        mock_rt.pretrained_model = "meta-llama/Llama-3.2-1B"
+        mock_rt.spec = None
+
+        mock_client = MagicMock()
+        mock_client.get_runtime.return_value = mock_rt
+        mock_client_fn.return_value = mock_client
+
+        result = get_runtime("torch-distributed")
+        assert result["success"] is True
+        data = result["data"]
+        assert data["name"] == "torch-distributed"
+        assert data["framework"] == "torch"
+        assert data["image"] == "pytorch/pytorch:2.0"
+        assert data["num_nodes"] == 2
+        assert data["device"] == "gpu"
+        assert data["device_count"] == "4"
+        assert data["trainer_type"] == "CustomTrainer"
+        assert data["pretrained_model"] == "meta-llama/Llama-3.2-1B"
+
+    @patch("kubeflow_mcp.trainer.api.discovery.get_trainer_client")
+    def test_get_runtime_spec_fallback(self, mock_client_fn):
+        mock_rt = MagicMock()
+        mock_rt.name = "custom-runtime"
+        mock_rt.trainer = None
+        mock_rt.pretrained_model = None
+
+        mock_ml_policy = MagicMock()
+        mock_ml_policy.torch = "torch"
+        mock_ml_policy.mpi = None
+
+        mock_replicated_job = MagicMock()
+        mock_replicated_job.name = "worker"
+        mock_replicated_job.template.spec.completions = 4
+
+        mock_spec = MagicMock()
+        mock_spec.ml_policy = mock_ml_policy
+        mock_spec.template.spec.replicated_jobs = [mock_replicated_job]
+        mock_rt.spec = mock_spec
+
+        mock_client = MagicMock()
+        mock_client.get_runtime.return_value = mock_rt
+        mock_client_fn.return_value = mock_client
+
+        result = get_runtime("custom-runtime")
+        assert result["success"] is True
+        data = result["data"]
+        assert data["name"] == "custom-runtime"
+        assert data["framework"] == "torch"
+        assert data["replicated_jobs"] == [{"name": "worker", "replicas": 4}]
+
+    @patch("kubeflow_mcp.trainer.api.discovery.get_trainer_client")
+    def test_get_runtime_not_found(self, mock_client_fn):
+        from kubernetes.client.exceptions import ApiException
+
+        mock_client = MagicMock()
+        mock_client.get_runtime.side_effect = ApiException(status=404, reason="Not Found")
+        mock_client_fn.return_value = mock_client
+
+        result = get_runtime("non-existent-runtime")
+        assert result["success"] is False
+        assert result["error_code"] == ErrorCode.RESOURCE_NOT_FOUND
+
+
+class TestGetRuntimeImage:
+    @patch("kubeflow_mcp.trainer.api.discovery.get_trainer_client")
+    def test_extracts_image_from_sdk_runtime(self, mock_client_fn):
+        mock_rt = MagicMock()
+        mock_rt.trainer.image = "docker.io/kubeflow/trainer:v2"
+        mock_client = MagicMock()
+        mock_client.get_runtime.return_value = mock_rt
+        mock_client_fn.return_value = mock_client
+
+        image = _get_runtime_image("torchtune-llama")
+        assert image == "docker.io/kubeflow/trainer:v2"
+
+    @patch("kubeflow_mcp.trainer.api.discovery.get_custom_objects_api")
+    @patch("kubeflow_mcp.trainer.api.discovery.get_trainer_client")
+    def test_fallback_to_custom_objects_api(self, mock_client_fn, mock_custom_api_fn):
+        mock_client_fn.side_effect = RuntimeError("SDK runtime lookup failed")
+
+        mock_custom_api = MagicMock()
+        mock_custom_api.get_cluster_custom_object.return_value = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "replicatedJobs": [
+                            {
+                                "template": {
+                                    "spec": {
+                                        "template": {
+                                            "spec": {
+                                                "containers": [
+                                                    {"image": "docker.io/kubeflow/fallback:v1"}
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        mock_custom_api_fn.return_value = mock_custom_api
+
+        image = _get_runtime_image("cluster-runtime")
+        assert image == "docker.io/kubeflow/fallback:v1"

--- a/kubeflow_mcp/trainer/api/discovery_test.py
+++ b/kubeflow_mcp/trainer/api/discovery_test.py
@@ -139,6 +139,40 @@ class TestGetRuntime:
         assert data["pretrained_model"] == "meta-llama/Llama-3.2-1B"
 
     @patch("kubeflow_mcp.trainer.api.discovery.get_trainer_client")
+    def test_get_runtime_with_real_sdk_runtime_objects(self, mock_client_fn):
+        from kubeflow.trainer.types.types import Runtime, RuntimeTrainer, TrainerType
+
+        real_trainer = RuntimeTrainer(
+            trainer_type=TrainerType.CUSTOM_TRAINER,
+            framework="torch",
+            image="pytorch/pytorch:2.0-cuda11.8",
+            num_nodes=0,
+            device="gpu",
+            device_count="4",
+        )
+        real_rt = Runtime(
+            name="torch-distributed",
+            trainer=real_trainer,
+            pretrained_model="meta-llama/Llama-3.2-1B",
+        )
+
+        mock_client = MagicMock()
+        mock_client.get_runtime.return_value = real_rt
+        mock_client_fn.return_value = mock_client
+
+        result = get_runtime("torch-distributed")
+        assert result["success"] is True
+        data = result["data"]
+        assert data["name"] == "torch-distributed"
+        assert data["framework"] == "torch"
+        assert data["image"] == "pytorch/pytorch:2.0-cuda11.8"
+        assert data["num_nodes"] == 0
+        assert data["device"] == "gpu"
+        assert data["device_count"] == "4"
+        assert data["trainer_type"] == "CustomTrainer"
+        assert data["pretrained_model"] == "meta-llama/Llama-3.2-1B"
+
+    @patch("kubeflow_mcp.trainer.api.discovery.get_trainer_client")
     def test_get_runtime_spec_fallback(self, mock_client_fn):
         mock_rt = MagicMock()
         mock_rt.name = "custom-runtime"
@@ -209,6 +243,19 @@ class TestGetRuntimeImage:
         image = _get_runtime_image("torchtune-llama", runtime_obj=mock_rt)
         assert image == "docker.io/kubeflow/passed:v1"
         mock_client_fn.assert_not_called()
+
+    def test_extracts_image_from_real_sdk_runtime_obj(self):
+        from kubeflow.trainer.types.types import Runtime, RuntimeTrainer, TrainerType
+
+        real_trainer = RuntimeTrainer(
+            trainer_type=TrainerType.CUSTOM_TRAINER,
+            framework="torch",
+            image="docker.io/kubeflow/real-trainer:v1",
+        )
+        real_rt = Runtime(name="real-runtime", trainer=real_trainer)
+
+        image = _get_runtime_image("real-runtime", runtime_obj=real_rt)
+        assert image == "docker.io/kubeflow/real-trainer:v1"
 
     @patch("kubeflow_mcp.trainer.api.discovery.get_trainer_client")
     def test_extracts_image_from_sdk_runtime(self, mock_client_fn):


### PR DESCRIPTION
### What this PR does

- Updates `get_runtime()` to extract runtime metadata (`framework`, `image`, `num_nodes`, `device`, `device_count`, `trainer_type`) from `rt.trainer` and `rt.pretrained_model`, aligning with the Kubeflow SDK's `types.Runtime` dataclass.
- Retains backward-compatible fallback for objects with `.spec`.
- Updates `_get_runtime_image` to check `client.get_runtime(name)` first (which resolves both namespaced and cluster-scoped runtimes) before falling back to `CustomObjectsApi`.
- Refactors extraction into `_extract_runtime_metadata` to keep cyclomatic complexity low.
- Adds comprehensive unit tests in `kubeflow_mcp/trainer/api/discovery_test.py`.

Fixes #191

### How it was tested

- `uv run pytest kubeflow_mcp/trainer/api/discovery_test.py` (14 passed)
- `uv run pytest` (516 passed, all unit & conformance schema snapshot tests pass)
- `uv run ruff check .` and `uv run ruff format --check .` (clean)
