### PR TITLE
feat(trainer): add confirm gate to update_training_job

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,9 +68,8 @@ kubeflow_mcp/                    # Main Python package (unit tests co-located as
  and `CLIENT_RESOURCES`; `optimizer` and `hub` are currently stubs. `core/server.py`
  loads selected clients dynamically.
 - **Workflow phases**: Plan → Discover → Train → Monitor → Lifecycle / Platform / Health.
-- **Confirm gate**: New mutating tools must preview when `confirmed=False` and execute only with
-  `confirmed=True`; `update_training_job` is a legacy exception that currently mutates immediately.
-  Do not copy, weaken, or broaden that exception.
+- **Confirm gate**: All mutating tools must preview when `confirmed=False` and execute only with
+  `confirmed=True`.
 - **Personas**: `readonly`, `data-scientist`, `ml-engineer`, `platform-admin`
   (see `core/policy.py`). New tools must be added to the correct persona allowlists.
 - **Tool modes**: `full`, `progressive`, and `semantic` (see `core/dynamic_tools.py`).

--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ Agent calls: fine_tune(..., confirmed=True) → TrainJob "train-gemma-abc" creat
 Agent calls: get_training_logs("train-gemma-abc") → training progress...
 ```
 
-Most mutating tools require `confirmed=True` and return a preview before making changes.
-`update_training_job` is a legacy exception and immediately suspends or resumes a training job.
+All mutating tools require `confirmed=True` and return a preview before making changes.
 
 ### MCP Client Config
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -51,7 +51,7 @@ Stub: `MODULE_INFO` + `TOOLS = []`. Implemented: all exports above + tests.
 
 **Confirm gate:** Mutators accept `confirmed: bool = False` — preview first, execute at
 `confirmed=True`. `delete_*`: `[DESTRUCTIVE]` in description, `destructiveHint: True`,
-entry in `DESTRUCTIVE_TOOLS`. Legacy exceptions: `update_training_job`; trainer runtime
+entry in `DESTRUCTIVE_TOOLS`. Legacy exceptions: trainer runtime
 previews use `ToolResponse` not `PreviewResponse` — do not extend.
 
 **Annotations** (every tool): `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`,

--- a/kubeflow_mcp/trainer/__init__.py
+++ b/kubeflow_mcp/trainer/__init__.py
@@ -114,7 +114,7 @@ CLIENT_TOOL_DESCRIPTIONS: dict[str, str] = {
     "get_training_events": "Get K8s events for debugging pending/failed jobs. Supports optional namespace.",
     "wait_for_training": "Block until job reaches target status (Complete/Failed). Supports optional namespace.",
     "delete_training_job": "[DESTRUCTIVE] Delete a training job permanently. Set confirmed=True to execute.",
-    "update_training_job": "Suspend or resume a training job. Pass action='suspend' or 'resume'.",
+    "update_training_job": "Suspend or resume a training job. Pass action='suspend' or 'resume'. Set confirmed=True to execute.",
     "inspect_crd": "List Trainer CRDs or get details for a specific one. Pass name= for details.",
     "inspect_controller": "Inspect controller pod. Pass view='logs' or 'events'. Auto-discovers namespace.",
     "patch_runtime": "Strategic merge patch on a ClusterTrainingRuntime. Set confirmed=True to apply.",
@@ -347,7 +347,7 @@ MONITORING AND LIFECYCLE:
 - All monitoring tools accept optional namespace= to query jobs in a different namespace
 - Suspended jobs show status "Created" in the API — this is a known controller behavior
 - delete_training_job(name, confirmed=True) -> remove job permanently (preview first, non-admin personas can only delete MCP-created jobs)
-- update_training_job(name, action="suspend"|"resume") -> pause/resume without deleting (non-admin personas can only modify MCP-created jobs)""",
+- update_training_job(name, action="suspend"|"resume", confirmed=True) -> pause/resume without deleting (preview first, non-admin personas can only modify MCP-created jobs)""",
     },
     "training": {
         "full": """\

--- a/kubeflow_mcp/trainer/api/lifecycle.py
+++ b/kubeflow_mcp/trainer/api/lifecycle.py
@@ -121,13 +121,17 @@ def update_training_job(
     name: str,
     action: str,
     namespace: str | None = None,
+    confirmed: bool = False,
 ) -> dict[str, Any]:
     """Suspend or resume a training job.
+
+    Requires ``confirmed=True`` to execute. First call returns a preview.
 
     Args:
         name: TrainJob name.
         action: ``"suspend"`` to pause execution, ``"resume"`` to continue.
         namespace: K8s namespace. Uses default from kubeconfig when omitted.
+        confirmed: Set ``True`` to update. ``False`` returns a preview.
 
     Returns:
         dict: Response containing ``job``, ``namespace``, ``action``, ``message``.
@@ -171,6 +175,12 @@ def update_training_job(
                         ),
                     },
                 ).model_dump()
+
+        if not confirmed:
+            return PreviewResponse(
+                message=f"Will {action} training job '{name}'. Set confirmed=True to proceed.",
+                config={"job": name, "namespace": ns, "action": action},
+            ).model_dump()
 
         api = mcp_utils.get_trainer_custom_objects_api()
         body = {"spec": {"suspend": action == "suspend"}}

--- a/kubeflow_mcp/trainer/api/lifecycle_test.py
+++ b/kubeflow_mcp/trainer/api/lifecycle_test.py
@@ -20,9 +20,20 @@ marked as TODOs.
 
 from __future__ import annotations
 
-import pytest
-from tests.common import FAILED, VALIDATION_ERROR, TestCase, assert_test_case
+from unittest.mock import MagicMock, patch
 
+import pytest
+from kubeflow.trainer.constants import constants as trainer_constants
+from kubernetes.client.exceptions import ApiException
+from tests.common import (
+    FAILED,
+    RESOURCE_NOT_FOUND,
+    VALIDATION_ERROR,
+    TestCase,
+    assert_test_case,
+)
+
+from kubeflow_mcp.common import utils as mcp_utils
 from kubeflow_mcp.trainer.api.lifecycle import delete_training_job, update_training_job
 
 
@@ -47,11 +58,35 @@ def test_delete_training_job_validation(test_case):
     assert_test_case(test_case, delete_training_job)
 
 
-# TODO(test): test preview (confirmed=False) returns job details
-# TODO(test): test confirmed=True with mock SDK deletes job
-# TODO(test): test not found returns RESOURCE_NOT_FOUND
-# TODO(test): test namespace policy enforcement
-# TODO(test): test non-admin persona cannot delete non-MCP jobs
+class TestDeleteTrainingJob:
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.get_effective_persona", return_value="platform-admin"
+    )
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_effective_namespace",
+        return_value="default",
+    )
+    def test_preview_delete_returns_preview_response(self, _ns, _persona):
+        result = delete_training_job(name="test-job", confirmed=False)
+        assert result["status"] == "preview"
+        assert "Will permanently delete" in result["message"]
+        assert result["config"] == {"job": "test-job", "namespace": "default"}
+
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.get_effective_persona", return_value="platform-admin"
+    )
+    @patch("kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_client_for_namespace")
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_effective_namespace",
+        return_value="default",
+    )
+    def test_confirmed_delete_removes_job(self, _ns, mock_client_fn, _persona):
+        mock_client = MagicMock()
+        mock_client_fn.return_value = mock_client
+        result = delete_training_job(name="test-job", confirmed=True)
+        assert result["success"] is True
+        assert result["data"]["deleted"] is True
+        mock_client.delete_job.assert_called_once_with(name="test-job")
 
 
 @pytest.mark.parametrize(
@@ -61,6 +96,12 @@ def test_delete_training_job_validation(test_case):
             name="invalid name rejected",
             expected_status=FAILED,
             config={"name": "INVALID", "action": "suspend"},
+            expected_error_code=VALIDATION_ERROR,
+        ),
+        TestCase(
+            name="empty name rejected",
+            expected_status=FAILED,
+            config={"name": "", "action": "suspend"},
             expected_error_code=VALIDATION_ERROR,
         ),
         TestCase(
@@ -75,8 +116,111 @@ def test_update_training_job_validation(test_case):
     assert_test_case(test_case, update_training_job)
 
 
-# TODO(test): test suspend action with mock SDK
-# TODO(test): test resume action with mock SDK
-# TODO(test): test not found returns RESOURCE_NOT_FOUND
-# TODO(test): test namespace policy enforcement
-# TODO(test): test non-admin persona cannot update non-MCP jobs
+class TestUpdateTrainingJob:
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.get_effective_persona", return_value="platform-admin"
+    )
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_effective_namespace",
+        return_value="default",
+    )
+    def test_preview_suspend_returns_preview_response(self, _ns, _persona):
+        result = update_training_job(name="test-job", action="suspend", confirmed=False)
+        assert result["status"] == "preview"
+        assert "Will suspend training job 'test-job'" in result["message"]
+        assert result["config"] == {"job": "test-job", "namespace": "default", "action": "suspend"}
+
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.get_effective_persona", return_value="platform-admin"
+    )
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_effective_namespace",
+        return_value="default",
+    )
+    def test_preview_resume_returns_preview_response(self, _ns, _persona):
+        result = update_training_job(name="test-job", action="resume", confirmed=False)
+        assert result["status"] == "preview"
+        assert "Will resume training job 'test-job'" in result["message"]
+        assert result["config"] == {"job": "test-job", "namespace": "default", "action": "resume"}
+
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.get_effective_persona", return_value="data-scientist"
+    )
+    @patch("kubeflow_mcp.trainer.api.lifecycle.mcp_utils.is_mcp_managed", return_value=False)
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_effective_namespace",
+        return_value="default",
+    )
+    def test_non_admin_cannot_preview_non_mcp_job(self, _ns, _managed, _persona):
+        result = update_training_job(name="external-job", action="suspend", confirmed=False)
+        assert result["success"] is False
+        assert result["error_code"] == VALIDATION_ERROR
+        assert "was not created by MCP" in result["error"]
+
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.get_effective_persona", return_value="platform-admin"
+    )
+    @patch("kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_custom_objects_api")
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_effective_namespace",
+        return_value="default",
+    )
+    def test_confirmed_suspend_patches_job(self, _ns, mock_api_fn, _persona):
+        mock_api = MagicMock()
+        mock_api_fn.return_value = mock_api
+        result = update_training_job(name="test-job", action="suspend", confirmed=True)
+        assert result["success"] is True
+        assert result["data"]["action"] == "suspend"
+        assert "suspended" in result["data"]["message"]
+        mock_api.patch_namespaced_custom_object.assert_called_once_with(
+            group=trainer_constants.GROUP,
+            version=trainer_constants.VERSION,
+            namespace="default",
+            plural=trainer_constants.TRAINJOB_PLURAL,
+            name="test-job",
+            body={"spec": {"suspend": True}},
+            _request_timeout=mcp_utils.K8S_TIMEOUT,
+        )
+
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.get_effective_persona", return_value="platform-admin"
+    )
+    @patch("kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_custom_objects_api")
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_effective_namespace",
+        return_value="default",
+    )
+    def test_confirmed_resume_patches_job(self, _ns, mock_api_fn, _persona):
+        mock_api = MagicMock()
+        mock_api_fn.return_value = mock_api
+        result = update_training_job(name="test-job", action="resume", confirmed=True)
+        assert result["success"] is True
+        assert result["data"]["action"] == "resume"
+        assert "resumed" in result["data"]["message"]
+        mock_api.patch_namespaced_custom_object.assert_called_once_with(
+            group=trainer_constants.GROUP,
+            version=trainer_constants.VERSION,
+            namespace="default",
+            plural=trainer_constants.TRAINJOB_PLURAL,
+            name="test-job",
+            body={"spec": {"suspend": False}},
+            _request_timeout=mcp_utils.K8S_TIMEOUT,
+        )
+
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.get_effective_persona", return_value="platform-admin"
+    )
+    @patch("kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_custom_objects_api")
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_effective_namespace",
+        return_value="default",
+    )
+    def test_confirmed_not_found_returns_resource_not_found(self, _ns, mock_api_fn, _persona):
+        mock_api = MagicMock()
+        mock_api.patch_namespaced_custom_object.side_effect = ApiException(
+            status=404, reason="Not Found"
+        )
+        mock_api_fn.return_value = mock_api
+        result = update_training_job(name="test-job", action="suspend", confirmed=True)
+        assert result["success"] is False
+        assert result["error_code"] == RESOURCE_NOT_FOUND

--- a/kubeflow_mcp/trainer/api/lifecycle_test.py
+++ b/kubeflow_mcp/trainer/api/lifecycle_test.py
@@ -27,6 +27,7 @@ from kubeflow.trainer.constants import constants as trainer_constants
 from kubernetes.client.exceptions import ApiException
 from tests.common import (
     FAILED,
+    PERMISSION_DENIED,
     RESOURCE_NOT_FOUND,
     VALIDATION_ERROR,
     TestCase,
@@ -34,6 +35,8 @@ from tests.common import (
 )
 
 from kubeflow_mcp.common import utils as mcp_utils
+from kubeflow_mcp.common.constants import ErrorCode
+from kubeflow_mcp.common.types import ToolError
 from kubeflow_mcp.trainer.api.lifecycle import delete_training_job, update_training_job
 
 
@@ -87,6 +90,46 @@ class TestDeleteTrainingJob:
         assert result["success"] is True
         assert result["data"]["deleted"] is True
         mock_client.delete_job.assert_called_once_with(name="test-job")
+
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.get_effective_persona", return_value="data-scientist"
+    )
+    @patch("kubeflow_mcp.trainer.api.lifecycle.mcp_utils.is_mcp_managed", return_value=False)
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_effective_namespace",
+        return_value="default",
+    )
+    def test_non_admin_cannot_delete_non_mcp_job(self, _ns, _managed, _persona):
+        result = delete_training_job(name="external-job", confirmed=False)
+        assert result["success"] is False
+        assert result["error_code"] == VALIDATION_ERROR
+        assert "was not created by MCP" in result["error"]
+
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.get_effective_persona", return_value="platform-admin"
+    )
+    @patch("kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_client_for_namespace")
+    @patch(
+        "kubeflow_mcp.trainer.api.lifecycle.mcp_utils.get_trainer_effective_namespace",
+        return_value="default",
+    )
+    def test_confirmed_not_found_returns_resource_not_found(self, _ns, mock_client_fn, _persona):
+        mock_client = MagicMock()
+        mock_client.delete_job.side_effect = ApiException(status=404, reason="Not Found")
+        mock_client_fn.return_value = mock_client
+        result = delete_training_job(name="test-job", confirmed=True)
+        assert result["success"] is False
+        assert result["error_code"] == RESOURCE_NOT_FOUND
+
+    @patch("kubeflow_mcp.trainer.api.lifecycle.check_namespace_allowed")
+    def test_namespace_policy_enforcement(self, mock_ns_check):
+        mock_ns_check.return_value = ToolError(
+            error="Namespace 'restricted-ns' is not allowed",
+            error_code=ErrorCode.PERMISSION_DENIED,
+        )
+        result = delete_training_job(name="test-job", namespace="restricted-ns", confirmed=True)
+        assert result["success"] is False
+        assert result["error_code"] == PERMISSION_DENIED
 
 
 @pytest.mark.parametrize(
@@ -224,3 +267,15 @@ class TestUpdateTrainingJob:
         result = update_training_job(name="test-job", action="suspend", confirmed=True)
         assert result["success"] is False
         assert result["error_code"] == RESOURCE_NOT_FOUND
+
+    @patch("kubeflow_mcp.trainer.api.lifecycle.check_namespace_allowed")
+    def test_namespace_policy_enforcement(self, mock_ns_check):
+        mock_ns_check.return_value = ToolError(
+            error="Namespace 'restricted-ns' is not allowed",
+            error_code=ErrorCode.PERMISSION_DENIED,
+        )
+        result = update_training_job(
+            name="test-job", action="suspend", namespace="restricted-ns", confirmed=True
+        )
+        assert result["success"] is False
+        assert result["error_code"] == PERMISSION_DENIED

--- a/kubeflow_mcp/trainer/resources/troubleshooting.md
+++ b/kubeflow_mcp/trainer/resources/troubleshooting.md
@@ -101,7 +101,7 @@ All three training tools (`fine_tune`, `run_custom_training`, `run_container_tra
 
 ### Suspended Jobs Show "Created" Status
 
-After `update_training_job(name, action="suspend")`, status becomes "Created" not "Suspended". This is controller behavior.
+After `update_training_job(name, action="suspend", confirmed=True)`, status becomes "Created" not "Suspended". This is controller behavior.
 **Workaround**: Check `get_training_events()` for the suspend event.
 
 ### list_training_jobs Status Filter is Client-Side

--- a/kubeflow_mcp/trainer/resources/troubleshooting.md
+++ b/kubeflow_mcp/trainer/resources/troubleshooting.md
@@ -140,9 +140,9 @@ All jobs created via MCP tools are labeled `kubeflow-mcp/managed-by=mcp`. Non-ad
 ## Recovery Actions
 
 ```
-delete_training_job(name)    # Delete and retry (MCP-created jobs only for non-admin)
-update_training_job(name, action="suspend")   # Pause
-update_training_job(name, action="resume")   # Resume
+delete_training_job(name, confirmed=True)    # Delete and retry (preview first, MCP-created jobs only for non-admin)
+update_training_job(name, action="suspend", confirmed=True)   # Pause (preview first)
+update_training_job(name, action="resume", confirmed=True)   # Resume (preview first)
 ```
 
 ## Parameter Rules (Non-Inferable)

--- a/tests/conformance/snapshots/tool_schema_platform_admin.json
+++ b/tests/conformance/snapshots/tool_schema_platform_admin.json
@@ -1670,6 +1670,10 @@
         "action": {
           "type": "string"
         },
+        "confirmed": {
+          "default": false,
+          "type": "boolean"
+        },
         "name": {
           "type": "string"
         },

--- a/tests/e2e/test_kubernetes_e2e.py
+++ b/tests/e2e/test_kubernetes_e2e.py
@@ -407,7 +407,17 @@ async def test_e2e_confirm_gate(mcp_session: ClientSession) -> None:
         )
         assert create_resp.get("success") is True
 
-        # 3. delete_training_job(confirmed=False) returns preview without deleting
+        # 3. update_training_job(confirmed=False) returns preview
+        upd_prev = await _call_tool(
+            mcp_session,
+            "update_training_job",
+            {"name": job_name, "action": "suspend", "namespace": namespace, "confirmed": False},
+        )
+        assert upd_prev.get("success") is True
+        assert upd_prev.get("status") == "preview"
+        assert "confirmed=True" in upd_prev.get("message", "")
+
+        # 4. delete_training_job(confirmed=False) returns preview without deleting
         del_prev = await _call_tool(
             mcp_session,
             "delete_training_job",
@@ -426,7 +436,7 @@ async def test_e2e_confirm_gate(mcp_session: ClientSession) -> None:
         assert still_there.get("success") is True
         assert still_there.get("data", {}).get("name") == job_name
 
-        # 4. delete_training_job(confirmed=True) executes deletion
+        # 5. delete_training_job(confirmed=True) executes deletion
         del_exec = await _call_tool(
             mcp_session,
             "delete_training_job",
@@ -477,11 +487,20 @@ async def test_e2e_job_lifecycle(mcp_session: ClientSession) -> None:
         assert create_resp.get("success") is True
         assert create_resp.get("data", {}).get("status") == "Created"
 
-        # 2. Suspend job
+        # 2. Suspend job (preview first, then execute with confirmed=True)
+        suspend_prev = await _call_tool(
+            mcp_session,
+            "update_training_job",
+            {"name": job_name, "action": "suspend", "namespace": namespace, "confirmed": False},
+        )
+        assert suspend_prev.get("success") is True
+        assert suspend_prev.get("status") == "preview"
+        assert "confirmed=True" in suspend_prev.get("message", "")
+
         suspend_resp = await _call_tool(
             mcp_session,
             "update_training_job",
-            {"name": job_name, "action": "suspend", "namespace": namespace},
+            {"name": job_name, "action": "suspend", "namespace": namespace, "confirmed": True},
         )
         assert suspend_resp.get("success") is True
         assert suspend_resp.get("data", {}).get("action") == "suspend"
@@ -496,11 +515,20 @@ async def test_e2e_job_lifecycle(mcp_session: ClientSession) -> None:
         assert get_resp.get("success") is True
         assert get_resp.get("data", {}).get("name") == job_name
 
-        # 3. Resume job
+        # 3. Resume job (preview first, then execute with confirmed=True)
+        resume_prev = await _call_tool(
+            mcp_session,
+            "update_training_job",
+            {"name": job_name, "action": "resume", "namespace": namespace, "confirmed": False},
+        )
+        assert resume_prev.get("success") is True
+        assert resume_prev.get("status") == "preview"
+        assert "confirmed=True" in resume_prev.get("message", "")
+
         resume_resp = await _call_tool(
             mcp_session,
             "update_training_job",
-            {"name": job_name, "action": "resume", "namespace": namespace},
+            {"name": job_name, "action": "resume", "namespace": namespace, "confirmed": True},
         )
         assert resume_resp.get("success") is True
         assert resume_resp.get("data", {}).get("action") == "resume"


### PR DESCRIPTION
## Description

Brings `update_training_job` in line with the standard confirm-gate pattern used across all mutating tools in the server.

### Key Changes
- **Tool Confirm Gate**: Added `confirmed: bool = False` to `update_training_job`. Calling with `confirmed=False` returns a `PreviewResponse` containing the action, target job, and namespace. Mutation executes only when `confirmed=True`.
- **Security & Ownership Order**: Placed the preview gate after namespace validation and MCP ownership checks (`is_mcp_managed`), ensuring unauthorized personas cannot obtain preview responses for unowned jobs.
- **Documentation & Instructions**: 
  - Updated `CLIENT_TOOL_DESCRIPTIONS` and `INSTRUCTION_SECTIONS` in `trainer/__init__.py`.
  - Updated recovery examples in `troubleshooting.md`.
  - Removed "legacy exception" wording from `AGENTS.md`, `README.md`, and `docs/CONVENTIONS.md`.
- **Conformance Snapshot**: Updated `tests/conformance/snapshots/tool_schema_platform_admin.json` to reflect the new `confirmed` parameter.
- **Tests**:
  - Added unit test suite in `kubeflow_mcp/trainer/api/lifecycle_test.py` covering validation, preview responses, non-admin ownership enforcement, confirmed suspend/resume, and 404 handling.
  - Updated `test_e2e_confirm_gate` and `test_e2e_job_lifecycle` in `tests/e2e/test_kubernetes_e2e.py` to verify preview and confirmed execution against a live cluster.

## Related Issue

Fixes #121

## Testing

- Unit tests: `uv run pytest kubeflow_mcp/trainer/api/lifecycle_test.py` (13 passed)
- Full test suite: `uv run pytest` (529 passed, 0 failures)
- Schema snapshot: `uv run pytest tests/conformance/tool_schema_snapshot_test.py` (passed)
- Linting & formatting: `uv run ruff check .` and `uv run ruff format --check .` (clean)
