### PR TITLE
fix(core): keep the circuit breaker from wedging in half-open

### DIFF
--- a/kubeflow_mcp/core/resilience.py
+++ b/kubeflow_mcp/core/resilience.py
@@ -50,10 +50,18 @@ class CircuitBreaker:
     last_failure_time: float = field(default=0.0)
     half_open_calls: int = field(default=0)
     _half_open_successes: int = field(default=0)
+    _half_open_started: float = field(default=0.0)
     _lock: threading.Lock = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._lock = threading.Lock()
+
+    def _open_probe_window(self, now: float) -> None:
+        """Start a fresh batch of half-open probes. Caller holds the lock."""
+        self.state = CircuitState.HALF_OPEN
+        self.half_open_calls = 0
+        self._half_open_successes = 0
+        self._half_open_started = now
 
     def can_execute(self) -> bool:
         """Check if call is allowed and atomically reserve a slot if half-open."""
@@ -61,14 +69,25 @@ class CircuitBreaker:
             if self.state == CircuitState.CLOSED:
                 return True
 
+            now = time.monotonic()
+
             if self.state == CircuitState.OPEN:
-                if time.time() - self.last_failure_time >= self.recovery_timeout:
-                    self.state = CircuitState.HALF_OPEN
-                    self.half_open_calls = 0
+                if now - self.last_failure_time >= self.recovery_timeout:
+                    self._open_probe_window(now)
                     logger.info("Circuit breaker: OPEN -> HALF_OPEN")
                     self.half_open_calls += 1
                     return True
                 return False
+
+            # A probe that never reports back holds its slot for good, and the
+            # breaker only leaves HALF_OPEN once a probe does report. Reopening
+            # a stale window keeps that from becoming a permanent outage.
+            if (
+                self.half_open_calls >= self.half_open_max_calls
+                and now - self._half_open_started >= self.recovery_timeout
+            ):
+                self._open_probe_window(now)
+                logger.info("Circuit breaker: reopened a stale half-open probe window")
 
             if self.half_open_calls < self.half_open_max_calls:
                 self.half_open_calls += 1
@@ -92,7 +111,7 @@ class CircuitBreaker:
         """Record failed call."""
         with self._lock:
             self.failure_count += 1
-            self.last_failure_time = time.time()
+            self.last_failure_time = time.monotonic()
 
             if self.state == CircuitState.HALF_OPEN:
                 self.state = CircuitState.OPEN
@@ -244,13 +263,13 @@ class RateLimiter:
 
     def __post_init__(self) -> None:
         self._tokens = self.capacity
-        self._last_update = time.time()
+        self._last_update = time.monotonic()
         self._lock = threading.Lock()
 
     def acquire(self, tokens: float = 1.0) -> bool:
         """Try to acquire tokens. Returns True if successful."""
         with self._lock:
-            now = time.time()
+            now = time.monotonic()
             elapsed = now - self._last_update
             self._tokens = min(self.capacity, self._tokens + elapsed * self.rate)
             self._last_update = now
@@ -270,10 +289,10 @@ class SessionManager:
 
     def record_activity(self) -> None:
         """Record session activity."""
-        self._timestamps.append(time.time())
+        self._timestamps.append(time.monotonic())
 
     def is_stale(self) -> bool:
         """Check if session appears stale."""
         if not self._timestamps:
             return False
-        return time.time() - self._timestamps[-1] > self.max_age
+        return time.monotonic() - self._timestamps[-1] > self.max_age

--- a/kubeflow_mcp/core/resilience_test.py
+++ b/kubeflow_mcp/core/resilience_test.py
@@ -91,7 +91,43 @@ class TestCircuitBreaker:
         cb.record_failure()
         assert cb.state == CircuitState.OPEN
 
-    # TODO(test): test half_open_max_calls limit
+    @pytest.mark.slow
+    def test_half_open_max_calls_limit(self):
+        cb = CircuitBreaker(failure_threshold=1, recovery_timeout=0.05, half_open_max_calls=2)
+        cb.record_failure()
+        time.sleep(0.06)
+
+        assert cb.can_execute() is True
+        assert cb.can_execute() is True
+        assert cb.can_execute() is False
+        assert cb.half_open_calls == 2
+
+    @pytest.mark.slow
+    def test_half_open_reopens_when_a_probe_never_reports(self):
+        """A probe that records neither outcome must not wedge the breaker."""
+        cb = CircuitBreaker(failure_threshold=1, recovery_timeout=0.01, half_open_max_calls=2)
+        cb.record_failure()
+        time.sleep(0.02)
+
+        cb.can_execute()
+        cb.record_success()
+        cb.can_execute()  # this probe never reports back
+
+        assert cb.can_execute() is False
+        time.sleep(0.02)
+        assert cb.can_execute() is True
+        assert cb.state == CircuitState.HALF_OPEN
+
+    def test_recovery_ignores_wall_clock_jumps(self, monkeypatch):
+        """A wall-clock jump must not release the circuit before its timeout."""
+        cb = CircuitBreaker(failure_threshold=1, recovery_timeout=60.0)
+        cb.record_failure()
+
+        jumped = time.time() + 3600
+        monkeypatch.setattr("time.time", lambda: jumped)
+        assert cb.can_execute() is False
+        assert cb.state == CircuitState.OPEN
+
     # TODO(test): test thread safety with concurrent record_failure/record_success
 
 
@@ -184,6 +220,12 @@ class TestRateLimiter:
         for _ in range(5):
             rl.acquire()
         time.sleep(0.01)
+        assert rl.acquire() is True
+
+    def test_acquire_ignores_wall_clock_jumps(self, monkeypatch):
+        rl = RateLimiter(rate=10.0, capacity=5.0)
+
+        monkeypatch.setattr("time.time", lambda: 0.0)
         assert rl.acquire() is True
 
     # TODO(test): test thread safety with concurrent acquire

--- a/kubeflow_mcp/core/resilience_test.py
+++ b/kubeflow_mcp/core/resilience_test.py
@@ -223,6 +223,11 @@ class TestRateLimiter:
         assert rl.acquire() is True
 
     def test_acquire_ignores_wall_clock_jumps(self, monkeypatch):
+        """A backward wall-clock step must not drain the bucket.
+
+        time.time is patched because that is the clock the limiter used to read.
+        Patching monotonic would assert a step it cannot make.
+        """
         rl = RateLimiter(rate=10.0, capacity=5.0)
 
         monkeypatch.setattr("time.time", lambda: 0.0)

--- a/kubeflow_mcp/core/server.py
+++ b/kubeflow_mcp/core/server.py
@@ -181,10 +181,14 @@ def _audit_wrap(tool_func):
                 )
                 span.set_attribute("tool.success", is_success)
                 span.set_attribute("tool.duration_ms", duration_ms)
-                if is_success:
-                    breaker.record_success()
-                elif is_infrastructure_error(result):
+                # A validation or not-found result still completed without an
+                # infrastructure fault, so it counts as a healthy probe. Recording
+                # nothing would leave a reserved half-open slot unresolved, which
+                # the breaker never hands back. Matches execute_tool's accounting.
+                if is_infrastructure_error(result):
                     breaker.record_failure()
+                else:
+                    breaker.record_success()
 
                 logger.info(
                     "tool_call",

--- a/kubeflow_mcp/core/server.py
+++ b/kubeflow_mcp/core/server.py
@@ -181,10 +181,8 @@ def _audit_wrap(tool_func):
                 )
                 span.set_attribute("tool.success", is_success)
                 span.set_attribute("tool.duration_ms", duration_ms)
-                # A validation or not-found result still completed without an
-                # infrastructure fault, so it counts as a healthy probe. Recording
-                # nothing would leave a reserved half-open slot unresolved, which
-                # the breaker never hands back. Matches execute_tool's accounting.
+                # A non-infrastructure result still resolves the half-open probe,
+                # so it records a success here, matching execute_tool.
                 if is_infrastructure_error(result):
                     breaker.record_failure()
                 else:

--- a/kubeflow_mcp/core/telemetry_test.py
+++ b/kubeflow_mcp/core/telemetry_test.py
@@ -22,6 +22,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from kubeflow_mcp.common.constants import ErrorCode
 from kubeflow_mcp.core import telemetry
 from kubeflow_mcp.core.server import _audit_wrap
 
@@ -372,6 +373,49 @@ def test_audit_wrap_records_exception_on_failure(monkeypatch: pytest.MonkeyPatch
         status = span.status_code
         assert status.status_code == _StatusCode.ERROR
         assert status.description == "boom"
+
+
+def test_audit_wrap_records_success_for_non_infrastructure_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A validation error must resolve the breaker probe, not leave it hanging."""
+    import kubeflow_mcp.core.server as server_mod
+
+    breaker = _FakeBreaker()
+    monkeypatch.setattr(server_mod, "_rate_limiter", None)
+    monkeypatch.setattr(server_mod, "with_correlation_id", lambda: "cid-789")
+    monkeypatch.setattr(server_mod, "get_effective_persona", lambda: "readonly")
+    monkeypatch.setattr(server_mod, "get_tracer", lambda _name: _FakeTracer(_FakeSpan()))
+    monkeypatch.setattr(server_mod, "get_breaker", lambda _tool: breaker)
+
+    def rejecting_tool(**_kwargs):
+        return {"success": False, "error": "bad name", "error_code": ErrorCode.VALIDATION_ERROR}
+
+    _audit_wrap(rejecting_tool)()
+
+    assert breaker.successes == 1
+    assert breaker.failures == 0
+
+
+def test_audit_wrap_records_failure_for_infrastructure_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kubeflow_mcp.core.server as server_mod
+
+    breaker = _FakeBreaker()
+    monkeypatch.setattr(server_mod, "_rate_limiter", None)
+    monkeypatch.setattr(server_mod, "with_correlation_id", lambda: "cid-789")
+    monkeypatch.setattr(server_mod, "get_effective_persona", lambda: "readonly")
+    monkeypatch.setattr(server_mod, "get_tracer", lambda _name: _FakeTracer(_FakeSpan()))
+    monkeypatch.setattr(server_mod, "get_breaker", lambda _tool: breaker)
+
+    def failing_tool(**_kwargs):
+        return {"success": False, "error": "api down", "error_code": ErrorCode.SDK_ERROR}
+
+    _audit_wrap(failing_tool)()
+
+    assert breaker.failures == 1
+    assert breaker.successes == 0
 
 
 def test_audit_wrap_circuit_breaker_open(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description

`can_execute()` reserves a half-open probe slot and only ever releases it when the probe reports an outcome. `_audit_wrap` reported nothing for a non-infrastructure result, so a single mistyped resource name during recovery could spend the last slot without a verdict. After that `can_execute()` refuses every call, nothing runs, nothing reports, and the breaker sits in `HALF_OPEN` until the process restarts — still telling callers it "retries automatically".

Three changes:

- `_audit_wrap` records a success only for a real success, and a failure for an infrastructure error. Anything else calls a new `CircuitBreaker.release()`, which hands a half-open slot back without counting as either, so a validation error can't reset the failure count during an outage.
- Each admission carries the probe generation, which moves on each time a half-open window opens, and reports from an older generation are ignored. Every admitted call now reports back, so there is no time-based reset, and a slow probe keeps its window.
- `resilience.py` measures elapsed time with `time.monotonic()`. `_audit_wrap` already did. A forward clock step used to hold the circuit open past `recovery_timeout`, and a backward one drove the rate limiter's bucket negative, so every tool returned `RATE_LIMITED` until it refilled.

The wedge test reproduces #221 on `main`, where the breaker stays `HALF_OPEN`, and the generation and release tests fail there too. `test_half_open_max_calls_limit` clears the `TODO(test)` marker that was sitting on that line.

No tool schema, parameter, or response shape changed.
ㅤ

## Related Issue
Fixes #221

## Checklist
- [x] I have read the CONTRIBUTING guide
- [x] Tests pass locally (`make test-python`)
- [x] Linting passes (`make verify`)
- [x] Documentation updated (if applicable)
- [x] My commits are signed off (`git commit -s`)

## Testing
- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manually tested (describe below)


> [!NOTE]
> `571 passed, 8 skipped`; `ruff check` / `ruff format --check` / `pre-commit run --all-files`
clean; tool schema snapshot unchanged.

Ran the reproduction from the issue before and after. Before, the tool returned `CIRCUIT_OPEN` forever. After, the mistyped name returns `RESOURCE_NOT_FOUND`, the next valid call succeeds, and the breaker closes.