### PR TITLE
fix(trainer): point failure hints at registered MCP resources

### DIFF
--- a/kubeflow_mcp/trainer/api/architecture_test.py
+++ b/kubeflow_mcp/trainer/api/architecture_test.py
@@ -367,6 +367,28 @@ class TestResourceLoading:
         for uri in CLIENT_RESOURCES:
             assert uri.startswith("trainer://"), f"URI '{uri}' should use trainer:// scheme"
 
+    def test_referenced_resource_uris_are_registered(self):
+        """Every trainer:// URI the shipped code points an agent at must resolve.
+
+        Hints and next_steps fire on the failure path, so an unregistered URI
+        breaks resources/read exactly when the agent follows our own advice.
+        """
+        import re
+        from pathlib import Path
+
+        import kubeflow_mcp
+
+        package = Path(kubeflow_mcp.__file__).parent
+        uri_pattern = re.compile(r"trainer://[\w-]+/[\w-]+")
+        sources = [p for p in package.rglob("*.py") if not p.name.endswith("_test.py")]
+        sources += sorted(package.rglob("*.md"))
+
+        for path in sources:
+            for uri in uri_pattern.findall(path.read_text(encoding="utf-8")):
+                assert uri in CLIENT_RESOURCES, (
+                    f"{path.relative_to(package)} references unregistered resource '{uri}'"
+                )
+
     def test_register_resources_with_mock_mcp(self):
         import kubeflow_mcp.trainer as trainer_module
         from kubeflow_mcp.core.resources import register_resources

--- a/kubeflow_mcp/trainer/api/discovery.py
+++ b/kubeflow_mcp/trainer/api/discovery.py
@@ -159,7 +159,7 @@ def get_training_job(name: str, namespace: str | None = None) -> dict[str, Any]:
             next_steps = [
                 f"get_training_events(name='{name}') — check for OOM/scheduling issues",
                 f"get_training_logs(name='{name}') — check error output",
-                "Read trainer://workflows/ops",
+                "Read trainer://guides/troubleshooting",
             ]
         elif status == "Running":
             next_steps = [f"get_training_logs(name='{name}') — check progress"]

--- a/kubeflow_mcp/trainer/api/monitoring.py
+++ b/kubeflow_mcp/trainer/api/monitoring.py
@@ -155,7 +155,7 @@ def get_training_logs(
             data["failure_hint"] = hint
             data["next_steps"] = [
                 f"Detected {hint['category']}: {hint['suggestion']}",
-                "Read trainer://workflows/ops for detailed fixes",
+                "Read trainer://guides/troubleshooting for detailed fixes",
             ]
 
         return ToolResponse(data=data).model_dump()
@@ -171,7 +171,7 @@ def get_training_logs(
         return ToolError(
             error=str(e),
             error_code=ErrorCode.SDK_ERROR,
-            hint="Read trainer://workflows/ops",
+            hint="Read trainer://guides/troubleshooting",
             details=exception_details(e),
         ).model_dump()
 
@@ -241,7 +241,7 @@ def get_training_events(
         return ToolError(
             error=str(e),
             error_code=ErrorCode.SDK_ERROR,
-            hint="Read trainer://workflows/ops",
+            hint="Read trainer://guides/troubleshooting",
             details=exception_details(e),
         ).model_dump()
 
@@ -333,6 +333,6 @@ def wait_for_training(
         return ToolError(
             error=str(e),
             error_code=ErrorCode.SDK_ERROR,
-            hint="Read trainer://workflows/ops",
+            hint="Read trainer://guides/troubleshooting",
             details=exception_details(e),
         ).model_dump()

--- a/kubeflow_mcp/trainer/api/training.py
+++ b/kubeflow_mcp/trainer/api/training.py
@@ -749,7 +749,7 @@ def fine_tune(
 
     Requires a torchtune ClusterTrainingRuntime (e.g. ``torchtune-llama3.2-1b``).
     Returns an error for non-torchtune runtimes — use ``run_custom_training()``
-    with a LoRA script instead (see ``trainer://guides/lora-script-template`` for best practices).
+    with a LoRA script instead (see ``trainer://guides/training-patterns`` for best practices).
 
     Supports HuggingFace (``hf://``) and S3 (``s3://``) model/dataset sources.
     Requires ``confirmed=True`` to submit. First call returns a preview.
@@ -898,7 +898,7 @@ def fine_tune(
                     "fine_tune() requires a torchtune runtime (e.g. torchtune-llama3.2-1b). "
                     "Run list_runtimes() to find available torchtune runtimes. "
                     "For non-torchtune runtimes, use run_custom_training() with a LoRA "
-                    "fine-tuning script instead — see the lora-script-template resource."
+                    "fine-tuning script instead — see trainer://guides/training-patterns."
                 ),
                 error_code=ErrorCode.VALIDATION_ERROR,
             ).model_dump()
@@ -998,7 +998,7 @@ def fine_tune(
     except Exception as e:
         return _sdk_error(
             e,
-            hint="Use troubleshooting_guide prompt for diagnosis, or resource_planning to check requirements",
+            hint="Read trainer://guides/troubleshooting, or call pre_flight() to check requirements",
         )
 
 
@@ -1209,7 +1209,7 @@ def run_custom_training(
         ).model_dump()
 
     except Exception as e:
-        return _sdk_error(e, hint="Use troubleshooting_guide prompt for diagnosis")
+        return _sdk_error(e, hint="Read trainer://guides/troubleshooting")
 
 
 def run_container_training(
@@ -1378,4 +1378,4 @@ def run_container_training(
         ).model_dump()
 
     except Exception as e:
-        return _sdk_error(e, hint="Use troubleshooting_guide prompt for diagnosis")
+        return _sdk_error(e, hint="Read trainer://guides/troubleshooting")


### PR DESCRIPTION
## Description

Tool responses referenced `trainer://workflows/ops` and `trainer://guides/lora-script-template`. Neither is in `CLIENT_RESOURCES`, so an agent that follows the hint gets `Resource not found: Unknown resource: ...` from `resources/read`.

Both have been there since the initial commit. Three training tools also hinted at `troubleshooting_guide` / `resource_planning` prompts, which the server never registers.
ㅤ

Repointed to the resources that already carry that content:

- `trainer://workflows/ops` -> `trainer://guides/troubleshooting` (5 call sites in `discovery.py` / `monitoring.py`)
- `trainer://guides/lora-script-template` -> `trainer://guides/training-patterns` (`fine_tune` docstring and its non-torchtune runtime error)
- prompt hints -> `trainer://guides/troubleshooting`; the `fine_tune` hint also names `pre_flight()` in place of `resource_planning`

`test_referenced_resource_uris_are_registered` scans the package for `trainer://` URIs and asserts each one is registered, so this cannot silently come back. Test files are skipped -- `core/http_edge_test.py` uses a deliberately missing URI to cover the not-found path.

Hint and `next_steps` strings only; no tool schema, parameter or response shape changes.
ㅤ

## Related Issue
Fixes #217


## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)

> [!NOTE]
> `562 passed, 8 skipped`; `ruff check` / `ruff format --check` / `pre-commit run --all-files` clean; tool schema snapshot unchanged.

Verified against a live `FastMCP` server before and after: `resources/read` on `trainer://workflows/ops` and `trainer://guides/lora-script-template` returned `Resource not found`; after the change every URI reachable from a tool response resolves.