### PR TITLE
fix(ci): prevent title check cancellation on code pushes

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -8,11 +8,10 @@ on:
       - edited
       - opened
       - reopened
-      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
Fixes the race where rapid push events cancel the title check run, leaving Tide unable to merge approved PRs (observed on #104).