### PR TITLE
chore(ci): migrate E2E runner from Oracle VM to CNCF ARC

### DIFF
--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   e2e:
     name: E2E Test (Kind Cluster)
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    runs-on: cncf-ubuntu-16-64-x86
     # Successful runs take ~35-40 min (cluster setup + tests); cap well
     # above that so hung runs cannot hold the large runner indefinitely.
     timeout-minutes: 50


### PR DESCRIPTION
## Description
Migrates the E2E Kind cluster test from the Oracle self-hosted VM runner (`oracle-vm-16cpu-64gb-x86-64`) to the CNCF ARC runner (`cncf-ubuntu-16-64-x86`). 

### Why
The Oracle runner has a limited pool shared across Kubeflow repos, causing E2E jobs to queue for extended periods and blocking PR merges. The CNCF runner is already used by `kubeflow/trainer` for its CPU E2E tests ([test-e2e.yaml#L33](https://github.com/kubeflow/trainer/blob/master/.github/workflows/test-e2e.yaml#L33)) and eliminates queue waits.
